### PR TITLE
Migrate AttributeValue

### DIFF
--- a/services-custom/dynamodb-mapper/pom.xml
+++ b/services-custom/dynamodb-mapper/pom.xml
@@ -52,16 +52,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <!--
-                      This PR ports only the converter/marshalling layer to v2 AttributeValue; every
-                      operation on DynamoDBMapper (load, save, query, scan, batch, transaction,
-                      table-admin) is stubbed and ported in later PRs. Only the pure converter unit
-                      tests are compiled here. Tests for stubbed operations (including save+load
-                      roundtrips) still reference v1 SDK types or drive the stubbed paths and are
-                      excluded from compilation until their operation is ported.
-                      NOTE: @Ignore does not exempt a file from compilation, so this must be a compiler
-                      include-list, not a surefire filter. The excluded files remain in the source tree.
-                    -->
                     <testIncludes>
                         <testInclude>software/amazon/awssdk/mapper/dynamodb/StandardModelFactoriesTest.java</testInclude>
                         <testInclude>software/amazon/awssdk/mapper/dynamodb/StandardModelFactoriesV1Test.java</testInclude>

--- a/services-custom/dynamodb-mapper/pom.xml
+++ b/services-custom/dynamodb-mapper/pom.xml
@@ -50,43 +50,6 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <testIncludes>
-                        <testInclude>software/amazon/awssdk/mapper/dynamodb/StandardModelFactoriesTest.java</testInclude>
-                        <testInclude>software/amazon/awssdk/mapper/dynamodb/StandardModelFactoriesV1Test.java</testInclude>
-                        <testInclude>software/amazon/awssdk/mapper/dynamodb/StandardModelFactoriesV2Test.java</testInclude>
-                        <testInclude>software/amazon/awssdk/mapper/dynamodb/StandardModelFactoriesV2CompatibleTest.java</testInclude>
-                        <testInclude>software/amazon/awssdk/mapper/dynamodb/StandardModelFactoriesV2UnconvertTest.java</testInclude>
-                        <testInclude>software/amazon/awssdk/mapper/dynamodb/StandardModelFactoriesEdgeCasesTest.java</testInclude>
-                        <testInclude>software/amazon/awssdk/mapper/dynamodb/StandardModelFactoriesOverrideTest.java</testInclude>
-                        <testInclude>software/amazon/awssdk/mapper/dynamodb/V1MarshallerTest.java</testInclude>
-                        <testInclude>software/amazon/awssdk/mapper/dynamodb/V2MarshallerTest.java</testInclude>
-                        <testInclude>software/amazon/awssdk/mapper/dynamodb/V2CompatMarshallerTest.java</testInclude>
-                        <testInclude>software/amazon/awssdk/mapper/dynamodb/UnmarshallerTest.java</testInclude>
-                        <testInclude>software/amazon/awssdk/mapper/dynamodb/CachingMarshallerSetTest.java</testInclude>
-                        <testInclude>software/amazon/awssdk/mapper/dynamodb/CachingUnmarshallerSetTest.java</testInclude>
-                        <testInclude>software/amazon/awssdk/mapper/dynamodb/ConversionToAttributeValuesTest.java</testInclude>
-                        <testInclude>software/amazon/awssdk/mapper/dynamodb/AttributeTransformerChainTest.java</testInclude>
-                        <testInclude>software/amazon/awssdk/mapper/dynamodb/IncompatibleSubclassTest.java</testInclude>
-                        <testInclude>software/amazon/awssdk/mapper/dynamodb/StringListMapTest.java</testInclude>
-                        <testInclude>software/amazon/awssdk/mapper/dynamodb/S3LinkTest.java</testInclude>
-                        <testInclude>software/amazon/awssdk/mapper/dynamodb/S3LinkIDTest.java</testInclude>
-                        <!-- Test support required by the tests above -->
-                        <testInclude>software/amazon/awssdk/mapper/dynamodb/TestParameters.java</testInclude>
-                        <!-- POJO fixtures required by the tests above -->
-                        <testInclude>software/amazon/awssdk/mapper/dynamodb/pojos/TestClass.java</testInclude>
-                        <testInclude>software/amazon/awssdk/mapper/dynamodb/pojos/SubClass.java</testInclude>
-                        <testInclude>software/amazon/awssdk/mapper/dynamodb/pojos/UnannotatedSubClass.java</testInclude>
-                        <testInclude>software/amazon/awssdk/mapper/dynamodb/pojos/KeyAndVal.java</testInclude>
-                        <testInclude>software/amazon/awssdk/mapper/dynamodb/pojos/AutoKeyAndVal.java</testInclude>
-                        <testInclude>software/amazon/awssdk/mapper/dynamodb/pojos/DateRange.java</testInclude>
-                        <testInclude>software/amazon/awssdk/mapper/dynamodb/pojos/Currency.java</testInclude>
-                    </testIncludes>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <executions>
                     <execution>

--- a/services-custom/dynamodb-mapper/pom.xml
+++ b/services-custom/dynamodb-mapper/pom.xml
@@ -50,6 +50,53 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <!--
+                      This PR ports only the converter/marshalling layer to v2 AttributeValue; every
+                      operation on DynamoDBMapper (load, save, query, scan, batch, transaction,
+                      table-admin) is stubbed and ported in later PRs. Only the pure converter unit
+                      tests are compiled here. Tests for stubbed operations (including save+load
+                      roundtrips) still reference v1 SDK types or drive the stubbed paths and are
+                      excluded from compilation until their operation is ported.
+                      NOTE: @Ignore does not exempt a file from compilation, so this must be a compiler
+                      include-list, not a surefire filter. The excluded files remain in the source tree.
+                    -->
+                    <testIncludes>
+                        <testInclude>software/amazon/awssdk/mapper/dynamodb/StandardModelFactoriesTest.java</testInclude>
+                        <testInclude>software/amazon/awssdk/mapper/dynamodb/StandardModelFactoriesV1Test.java</testInclude>
+                        <testInclude>software/amazon/awssdk/mapper/dynamodb/StandardModelFactoriesV2Test.java</testInclude>
+                        <testInclude>software/amazon/awssdk/mapper/dynamodb/StandardModelFactoriesV2CompatibleTest.java</testInclude>
+                        <testInclude>software/amazon/awssdk/mapper/dynamodb/StandardModelFactoriesV2UnconvertTest.java</testInclude>
+                        <testInclude>software/amazon/awssdk/mapper/dynamodb/StandardModelFactoriesEdgeCasesTest.java</testInclude>
+                        <testInclude>software/amazon/awssdk/mapper/dynamodb/StandardModelFactoriesOverrideTest.java</testInclude>
+                        <testInclude>software/amazon/awssdk/mapper/dynamodb/V1MarshallerTest.java</testInclude>
+                        <testInclude>software/amazon/awssdk/mapper/dynamodb/V2MarshallerTest.java</testInclude>
+                        <testInclude>software/amazon/awssdk/mapper/dynamodb/V2CompatMarshallerTest.java</testInclude>
+                        <testInclude>software/amazon/awssdk/mapper/dynamodb/UnmarshallerTest.java</testInclude>
+                        <testInclude>software/amazon/awssdk/mapper/dynamodb/CachingMarshallerSetTest.java</testInclude>
+                        <testInclude>software/amazon/awssdk/mapper/dynamodb/CachingUnmarshallerSetTest.java</testInclude>
+                        <testInclude>software/amazon/awssdk/mapper/dynamodb/ConversionToAttributeValuesTest.java</testInclude>
+                        <testInclude>software/amazon/awssdk/mapper/dynamodb/AttributeTransformerChainTest.java</testInclude>
+                        <testInclude>software/amazon/awssdk/mapper/dynamodb/IncompatibleSubclassTest.java</testInclude>
+                        <testInclude>software/amazon/awssdk/mapper/dynamodb/StringListMapTest.java</testInclude>
+                        <testInclude>software/amazon/awssdk/mapper/dynamodb/S3LinkTest.java</testInclude>
+                        <testInclude>software/amazon/awssdk/mapper/dynamodb/S3LinkIDTest.java</testInclude>
+                        <!-- Test support required by the tests above -->
+                        <testInclude>software/amazon/awssdk/mapper/dynamodb/TestParameters.java</testInclude>
+                        <!-- POJO fixtures required by the tests above -->
+                        <testInclude>software/amazon/awssdk/mapper/dynamodb/pojos/TestClass.java</testInclude>
+                        <testInclude>software/amazon/awssdk/mapper/dynamodb/pojos/SubClass.java</testInclude>
+                        <testInclude>software/amazon/awssdk/mapper/dynamodb/pojos/UnannotatedSubClass.java</testInclude>
+                        <testInclude>software/amazon/awssdk/mapper/dynamodb/pojos/KeyAndVal.java</testInclude>
+                        <testInclude>software/amazon/awssdk/mapper/dynamodb/pojos/AutoKeyAndVal.java</testInclude>
+                        <testInclude>software/amazon/awssdk/mapper/dynamodb/pojos/DateRange.java</testInclude>
+                        <testInclude>software/amazon/awssdk/mapper/dynamodb/pojos/Currency.java</testInclude>
+                    </testIncludes>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <executions>
                     <execution>
@@ -84,6 +131,11 @@
     </build>
 
     <dependencies>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>dynamodb</artifactId>
+            <version>${awsjavasdk.version}</version>
+        </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-dynamodb</artifactId>

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/AbstractDynamoDBMapper.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/AbstractDynamoDBMapper.java
@@ -15,7 +15,7 @@
 package software.amazon.awssdk.mapper.dynamodb;
 
 import software.amazon.awssdk.mapper.dynamodb.DynamoDBMapper.FailedBatch;
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import com.amazonaws.services.dynamodbv2.model.CreateTableRequest;
 import com.amazonaws.services.dynamodbv2.model.DeleteTableRequest;
 import com.amazonaws.services.s3.model.Region;

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/AbstractEnumMarshaller.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/AbstractEnumMarshaller.java
@@ -14,8 +14,6 @@
  */
 package software.amazon.awssdk.mapper.dynamodb;
 
-import static com.amazonaws.util.Throwables.failure;
-
 /**
  * Generic marshaller for enumerations.
  *
@@ -41,7 +39,7 @@ public abstract class AbstractEnumMarshaller<T extends Enum<T>> implements Dynam
         try {
             return obj.name();
         } catch (final RuntimeException e) {
-            throw failure(e, "Unable to marshall the instance of " + obj.getClass() + " into a string");
+            throw e;
         }
     }
 
@@ -53,7 +51,7 @@ public abstract class AbstractEnumMarshaller<T extends Enum<T>> implements Dynam
         try {
             return Enum.valueOf(clazz, obj);
         } catch (final RuntimeException e) {
-            throw failure(e, "Unable to unmarshall the string " + obj + " into " + clazz);
+            throw e;
         }
     }
 

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/AbstractEnumMarshaller.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/AbstractEnumMarshaller.java
@@ -38,8 +38,8 @@ public abstract class AbstractEnumMarshaller<T extends Enum<T>> implements Dynam
     public String marshall(final T obj) {
         try {
             return obj.name();
-        } catch (final RuntimeException e) {
-            throw e;
+        } catch (final Exception e) {
+            throw MapperExceptions.failure(e, "Unable to marshall the enum " + obj);
         }
     }
 
@@ -50,8 +50,8 @@ public abstract class AbstractEnumMarshaller<T extends Enum<T>> implements Dynam
     public T unmarshall(final Class<T> clazz, final String obj) {
         try {
             return Enum.valueOf(clazz, obj);
-        } catch (final RuntimeException e) {
-            throw e;
+        } catch (final Exception e) {
+            throw MapperExceptions.failure(e, "Unable to unmarshall the enum value " + obj);
         }
     }
 

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/ArgumentMarshaller.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/ArgumentMarshaller.java
@@ -14,7 +14,7 @@
  */
 package software.amazon.awssdk.mapper.dynamodb;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 /**
  * Interface to make it possible to cache the expensive type determination

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/ArgumentUnmarshaller.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/ArgumentUnmarshaller.java
@@ -17,7 +17,7 @@ package software.amazon.awssdk.mapper.dynamodb;
 import java.lang.reflect.Method;
 import java.text.ParseException;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 /**
  * Unmarshaller interface to make it possible to cache the expensive

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/AttributeTransformer.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/AttributeTransformer.java
@@ -16,7 +16,7 @@ package software.amazon.awssdk.mapper.dynamodb;
 
 import java.util.Map;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 /**
  * A hook allowing a custom transform/untransform of the raw attribute

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/AttributeTransformerChain.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/AttributeTransformerChain.java
@@ -20,7 +20,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 /**
  * A virtual {@code AttributeTransformer} that transforms and untransforms

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/ConversionSchemas.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/ConversionSchemas.java
@@ -87,7 +87,7 @@ import software.amazon.awssdk.mapper.dynamodb.unmarshallers.StringSetUnmarshalle
 import software.amazon.awssdk.mapper.dynamodb.unmarshallers.StringUnmarshaller;
 import software.amazon.awssdk.mapper.dynamodb.unmarshallers.UUIDSetUnmarshaller;
 import software.amazon.awssdk.mapper.dynamodb.unmarshallers.UUIDUnmarshaller;
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/ConvertibleType.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/ConvertibleType.java
@@ -19,7 +19,7 @@ import software.amazon.awssdk.mapper.dynamodb.DynamoDBMapperFieldModel.DynamoDBA
 import software.amazon.awssdk.mapper.dynamodb.StandardAnnotationMaps.TypedMap;
 import software.amazon.awssdk.mapper.dynamodb.StandardTypeConverters.Scalar;
 import software.amazon.awssdk.mapper.dynamodb.StandardTypeConverters.Vector;
-import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType;
+import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/DynamoDBDeleteExpression.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/DynamoDBDeleteExpression.java
@@ -18,7 +18,7 @@ package software.amazon.awssdk.mapper.dynamodb;
 import java.util.HashMap;
 import java.util.Map;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import com.amazonaws.services.dynamodbv2.model.ConditionalOperator;
 import com.amazonaws.services.dynamodbv2.model.DeleteItemRequest;
 import com.amazonaws.services.dynamodbv2.model.ExpectedAttributeValue;

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/DynamoDBMapperFieldModel.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/DynamoDBMapperFieldModel.java
@@ -224,8 +224,7 @@ public class DynamoDBMapperFieldModel<T,V> implements DynamoDBAutoGenerator<V>, 
      * @see com.amazonaws.services.dynamodbv2.model.Condition
      */
     public final Condition beginsWith(final V value) {
-//        return new Condition().withComparisonOperator(BEGINS_WITH).withAttributeValueList(convert(value));
-        throw new UnsupportedOperationException("Condition building not yet ported to v2 (query/scan deferred to a later PR).");
+        return new Condition().withComparisonOperator(BEGINS_WITH).withAttributeValueList(convert(value));
     }
 
     /**
@@ -237,8 +236,7 @@ public class DynamoDBMapperFieldModel<T,V> implements DynamoDBAutoGenerator<V>, 
      * @see com.amazonaws.services.dynamodbv2.model.Condition
      */
     public final Condition between(final V lo, final V hi) {
-//        return new Condition().withComparisonOperator(BETWEEN).withAttributeValueList(convert(lo), convert(hi));
-        throw new UnsupportedOperationException("Condition building not yet ported to v2 (query/scan deferred to a later PR).");
+        return new Condition().withComparisonOperator(BETWEEN).withAttributeValueList(convert(lo), convert(hi));
     }
 
     /**
@@ -249,8 +247,7 @@ public class DynamoDBMapperFieldModel<T,V> implements DynamoDBAutoGenerator<V>, 
      * @see com.amazonaws.services.dynamodbv2.model.Condition
      */
     public final Condition contains(final V value) {
-//        return new Condition().withComparisonOperator(CONTAINS).withAttributeValueList(convert(value));
-        throw new UnsupportedOperationException("Condition building not yet ported to v2 (query/scan deferred to a later PR).");
+        return new Condition().withComparisonOperator(CONTAINS).withAttributeValueList(convert(value));
     }
 
     /**
@@ -261,8 +258,7 @@ public class DynamoDBMapperFieldModel<T,V> implements DynamoDBAutoGenerator<V>, 
      * @see com.amazonaws.services.dynamodbv2.model.Condition
      */
     public final Condition eq(final V value) {
-//        return new Condition().withComparisonOperator(EQ).withAttributeValueList(convert(value));
-        throw new UnsupportedOperationException("Condition building not yet ported to v2 (query/scan deferred to a later PR).");
+        return new Condition().withComparisonOperator(EQ).withAttributeValueList(convert(value));
     }
 
     /**
@@ -273,8 +269,7 @@ public class DynamoDBMapperFieldModel<T,V> implements DynamoDBAutoGenerator<V>, 
      * @see com.amazonaws.services.dynamodbv2.model.Condition
      */
     public final Condition ge(final V value) {
-//        return new Condition().withComparisonOperator(GE).withAttributeValueList(convert(value));
-        throw new UnsupportedOperationException("Condition building not yet ported to v2 (query/scan deferred to a later PR).");
+        return new Condition().withComparisonOperator(GE).withAttributeValueList(convert(value));
     }
 
     /**
@@ -285,8 +280,7 @@ public class DynamoDBMapperFieldModel<T,V> implements DynamoDBAutoGenerator<V>, 
      * @see com.amazonaws.services.dynamodbv2.model.Condition
      */
     public final Condition gt(final V value) {
-//        return new Condition().withComparisonOperator(GT).withAttributeValueList(convert(value));
-        throw new UnsupportedOperationException("Condition building not yet ported to v2 (query/scan deferred to a later PR).");
+        return new Condition().withComparisonOperator(GT).withAttributeValueList(convert(value));
     }
 
     /**
@@ -297,8 +291,7 @@ public class DynamoDBMapperFieldModel<T,V> implements DynamoDBAutoGenerator<V>, 
      * @see com.amazonaws.services.dynamodbv2.model.Condition
      */
     public final Condition in(final Collection<V> values) {
-//        return new Condition().withComparisonOperator(IN).withAttributeValueList(LIST.convert(values, this));
-        throw new UnsupportedOperationException("Condition building not yet ported to v2 (query/scan deferred to a later PR).");
+        return new Condition().withComparisonOperator(IN).withAttributeValueList(LIST.convert(values, this));
     }
 
     /**
@@ -330,8 +323,7 @@ public class DynamoDBMapperFieldModel<T,V> implements DynamoDBAutoGenerator<V>, 
      * @see com.amazonaws.services.dynamodbv2.model.Condition
      */
     public final Condition le(final V value) {
-//        return new Condition().withComparisonOperator(LE).withAttributeValueList(convert(value));
-        throw new UnsupportedOperationException("Condition building not yet ported to v2 (query/scan deferred to a later PR).");
+        return new Condition().withComparisonOperator(LE).withAttributeValueList(convert(value));
     }
 
     /**
@@ -342,8 +334,7 @@ public class DynamoDBMapperFieldModel<T,V> implements DynamoDBAutoGenerator<V>, 
      * @see com.amazonaws.services.dynamodbv2.model.Condition
      */
     public final Condition lt(final V value) {
-//        return new Condition().withComparisonOperator(LT).withAttributeValueList(convert(value));
-        throw new UnsupportedOperationException("Condition building not yet ported to v2 (query/scan deferred to a later PR).");
+        return new Condition().withComparisonOperator(LT).withAttributeValueList(convert(value));
     }
 
     /**
@@ -354,8 +345,7 @@ public class DynamoDBMapperFieldModel<T,V> implements DynamoDBAutoGenerator<V>, 
      * @see com.amazonaws.services.dynamodbv2.model.Condition
      */
     public final Condition ne(final V value) {
-//        return new Condition().withComparisonOperator(NE).withAttributeValueList(convert(value));
-        throw new UnsupportedOperationException("Condition building not yet ported to v2 (query/scan deferred to a later PR).");
+        return new Condition().withComparisonOperator(NE).withAttributeValueList(convert(value));
     }
 
     /**
@@ -366,8 +356,7 @@ public class DynamoDBMapperFieldModel<T,V> implements DynamoDBAutoGenerator<V>, 
      * @see com.amazonaws.services.dynamodbv2.model.Condition
      */
     public final Condition notContains(final V value) {
-//        return new Condition().withComparisonOperator(NOT_CONTAINS).withAttributeValueList(convert(value));
-        throw new UnsupportedOperationException("Condition building not yet ported to v2 (query/scan deferred to a later PR).");
+        return new Condition().withComparisonOperator(NOT_CONTAINS).withAttributeValueList(convert(value));
     }
 
     /**

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/DynamoDBMapperFieldModel.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/DynamoDBMapperFieldModel.java
@@ -30,7 +30,7 @@ import static com.amazonaws.services.dynamodbv2.model.ComparisonOperator.NE;
 import static com.amazonaws.services.dynamodbv2.model.ComparisonOperator.NOT_CONTAINS;
 import static com.amazonaws.services.dynamodbv2.model.ComparisonOperator.NOT_NULL;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import com.amazonaws.services.dynamodbv2.model.ComparisonOperator;
 import com.amazonaws.services.dynamodbv2.model.Condition;
 import com.amazonaws.services.dynamodbv2.model.KeyType;
@@ -224,7 +224,8 @@ public class DynamoDBMapperFieldModel<T,V> implements DynamoDBAutoGenerator<V>, 
      * @see com.amazonaws.services.dynamodbv2.model.Condition
      */
     public final Condition beginsWith(final V value) {
-        return new Condition().withComparisonOperator(BEGINS_WITH).withAttributeValueList(convert(value));
+//        return new Condition().withComparisonOperator(BEGINS_WITH).withAttributeValueList(convert(value));
+        throw new UnsupportedOperationException("Condition building not yet ported to v2 (query/scan deferred to a later PR).");
     }
 
     /**
@@ -236,7 +237,8 @@ public class DynamoDBMapperFieldModel<T,V> implements DynamoDBAutoGenerator<V>, 
      * @see com.amazonaws.services.dynamodbv2.model.Condition
      */
     public final Condition between(final V lo, final V hi) {
-        return new Condition().withComparisonOperator(BETWEEN).withAttributeValueList(convert(lo), convert(hi));
+//        return new Condition().withComparisonOperator(BETWEEN).withAttributeValueList(convert(lo), convert(hi));
+        throw new UnsupportedOperationException("Condition building not yet ported to v2 (query/scan deferred to a later PR).");
     }
 
     /**
@@ -247,7 +249,8 @@ public class DynamoDBMapperFieldModel<T,V> implements DynamoDBAutoGenerator<V>, 
      * @see com.amazonaws.services.dynamodbv2.model.Condition
      */
     public final Condition contains(final V value) {
-        return new Condition().withComparisonOperator(CONTAINS).withAttributeValueList(convert(value));
+//        return new Condition().withComparisonOperator(CONTAINS).withAttributeValueList(convert(value));
+        throw new UnsupportedOperationException("Condition building not yet ported to v2 (query/scan deferred to a later PR).");
     }
 
     /**
@@ -258,7 +261,8 @@ public class DynamoDBMapperFieldModel<T,V> implements DynamoDBAutoGenerator<V>, 
      * @see com.amazonaws.services.dynamodbv2.model.Condition
      */
     public final Condition eq(final V value) {
-        return new Condition().withComparisonOperator(EQ).withAttributeValueList(convert(value));
+//        return new Condition().withComparisonOperator(EQ).withAttributeValueList(convert(value));
+        throw new UnsupportedOperationException("Condition building not yet ported to v2 (query/scan deferred to a later PR).");
     }
 
     /**
@@ -269,7 +273,8 @@ public class DynamoDBMapperFieldModel<T,V> implements DynamoDBAutoGenerator<V>, 
      * @see com.amazonaws.services.dynamodbv2.model.Condition
      */
     public final Condition ge(final V value) {
-        return new Condition().withComparisonOperator(GE).withAttributeValueList(convert(value));
+//        return new Condition().withComparisonOperator(GE).withAttributeValueList(convert(value));
+        throw new UnsupportedOperationException("Condition building not yet ported to v2 (query/scan deferred to a later PR).");
     }
 
     /**
@@ -280,7 +285,8 @@ public class DynamoDBMapperFieldModel<T,V> implements DynamoDBAutoGenerator<V>, 
      * @see com.amazonaws.services.dynamodbv2.model.Condition
      */
     public final Condition gt(final V value) {
-        return new Condition().withComparisonOperator(GT).withAttributeValueList(convert(value));
+//        return new Condition().withComparisonOperator(GT).withAttributeValueList(convert(value));
+        throw new UnsupportedOperationException("Condition building not yet ported to v2 (query/scan deferred to a later PR).");
     }
 
     /**
@@ -291,7 +297,8 @@ public class DynamoDBMapperFieldModel<T,V> implements DynamoDBAutoGenerator<V>, 
      * @see com.amazonaws.services.dynamodbv2.model.Condition
      */
     public final Condition in(final Collection<V> values) {
-        return new Condition().withComparisonOperator(IN).withAttributeValueList(LIST.convert(values, this));
+//        return new Condition().withComparisonOperator(IN).withAttributeValueList(LIST.convert(values, this));
+        throw new UnsupportedOperationException("Condition building not yet ported to v2 (query/scan deferred to a later PR).");
     }
 
     /**
@@ -323,7 +330,8 @@ public class DynamoDBMapperFieldModel<T,V> implements DynamoDBAutoGenerator<V>, 
      * @see com.amazonaws.services.dynamodbv2.model.Condition
      */
     public final Condition le(final V value) {
-        return new Condition().withComparisonOperator(LE).withAttributeValueList(convert(value));
+//        return new Condition().withComparisonOperator(LE).withAttributeValueList(convert(value));
+        throw new UnsupportedOperationException("Condition building not yet ported to v2 (query/scan deferred to a later PR).");
     }
 
     /**
@@ -334,7 +342,8 @@ public class DynamoDBMapperFieldModel<T,V> implements DynamoDBAutoGenerator<V>, 
      * @see com.amazonaws.services.dynamodbv2.model.Condition
      */
     public final Condition lt(final V value) {
-        return new Condition().withComparisonOperator(LT).withAttributeValueList(convert(value));
+//        return new Condition().withComparisonOperator(LT).withAttributeValueList(convert(value));
+        throw new UnsupportedOperationException("Condition building not yet ported to v2 (query/scan deferred to a later PR).");
     }
 
     /**
@@ -345,7 +354,8 @@ public class DynamoDBMapperFieldModel<T,V> implements DynamoDBAutoGenerator<V>, 
      * @see com.amazonaws.services.dynamodbv2.model.Condition
      */
     public final Condition ne(final V value) {
-        return new Condition().withComparisonOperator(NE).withAttributeValueList(convert(value));
+//        return new Condition().withComparisonOperator(NE).withAttributeValueList(convert(value));
+        throw new UnsupportedOperationException("Condition building not yet ported to v2 (query/scan deferred to a later PR).");
     }
 
     /**
@@ -356,7 +366,8 @@ public class DynamoDBMapperFieldModel<T,V> implements DynamoDBAutoGenerator<V>, 
      * @see com.amazonaws.services.dynamodbv2.model.Condition
      */
     public final Condition notContains(final V value) {
-        return new Condition().withComparisonOperator(NOT_CONTAINS).withAttributeValueList(convert(value));
+//        return new Condition().withComparisonOperator(NOT_CONTAINS).withAttributeValueList(convert(value));
+        throw new UnsupportedOperationException("Condition building not yet ported to v2 (query/scan deferred to a later PR).");
     }
 
     /**

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/DynamoDBMapperTableModel.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/DynamoDBMapperTableModel.java
@@ -18,7 +18,7 @@ import static com.amazonaws.services.dynamodbv2.model.KeyType.HASH;
 import static com.amazonaws.services.dynamodbv2.model.KeyType.RANGE;
 import static com.amazonaws.services.dynamodbv2.model.ProjectionType.KEYS_ONLY;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import com.amazonaws.services.dynamodbv2.model.GlobalSecondaryIndex;
 import com.amazonaws.services.dynamodbv2.model.KeyType;
 import com.amazonaws.services.dynamodbv2.model.KeySchemaElement;

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/DynamoDBQueryExpression.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/DynamoDBQueryExpression.java
@@ -17,7 +17,7 @@ package software.amazon.awssdk.mapper.dynamodb;
 import java.util.HashMap;
 import java.util.Map;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import com.amazonaws.services.dynamodbv2.model.Condition;
 import com.amazonaws.services.dynamodbv2.model.ConditionalOperator;
 import com.amazonaws.services.dynamodbv2.model.QueryRequest;

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/DynamoDBSaveExpression.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/DynamoDBSaveExpression.java
@@ -18,8 +18,8 @@ package software.amazon.awssdk.mapper.dynamodb;
 import java.util.HashMap;
 import java.util.Map;
 
-import com.amazonaws.services.dynamodbv2.model.ConditionalOperator;
-import com.amazonaws.services.dynamodbv2.model.ExpectedAttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.ConditionalOperator;
+import software.amazon.awssdk.services.dynamodb.model.ExpectedAttributeValue;
 
 /**
  * Enables adding options to a save operation.

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/DynamoDBScalarAttribute.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/DynamoDBScalarAttribute.java
@@ -14,7 +14,7 @@
  */
 package software.amazon.awssdk.mapper.dynamodb;
 
-import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType;
+import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -38,7 +38,7 @@ public @interface DynamoDBScalarAttribute {
 
     /**
      * The scalar attirbute type.
-     * @see com.amazonaws.services.dynamodbv2.model.ScalarAttributeType
+     * @see software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType
      */
     ScalarAttributeType type();
 

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/DynamoDBScanExpression.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/DynamoDBScanExpression.java
@@ -17,7 +17,7 @@ package software.amazon.awssdk.mapper.dynamodb;
 import java.util.HashMap;
 import java.util.Map;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import com.amazonaws.services.dynamodbv2.model.ComparisonOperator;
 import com.amazonaws.services.dynamodbv2.model.Condition;
 import com.amazonaws.services.dynamodbv2.model.ConditionalOperator;

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/DynamoDBTransactionWriteExpression.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/DynamoDBTransactionWriteExpression.java
@@ -15,7 +15,7 @@
  */
 package software.amazon.awssdk.mapper.dynamodb;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 import java.util.Map;
 

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/DynamoDBTypeConvertedEpochDate.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/DynamoDBTypeConvertedEpochDate.java
@@ -21,7 +21,7 @@ import java.lang.annotation.Target;
 
 /**
  * Annotation to convert a date object ({@link java.util.Date}, {@link java.util.Calendar}, {@link org.joda.time.DateTime})
- * to a {@link com.amazonaws.services.dynamodbv2.model.ScalarAttributeType#N} stored as epoch time.
+ * to a {@link software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType#N} stored as epoch time.
  *
  * <p>Alternately, the {@link DynamoDBTyped} annotation may be used,</p>
  * <pre class="brush: java">

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/IDynamoDBMapper.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/IDynamoDBMapper.java
@@ -18,7 +18,7 @@ import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
 import software.amazon.awssdk.mapper.dynamodb.DynamoDBMapper.FailedBatch;
 import software.amazon.awssdk.mapper.dynamodb.DynamoDBMapperConfig.PaginationLoadingStrategy;
 import software.amazon.awssdk.mapper.dynamodb.DynamoDBMapperConfig.SaveBehavior;
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import com.amazonaws.services.dynamodbv2.model.BatchGetItemRequest;
 import com.amazonaws.services.dynamodbv2.model.BatchWriteItemRequest;
 import com.amazonaws.services.dynamodbv2.model.CreateTableRequest;

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/ItemConverter.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/ItemConverter.java
@@ -17,7 +17,7 @@ package software.amazon.awssdk.mapper.dynamodb;
 import java.lang.reflect.Method;
 import java.util.Map;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 /**
  * The concrete realization of a strategy for converting between Java objects

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/JsonMarshaller.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/JsonMarshaller.java
@@ -14,8 +14,6 @@
  */
 package software.amazon.awssdk.mapper.dynamodb;
 
-import static com.amazonaws.util.Throwables.failure;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
@@ -66,9 +64,9 @@ public class JsonMarshaller<T extends Object> implements DynamoDBMarshaller<T> {
         try {
             return writer.writeValueAsString(obj);
         } catch (JsonProcessingException e) {
-            throw failure(e,
+            throw new DynamoDBMappingException(
                     "Unable to marshall the instance of " + obj.getClass()
-                            + "into a string");
+                            + "into a string", e);
         }
     }
 
@@ -76,9 +74,11 @@ public class JsonMarshaller<T extends Object> implements DynamoDBMarshaller<T> {
     public T unmarshall(Class<T> clazz, String json) {
         try {
             return mapper.readValue(json, (getValueType() == null ? clazz : getValueType()));
+        } catch (RuntimeException e) {
+            throw e;
         } catch (Exception e) {
-            throw failure(e, "Unable to unmarshall the string " + json
-                    + "into " + clazz);
+            throw new DynamoDBMappingException("Unable to unmarshall the string " + json
+                    + "into " + clazz, e);
         }
     }
 }

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/JsonMarshaller.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/JsonMarshaller.java
@@ -63,10 +63,9 @@ public class JsonMarshaller<T extends Object> implements DynamoDBMarshaller<T> {
 
         try {
             return writer.writeValueAsString(obj);
-        } catch (JsonProcessingException e) {
-            throw new DynamoDBMappingException(
-                    "Unable to marshall the instance of " + obj.getClass()
-                            + "into a string", e);
+        } catch (Exception e) {
+            throw MapperExceptions.failure(e,
+                    "Unable to marshall the instance of " + obj.getClass() + "into a string");
         }
     }
 
@@ -74,11 +73,8 @@ public class JsonMarshaller<T extends Object> implements DynamoDBMarshaller<T> {
     public T unmarshall(Class<T> clazz, String json) {
         try {
             return mapper.readValue(json, (getValueType() == null ? clazz : getValueType()));
-        } catch (RuntimeException e) {
-            throw e;
         } catch (Exception e) {
-            throw new DynamoDBMappingException("Unable to unmarshall the string " + json
-                    + "into " + clazz, e);
+            throw MapperExceptions.failure(e, "Unable to unmarshall the string " + json + "into " + clazz);
         }
     }
 }

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/MapperBinaryUtils.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/MapperBinaryUtils.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package software.amazon.awssdk.mapper.dynamodb;
+
+import java.nio.ByteBuffer;
+
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.core.SdkBytes;
+
+/**
+ * Binary conversion helpers shared by the mapper's converters and unmarshallers.
+ */
+@SdkInternalApi
+public final class MapperBinaryUtils {
+
+    private MapperBinaryUtils() {
+    }
+
+    /**
+     * Returns a writable {@link ByteBuffer} containing the given bytes, preserving v1 behavior.
+     * {@link SdkBytes#asByteBuffer()} is read-only, so this wraps the copy from
+     * {@link SdkBytes#asByteArray()} instead.
+     *
+     * @param sdkBytes the bytes to wrap, may be {@code null}
+     * @return a writable buffer, or {@code null} if {@code sdkBytes} is {@code null}
+     */
+    public static ByteBuffer toWritableByteBuffer(SdkBytes sdkBytes) {
+        return sdkBytes == null ? null : ByteBuffer.wrap(sdkBytes.asByteArray());
+    }
+}

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/MapperDateUtils.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/MapperDateUtils.java
@@ -1,8 +1,5 @@
 /*
- * Copyright 2010-2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Portions copyright 2006-2009 James Murty. Please see LICENSE.txt
- * for applicable license terms and NOTICE.txt for applicable notices.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -30,22 +27,9 @@ import org.joda.time.tz.FixedDateTimeZone;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 
 /**
- * Narrowly-scoped ISO-8601 date parsing and formatting for the mapper's converter layer.
- *
- * <p>The v1 {@code DynamoDBMapper} formatted and parsed {@link Date}/{@code Calendar} attributes
- * with {@code com.amazonaws.util.DateUtils} from {@code aws-java-sdk-core}. That class is v1 SDK
- * infrastructure (it pulls in {@code com.amazonaws.SdkClientException} and
- * {@code com.amazonaws.util.JodaTime}) and cannot be depended on from a v2 module. The v2 SDK's
- * own {@code software.amazon.awssdk.utils.DateUtils} is {@code java.time}-based and is <em>not</em>
- * a drop-in: its parser rejects some ISO-8601 shapes v1 accepts (e.g. basic-format offsets like
- * {@code -0700}) and its formatter omits trailing-zero milliseconds ({@code .000Z}), which would
- * silently change the string form of data written by v1.</p>
- *
- * <p>To preserve byte-for-byte read/write compatibility with data produced by the v1 mapper, this
- * class reproduces exactly the two ISO-8601 methods the converter layer uses, using the same
- * Joda-Time formatters v1 used. It intentionally excludes the other 11 methods of the v1 utility
- * (RFC-822, compressed-ISO, Unix-timestamp, etc.) that the mapper never calls. Do not grow this
- * class beyond ISO-8601 parse/format.</p>
+ * A thin port of only the ISO-8601 parse/format methods of the v1 {@code com.amazonaws.util.DateUtils}
+ * that the mapper's converter layer uses, kept on the same Joda-Time formatters to preserve byte-for-byte
+ * compatibility with dates written by the v1 mapper.
  */
 @SdkInternalApi
 public final class MapperDateUtils {

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/MapperDateUtils.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/MapperDateUtils.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2010-2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Portions copyright 2006-2009 James Murty. Please see LICENSE.txt
+ * for applicable license terms and NOTICE.txt for applicable notices.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package software.amazon.awssdk.mapper.dynamodb;
+
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+
+import org.joda.time.DateTimeZone;
+import org.joda.time.format.DateTimeFormat;
+import org.joda.time.format.DateTimeFormatter;
+import org.joda.time.format.ISODateTimeFormat;
+import org.joda.time.tz.FixedDateTimeZone;
+
+import software.amazon.awssdk.annotations.SdkInternalApi;
+
+/**
+ * Narrowly-scoped ISO-8601 date parsing and formatting for the mapper's converter layer.
+ *
+ * <p>The v1 {@code DynamoDBMapper} formatted and parsed {@link Date}/{@code Calendar} attributes
+ * with {@code com.amazonaws.util.DateUtils} from {@code aws-java-sdk-core}. That class is v1 SDK
+ * infrastructure (it pulls in {@code com.amazonaws.SdkClientException} and
+ * {@code com.amazonaws.util.JodaTime}) and cannot be depended on from a v2 module. The v2 SDK's
+ * own {@code software.amazon.awssdk.utils.DateUtils} is {@code java.time}-based and is <em>not</em>
+ * a drop-in: its parser rejects some ISO-8601 shapes v1 accepts (e.g. basic-format offsets like
+ * {@code -0700}) and its formatter omits trailing-zero milliseconds ({@code .000Z}), which would
+ * silently change the string form of data written by v1.</p>
+ *
+ * <p>To preserve byte-for-byte read/write compatibility with data produced by the v1 mapper, this
+ * class reproduces exactly the two ISO-8601 methods the converter layer uses, using the same
+ * Joda-Time formatters v1 used. It intentionally excludes the other 11 methods of the v1 utility
+ * (RFC-822, compressed-ISO, Unix-timestamp, etc.) that the mapper never calls. Do not grow this
+ * class beyond ISO-8601 parse/format.</p>
+ */
+@SdkInternalApi
+public final class MapperDateUtils {
+
+    private static final DateTimeZone GMT = new FixedDateTimeZone("GMT", "GMT", 0, 0);
+    private static final long MILLI_SECONDS_OF_365_DAYS = 365L * 24 * 60 * 60 * 1000;
+
+    /** ISO 8601 format. */
+    private static final DateTimeFormatter ISO8601_DATE_FORMAT =
+        ISODateTimeFormat.dateTime().withZone(GMT);
+
+    /** Alternate ISO 8601 format without fractional seconds. */
+    private static final DateTimeFormatter ALTERNATE_ISO8601_DATE_FORMAT =
+        DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ss'Z'").withZone(GMT);
+
+    /** ISO 8601 format with a UTC offset. */
+    private static final DateTimeFormatter ISO8601_DATE_FORMAT_WITH_OFFSET =
+        DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ssZZ");
+
+    private static final List<DateTimeFormatter> ALTERNATE_ISO8601_FORMATTERS = Arrays.asList(
+        ALTERNATE_ISO8601_DATE_FORMAT, ISO8601_DATE_FORMAT_WITH_OFFSET);
+
+    private MapperDateUtils() {
+    }
+
+    /**
+     * Parses the specified date string as an ISO 8601 date and returns the {@link Date} object.
+     *
+     * @param dateStringOrig the date string to parse
+     * @return the parsed {@link Date} object
+     */
+    public static Date parseISO8601Date(final String dateStringOrig) {
+        String dateString = dateStringOrig;
+
+        // For EC2 Spot Fleet.
+        if (dateString.endsWith("+0000")) {
+            dateString = dateString
+                    .substring(0, dateString.length() - 5)
+                    .concat("Z");
+        }
+
+        // https://github.com/aws/aws-sdk-java/issues/233
+        String temp = tempDateStringForJodaTime(dateString);
+        try {
+            if (temp.equals(dateString)) {
+                // Normal case: nothing special here
+                return new Date(ISO8601_DATE_FORMAT.parseMillis(dateString));
+            }
+            // Handling edge case:
+            // Joda-time can only handle up to year 292278993 but we are given
+            // 292278994; So we parse the date string by first adjusting
+            // the year to 292278993. Then we add 1 year back afterwards.
+            final long milliLess365Days = ISO8601_DATE_FORMAT.parseMillis(temp);
+            final long milli = milliLess365Days + MILLI_SECONDS_OF_365_DAYS;
+            if (milli < 0) { // overflow!
+                // re-parse the original date string using JodaTime so as to
+                // throw an exception with a consistent message
+                return new Date(ISO8601_DATE_FORMAT.parseMillis(dateString));
+            }
+            return new Date(milli);
+        } catch (IllegalArgumentException e) {
+            for (DateTimeFormatter dateTimeFormatter : ALTERNATE_ISO8601_FORMATTERS) {
+                try {
+                    // If the first ISO 8601 parser didn't work, try the alternate
+                    // version which doesn't include fractional seconds
+                    return new Date(dateTimeFormatter.parseMillis(dateString));
+                } catch (Exception oops) {
+                    // ignore
+                }
+            }
+
+            throw e;
+        }
+    }
+
+    /**
+     * Formats the specified date as an ISO 8601 string.
+     *
+     * @param date the date to format
+     * @return the ISO 8601 string representing the specified date
+     */
+    public static String formatISO8601Date(final Date date) {
+        return ISO8601_DATE_FORMAT.print(date.getTime());
+    }
+
+    /**
+     * Returns a date string with the prefix temporarily substituted, if applicable, so that
+     * JodaTime can handle it. Otherwise, if not applicable, the original date string is returned.
+     *
+     * <p>See https://github.com/aws/aws-sdk-java/issues/233</p>
+     */
+    private static String tempDateStringForJodaTime(final String dateString) {
+        final String fromPrefix = "292278994-";
+        final String toPrefix = "292278993-";
+        return dateString.startsWith(fromPrefix)
+             ? toPrefix + dateString.substring(fromPrefix.length())
+             : dateString;
+    }
+}

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/MapperExceptions.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/MapperExceptions.java
@@ -1,16 +1,16 @@
 /*
- * Copyright 2011-2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
  *
- *    http://aws.amazon.com/apache2.0
+ *  http://aws.amazon.com/apache2.0
  *
- * This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
- * OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and
- * limitations under the License.
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
  */
 package software.amazon.awssdk.mapper.dynamodb;
 
@@ -37,7 +37,6 @@ final class MapperExceptions {
             throw (Error) t;
         }
         if (t instanceof InterruptedException) {
-            Thread.currentThread().interrupt();
             return AbortedException.create(message, t);
         }
         return SdkClientException.create(message, t);

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/MapperExceptions.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/MapperExceptions.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2011-2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *    http://aws.amazon.com/apache2.0
+ *
+ * This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package software.amazon.awssdk.mapper.dynamodb;
+
+import software.amazon.awssdk.core.exception.AbortedException;
+import software.amazon.awssdk.core.exception.SdkClientException;
+
+/**
+ * Port of v1 {@code com.amazonaws.util.Throwables.failure}, using the v2 exception
+ * hierarchy. A {@link RuntimeException} is returned unchanged (the message argument is
+ * discarded, matching v1); an {@link Error} is rethrown; an {@link InterruptedException}
+ * becomes an {@link AbortedException}; any other checked exception becomes an
+ * {@link SdkClientException} (the v2 analog of v1's {@code AmazonClientException}).
+ */
+final class MapperExceptions {
+
+    private MapperExceptions() {
+    }
+
+    static RuntimeException failure(Throwable t, String message) {
+        if (t instanceof RuntimeException) {
+            return (RuntimeException) t;
+        }
+        if (t instanceof Error) {
+            throw (Error) t;
+        }
+        if (t instanceof InterruptedException) {
+            Thread.currentThread().interrupt();
+            return AbortedException.create(message, t);
+        }
+        return SdkClientException.create(message, t);
+    }
+}

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/QueryResultPage.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/QueryResultPage.java
@@ -17,7 +17,7 @@ package software.amazon.awssdk.mapper.dynamodb;
 import java.util.List;
 import java.util.Map;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import com.amazonaws.services.dynamodbv2.model.ConsumedCapacity;
 
 /**

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/ScanResultPage.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/ScanResultPage.java
@@ -17,7 +17,7 @@ package software.amazon.awssdk.mapper.dynamodb;
 import java.util.List;
 import java.util.Map;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import com.amazonaws.services.dynamodbv2.model.ConsumedCapacity;
 
 /**

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/StandardModelFactories.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/StandardModelFactories.java
@@ -329,7 +329,8 @@ final class StandardModelFactories {
             }
             @Override
             public ByteBuffer get(AttributeValue value) {
-                return value.b() == null ? null : value.b().asByteBuffer();
+                // Writable copy for v1 parity; SdkBytes.asByteBuffer() would be read-only.
+                return value.b() == null ? null : ByteBuffer.wrap(value.b().asByteArray());
             }
             @Override
             public AttributeValue build(ByteBuffer o) {
@@ -409,7 +410,8 @@ final class StandardModelFactories {
                 }
                 final List<ByteBuffer> result = new ArrayList<ByteBuffer>(value.bs().size());
                 for (software.amazon.awssdk.core.SdkBytes sb : value.bs()) {
-                    result.add(sb.asByteBuffer());
+                    // Writable copy for v1 parity; SdkBytes.asByteBuffer() would be read-only.
+                    result.add(ByteBuffer.wrap(sb.asByteArray()));
                 }
                 return result;
             }

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/StandardModelFactories.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/StandardModelFactories.java
@@ -330,8 +330,7 @@ final class StandardModelFactories {
             }
             @Override
             public ByteBuffer get(AttributeValue value) {
-                // Writable copy for v1 parity; SdkBytes.asByteBuffer() would be read-only.
-                return value.b() == null ? null : ByteBuffer.wrap(value.b().asByteArray());
+                return MapperBinaryUtils.toWritableByteBuffer(value.b());
             }
             @Override
             public AttributeValue build(ByteBuffer o) {
@@ -411,8 +410,7 @@ final class StandardModelFactories {
                 }
                 final List<ByteBuffer> result = new ArrayList<ByteBuffer>(value.bs().size());
                 for (SdkBytes sb : value.bs()) {
-                    // Writable copy for v1 parity; SdkBytes.asByteBuffer() would be read-only.
-                    result.add(ByteBuffer.wrap(sb.asByteArray()));
+                    result.add(MapperBinaryUtils.toWritableByteBuffer(sb));
                 }
                 return result;
             }

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/StandardModelFactories.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/StandardModelFactories.java
@@ -14,7 +14,7 @@
  */
 package software.amazon.awssdk.mapper.dynamodb;
 
-import com.amazonaws.annotation.SdkInternalApi;
+import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.mapper.dynamodb.DynamoDBMapperFieldModel.DynamoDBAttributeType;
 import software.amazon.awssdk.mapper.dynamodb.DynamoDBMapperFieldModel.Reflect;
 import software.amazon.awssdk.mapper.dynamodb.DynamoDBMapperModelFactory.TableFactory;
@@ -22,13 +22,14 @@ import software.amazon.awssdk.mapper.dynamodb.DynamoDBTypeConverter.AbstractConv
 import software.amazon.awssdk.mapper.dynamodb.DynamoDBTypeConverter.DelegateConverter;
 import software.amazon.awssdk.mapper.dynamodb.StandardBeanProperties.Bean;
 import software.amazon.awssdk.mapper.dynamodb.StandardBeanProperties.Beans;
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.joda.time.DateTime;
 
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collection;
 import java.util.Date;
@@ -45,9 +46,9 @@ import static software.amazon.awssdk.mapper.dynamodb.StandardTypeConverters.Scal
 import static software.amazon.awssdk.mapper.dynamodb.StandardTypeConverters.Vector.LIST;
 import static software.amazon.awssdk.mapper.dynamodb.StandardTypeConverters.Vector.MAP;
 import static software.amazon.awssdk.mapper.dynamodb.StandardTypeConverters.Vector.SET;
-import static com.amazonaws.services.dynamodbv2.model.ScalarAttributeType.B;
-import static com.amazonaws.services.dynamodbv2.model.ScalarAttributeType.N;
-import static com.amazonaws.services.dynamodbv2.model.ScalarAttributeType.S;
+import static software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType.B;
+import static software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType.N;
+import static software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType.S;
 
 /**
  * Pre-defined strategies for mapping between Java types and DynamoDB types.
@@ -226,11 +227,8 @@ final class StandardModelFactories {
                 return o;
             }
             @Override
-            public void set(AttributeValue value, AttributeValue o) {
-                value.withS(o.getS()).withN(o.getN()).withB(o.getB())
-                    .withSS(o.getSS()).withNS(o.getNS()).withBS(o.getBS())
-                    .withBOOL(o.getBOOL()).withL(o.getL()).withM(o.getM())
-                    .withNULL(o.getNULL());
+            public AttributeValue build(AttributeValue o) {
+                return o;
             }
         }
 
@@ -251,11 +249,11 @@ final class StandardModelFactories {
             }
             @Override
             public String get(AttributeValue value) {
-                return value.getS();
+                return value.s();
             }
             @Override
-            public void set(AttributeValue value, String o) {
-                value.setS(o);
+            public AttributeValue build(String o) {
+                return AttributeValue.builder().s(o).build();
             }
             @Override
             public AttributeValue convert(String o) {
@@ -280,11 +278,11 @@ final class StandardModelFactories {
             }
             @Override
             public String get(AttributeValue value) {
-                return value.getN();
+                return value.n();
             }
             @Override
-            public void set(AttributeValue value, String o) {
-                value.setN(o);
+            public AttributeValue build(String o) {
+                return AttributeValue.builder().n(o).build();
             }
         }
 
@@ -306,11 +304,11 @@ final class StandardModelFactories {
             }
             @Override
             public Long get(AttributeValue value) {
-                return Long.valueOf(value.getN());
+                return Long.valueOf(value.n());
             }
             @Override
-            public void set(AttributeValue value, Long o) {
-                value.setN(String.valueOf(o));
+            public AttributeValue build(Long o) {
+                return AttributeValue.builder().n(String.valueOf(o)).build();
             }
         }
 
@@ -331,11 +329,11 @@ final class StandardModelFactories {
             }
             @Override
             public ByteBuffer get(AttributeValue value) {
-                return value.getB();
+                return value.b() == null ? null : value.b().asByteBuffer();
             }
             @Override
-            public void set(AttributeValue value, ByteBuffer o) {
-                value.setB(o);
+            public AttributeValue build(ByteBuffer o) {
+                return AttributeValue.builder().b(software.amazon.awssdk.core.SdkBytes.fromByteBuffer(o)).build();
             }
         }
 
@@ -356,11 +354,11 @@ final class StandardModelFactories {
             }
             @Override
             public List<String> get(AttributeValue value) {
-                return value.getSS();
+                return value.hasSs() ? value.ss() : null;
             }
             @Override
-            public void set(AttributeValue value, List<String> o) {
-                value.setSS(o);
+            public AttributeValue build(List<String> o) {
+                return AttributeValue.builder().ss(o).build();
             }
         }
 
@@ -381,11 +379,11 @@ final class StandardModelFactories {
             }
             @Override
             public List<String> get(AttributeValue value) {
-                return value.getNS();
+                return value.hasNs() ? value.ns() : null;
             }
             @Override
-            public void set(AttributeValue value, List<String> o) {
-                value.setNS(o);
+            public AttributeValue build(List<String> o) {
+                return AttributeValue.builder().ns(o).build();
             }
         }
 
@@ -406,11 +404,23 @@ final class StandardModelFactories {
             }
             @Override
             public List<ByteBuffer> get(AttributeValue value) {
-                return value.getBS();
+                if (!value.hasBs()) {
+                    return null;
+                }
+                final List<ByteBuffer> result = new ArrayList<ByteBuffer>(value.bs().size());
+                for (software.amazon.awssdk.core.SdkBytes sb : value.bs()) {
+                    result.add(sb.asByteBuffer());
+                }
+                return result;
             }
             @Override
-            public void set(AttributeValue value, List<ByteBuffer> o) {
-                value.setBS(o);
+            public AttributeValue build(List<ByteBuffer> o) {
+                final List<software.amazon.awssdk.core.SdkBytes> sdkBytes =
+                    new ArrayList<software.amazon.awssdk.core.SdkBytes>(o.size());
+                for (ByteBuffer bb : o) {
+                    sdkBytes.add(software.amazon.awssdk.core.SdkBytes.fromByteBuffer(bb));
+                }
+                return AttributeValue.builder().bs(sdkBytes).build();
             }
         }
 
@@ -454,16 +464,16 @@ final class StandardModelFactories {
             }
             @Override
             public Boolean get(AttributeValue o) {
-                return o.getBOOL();
+                return o.bool();
             }
             @Override
-            public void set(AttributeValue o, Boolean value) {
-                o.setBOOL(value);
+            public AttributeValue build(Boolean value) {
+                return AttributeValue.builder().bool(value).build();
             }
             @Override
             public Boolean unconvert(AttributeValue o) {
-                if (o.getBOOL() == null && o.getN() != null) {
-                    return BOOLEAN.<Boolean>convert(o.getN());
+                if (o.bool() == null && o.n() != null) {
+                    return BOOLEAN.<Boolean>convert(o.n());
                 }
                 return super.unconvert(o);
             }
@@ -493,11 +503,11 @@ final class StandardModelFactories {
              */
             @Override
             public String get(AttributeValue o) {
-                if(o.getBOOL() != null) {
+                if(o.bool() != null) {
                     // Handle native bools, transform to expected numeric representation.
-                    return o.getBOOL() ? "1" : "0";
+                    return o.bool() ? "1" : "0";
                 }
-                return o.getN();
+                return o.n();
             }
 
             /**
@@ -505,8 +515,8 @@ final class StandardModelFactories {
              * DynamoDBNativeBoolean} or {@link DynamoDBTyped}.
              */
             @Override
-            public void set(AttributeValue o, String value) {
-                o.setN(value);
+            public AttributeValue build(String value) {
+                return AttributeValue.builder().n(value).build();
             }
         }
 
@@ -527,11 +537,11 @@ final class StandardModelFactories {
             }
             @Override
             public List<AttributeValue> get(AttributeValue value) {
-                return value.getL();
+                return value.hasL() ? value.l() : null;
             }
             @Override
-            public void set(AttributeValue value, List<AttributeValue> o) {
-                value.setL(o);
+            public AttributeValue build(List<AttributeValue> o) {
+                return AttributeValue.builder().l(o).build();
             }
         }
 
@@ -548,8 +558,8 @@ final class StandardModelFactories {
             }
             @Override
             public List<AttributeValue> unconvert(AttributeValue o) {
-                if (o.getL() == null && o.getNS() != null) {
-                    return LIST.convert(o.getNS(), new NativeBool(true).join(scalars.getConverter(Boolean.class, String.class)));
+                if (!o.hasL() && o.hasNs()) {
+                    return LIST.convert(o.ns(), new NativeBool(true).join(scalars.getConverter(Boolean.class, String.class)));
                 }
                 return super.unconvert(o);
             }
@@ -572,11 +582,11 @@ final class StandardModelFactories {
             }
             @Override
             public List<AttributeValue> get(AttributeValue value) {
-                return value.getL();
+                return value.hasL() ? value.l() : null;
             }
             @Override
-            public void set(AttributeValue value, List<AttributeValue> o) {
-                value.setL(o);
+            public AttributeValue build(List<AttributeValue> o) {
+                return AttributeValue.builder().l(o).build();
             }
         }
 
@@ -600,11 +610,11 @@ final class StandardModelFactories {
             }
             @Override
             public Map<String,AttributeValue> get(AttributeValue value) {
-                return value.getM();
+                return value.hasM() ? value.m() : null;
             }
             @Override
-            public void set(AttributeValue value, Map<String,AttributeValue> o) {
-                value.setM(o);
+            public AttributeValue build(Map<String,AttributeValue> o) {
+                return AttributeValue.builder().m(o).build();
             }
         }
 
@@ -636,11 +646,11 @@ final class StandardModelFactories {
             }
             @Override
             public Map<String,AttributeValue> get(AttributeValue value) {
-                return value.getM();
+                return value.hasM() ? value.m() : null;
             }
             @Override
-            public void set(AttributeValue value, Map<String,AttributeValue> o) {
-                value.setM(o);
+            public AttributeValue build(Map<String,AttributeValue> o) {
+                return AttributeValue.builder().m(o).build();
             }
         }
 
@@ -660,7 +670,7 @@ final class StandardModelFactories {
                 throw new DynamoDBMappingException("not supported; requires @DynamoDBTyped or @DynamoDBTypeConverted");
             }
             @Override
-            public void set(AttributeValue value, T o) {
+            public AttributeValue build(T o) {
                 throw new DynamoDBMappingException("not supported; requires @DynamoDBTyped or @DynamoDBTypeConverted");
             }
         }
@@ -679,7 +689,7 @@ final class StandardModelFactories {
         private DynamoDBTypeConverter<AttributeValue,T> getConverter(ConvertibleType<T> type) {
             return new DelegateConverter<AttributeValue,T>(getRule(type).newConverter(type)) {
                 public final AttributeValue convert(T o) {
-                    return o == null ? new AttributeValue().withNULL(true) : super.convert(o);
+                    return o == null ? AttributeValue.builder().nul(true).build() : super.convert(o);
                 }
             };
         }
@@ -688,7 +698,7 @@ final class StandardModelFactories {
     /**
      * Basic attribute value conversion functions.
      */
-    private static abstract class AbstractRule<S,T> extends AbstractConverter<AttributeValue,S> implements Reflect<AttributeValue,S>, Rule<T> {
+    private static abstract class AbstractRule<S,T> extends AbstractConverter<AttributeValue,S> implements Rule<T> {
         protected final DynamoDBAttributeType attributeType;
         protected final boolean supported;
         protected AbstractRule(DynamoDBAttributeType attributeType, boolean supported) {
@@ -705,14 +715,20 @@ final class StandardModelFactories {
         }
         @Override
         public AttributeValue convert(final S o) {
-            final AttributeValue value = new AttributeValue();
-            set(value, o);
-            return value;
+            return build(o);
         }
+        /**
+         * Builds an immutable v2 AttributeValue from the given value.
+         */
+        public abstract AttributeValue build(S o);
+        /**
+         * Extracts the value from an AttributeValue.
+         */
+        public abstract S get(AttributeValue o);
         @Override
         public S unconvert(final AttributeValue o) {
             final S value = get(o);
-            if (value == null && o.isNULL() == null) {
+            if (value == null && o.nul() == null) {
                 throw new DynamoDBMappingException("expected " + attributeType  + " in value " + o);
             }
             return value;

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/StandardModelFactories.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/StandardModelFactories.java
@@ -15,6 +15,7 @@
 package software.amazon.awssdk.mapper.dynamodb;
 
 import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.mapper.dynamodb.DynamoDBMapperFieldModel.DynamoDBAttributeType;
 import software.amazon.awssdk.mapper.dynamodb.DynamoDBMapperFieldModel.Reflect;
 import software.amazon.awssdk.mapper.dynamodb.DynamoDBMapperModelFactory.TableFactory;
@@ -334,7 +335,7 @@ final class StandardModelFactories {
             }
             @Override
             public AttributeValue build(ByteBuffer o) {
-                return AttributeValue.builder().b(software.amazon.awssdk.core.SdkBytes.fromByteBuffer(o)).build();
+                return AttributeValue.builder().b(SdkBytes.fromByteBuffer(o)).build();
             }
         }
 
@@ -409,7 +410,7 @@ final class StandardModelFactories {
                     return null;
                 }
                 final List<ByteBuffer> result = new ArrayList<ByteBuffer>(value.bs().size());
-                for (software.amazon.awssdk.core.SdkBytes sb : value.bs()) {
+                for (SdkBytes sb : value.bs()) {
                     // Writable copy for v1 parity; SdkBytes.asByteBuffer() would be read-only.
                     result.add(ByteBuffer.wrap(sb.asByteArray()));
                 }
@@ -417,10 +418,10 @@ final class StandardModelFactories {
             }
             @Override
             public AttributeValue build(List<ByteBuffer> o) {
-                final List<software.amazon.awssdk.core.SdkBytes> sdkBytes =
-                    new ArrayList<software.amazon.awssdk.core.SdkBytes>(o.size());
+                final List<SdkBytes> sdkBytes =
+                    new ArrayList<SdkBytes>(o.size());
                 for (ByteBuffer bb : o) {
-                    sdkBytes.add(software.amazon.awssdk.core.SdkBytes.fromByteBuffer(bb));
+                    sdkBytes.add(SdkBytes.fromByteBuffer(bb));
                 }
                 return AttributeValue.builder().bs(sdkBytes).build();
             }

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/StandardTypeConverters.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/StandardTypeConverters.java
@@ -14,9 +14,8 @@
  */
 package software.amazon.awssdk.mapper.dynamodb;
 
-import com.amazonaws.annotation.SdkInternalApi;
-import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType;
-import com.amazonaws.util.DateUtils;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -686,7 +685,7 @@ final class StandardTypeConverters extends DynamoDBTypeConverterFactory {
         private static final ToDate<String> FromString = new ToDate<String>() {
             @Override
             public final Date convert(final String o) {
-                return DateUtils.parseISO8601Date(o);
+                return MapperDateUtils.parseISO8601Date(o);
             }
         };
     }
@@ -856,7 +855,7 @@ final class StandardTypeConverters extends DynamoDBTypeConverterFactory {
         private static final ToString<Date> FromDate = new ToString<Date>() {
             @Override
             public final String convert(final Date o) {
-                return DateUtils.formatISO8601Date(o);
+                return MapperDateUtils.formatISO8601Date(o);
             }
         };
 

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/UpdateExpressionGenerator.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/UpdateExpressionGenerator.java
@@ -26,7 +26,7 @@ import java.util.Set;
 import java.util.zip.Adler32;
 
 import com.amazonaws.annotation.SdkInternalApi;
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 /**
  * This class will contain logic for converting an update object that customer has passed-in into

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/VersionAttributeConditionExpressionGenerator.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/VersionAttributeConditionExpressionGenerator.java
@@ -19,7 +19,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import com.amazonaws.annotation.SdkInternalApi;
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 /**
  * This class contains logic to generate condition expressions for version attribute

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/marshallers/BooleanSetToNumberSetMarshaller.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/marshallers/BooleanSetToNumberSetMarshaller.java
@@ -19,7 +19,7 @@ import java.util.List;
 import java.util.Set;
 
 import software.amazon.awssdk.mapper.dynamodb.ArgumentMarshaller.NumberSetAttributeMarshaller;
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 /**
  * A legacy marshaller that marshals sets of Java {@code Booleans} into DynamoDB
@@ -54,6 +54,6 @@ public class BooleanSetToNumberSetMarshaller
             }
         }
 
-        return new AttributeValue().withNS(booleanAttributes);
+        return AttributeValue.builder().ns(booleanAttributes).build();
     }
 }

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/marshallers/BooleanToBooleanMarshaller.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/marshallers/BooleanToBooleanMarshaller.java
@@ -15,7 +15,7 @@
 package software.amazon.awssdk.mapper.dynamodb.marshallers;
 
 import software.amazon.awssdk.mapper.dynamodb.ArgumentMarshaller.BooleanAttributeMarshaller;
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 /**
  * A marshaller that marshals Java {@code Boolean} objects to Dynamodb-native
@@ -35,6 +35,6 @@ public class BooleanToBooleanMarshaller implements BooleanAttributeMarshaller {
 
     @Override
     public AttributeValue marshall(Object obj) {
-        return new AttributeValue().withBOOL((Boolean) obj);
+        return AttributeValue.builder().bool((Boolean) obj).build();
     }
 }

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/marshallers/BooleanToNumberMarshaller.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/marshallers/BooleanToNumberMarshaller.java
@@ -15,7 +15,7 @@
 package software.amazon.awssdk.mapper.dynamodb.marshallers;
 
 import software.amazon.awssdk.mapper.dynamodb.ArgumentMarshaller.NumberAttributeMarshaller;
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 /**
  * A legacy marshaller that marshals Java {@code Booleans} into DynamoDB
@@ -39,9 +39,9 @@ public class BooleanToNumberMarshaller implements NumberAttributeMarshaller {
     public AttributeValue marshall(Object obj) {
         Boolean bool = (Boolean) obj;
         if (bool == null || bool == false) {
-            return new AttributeValue().withN("0");
+            return AttributeValue.builder().n("0").build();
         } else {
-            return new AttributeValue().withN("1");
+            return AttributeValue.builder().n("1").build();
         }
     }
 }

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/marshallers/ByteArraySetToBinarySetMarshaller.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/marshallers/ByteArraySetToBinarySetMarshaller.java
@@ -20,7 +20,8 @@ import java.util.List;
 import java.util.Set;
 
 import software.amazon.awssdk.mapper.dynamodb.ArgumentMarshaller.BinarySetAttributeMarshaller;
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 /**
  * A marshaller that marshals sets of Java {@code byte[]}s into DynamoDB
@@ -43,12 +44,12 @@ public class ByteArraySetToBinarySetMarshaller
     public AttributeValue marshall(Object obj) {
         @SuppressWarnings("unchecked")
         Set<byte[]> buffers = (Set<byte[]>) obj;
-        List<ByteBuffer> attributes = new ArrayList<ByteBuffer>(buffers.size());
+        List<SdkBytes> attributes = new ArrayList<SdkBytes>(buffers.size());
 
         for (byte[] b : buffers) {
-            attributes.add(ByteBuffer.wrap(b));
+            attributes.add(SdkBytes.fromByteArray(b));
         }
 
-        return new AttributeValue().withBS(attributes);
+        return AttributeValue.builder().bs(attributes).build();
     }
 }

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/marshallers/ByteArrayToBinaryMarshaller.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/marshallers/ByteArrayToBinaryMarshaller.java
@@ -17,7 +17,8 @@ package software.amazon.awssdk.mapper.dynamodb.marshallers;
 import java.nio.ByteBuffer;
 
 import software.amazon.awssdk.mapper.dynamodb.ArgumentMarshaller.BinaryAttributeMarshaller;
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 /**
  * A marshaller that marshals Java {@code byte[]}s into DynamoDB Binary
@@ -37,6 +38,6 @@ public class ByteArrayToBinaryMarshaller implements BinaryAttributeMarshaller {
 
     @Override
     public AttributeValue marshall(Object obj) {
-        return new AttributeValue().withB(ByteBuffer.wrap((byte[]) obj));
+        return AttributeValue.builder().b(SdkBytes.fromByteArray((byte[]) obj)).build();
     }
 }

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/marshallers/ByteBufferSetToBinarySetMarshaller.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/marshallers/ByteBufferSetToBinarySetMarshaller.java
@@ -20,7 +20,8 @@ import java.util.List;
 import java.util.Set;
 
 import software.amazon.awssdk.mapper.dynamodb.ArgumentMarshaller.BinarySetAttributeMarshaller;
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 /**
  * A marshaller that marshals sets of Java {@code ByteBuffer}s into DynamoDB
@@ -43,12 +44,12 @@ public class ByteBufferSetToBinarySetMarshaller
     public AttributeValue marshall(Object obj) {
         @SuppressWarnings("unchecked")
         Set<ByteBuffer> buffers = (Set<ByteBuffer>) obj;
-        List<ByteBuffer> attributes = new ArrayList<ByteBuffer>(buffers.size());
+        List<SdkBytes> attributes = new ArrayList<SdkBytes>(buffers.size());
 
         for (ByteBuffer b : buffers) {
-            attributes.add(b);
+            attributes.add(SdkBytes.fromByteBuffer(b));
         }
 
-        return new AttributeValue().withBS(attributes);
+        return AttributeValue.builder().bs(attributes).build();
     }
 }

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/marshallers/ByteBufferToBinaryMarshaller.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/marshallers/ByteBufferToBinaryMarshaller.java
@@ -17,7 +17,8 @@ package software.amazon.awssdk.mapper.dynamodb.marshallers;
 import java.nio.ByteBuffer;
 
 import software.amazon.awssdk.mapper.dynamodb.ArgumentMarshaller.BinaryAttributeMarshaller;
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 /**
  * A marshaller that marshals Java {@code ByteBuffer}s into DynamoDB Binary
@@ -37,6 +38,6 @@ public class ByteBufferToBinaryMarshaller implements BinaryAttributeMarshaller {
 
     @Override
     public AttributeValue marshall(Object obj) {
-        return new AttributeValue().withB((ByteBuffer) obj);
+        return AttributeValue.builder().b(SdkBytes.fromByteBuffer((ByteBuffer) obj)).build();
     }
 }

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/marshallers/CalendarSetToStringSetMarshaller.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/marshallers/CalendarSetToStringSetMarshaller.java
@@ -14,14 +14,15 @@
  */
 package software.amazon.awssdk.mapper.dynamodb.marshallers;
 
+import software.amazon.awssdk.mapper.dynamodb.MapperDateUtils;
+
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.List;
 import java.util.Set;
 
 import software.amazon.awssdk.mapper.dynamodb.ArgumentMarshaller.StringSetAttributeMarshaller;
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
-import com.amazonaws.util.DateUtils;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 /**
  * A marshaller that marshals sets of Java {@code Calendar} objects into
@@ -47,9 +48,9 @@ public class CalendarSetToStringSetMarshaller
 
         List<String> timestamps = new ArrayList<String>(dates.size());
         for (Calendar date : dates) {
-            timestamps.add(DateUtils.formatISO8601Date(date.getTime()));
+            timestamps.add(MapperDateUtils.formatISO8601Date(date.getTime()));
         }
 
-        return new AttributeValue().withSS(timestamps);
+        return AttributeValue.builder().ss(timestamps).build();
     }
 }

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/marshallers/CalendarToStringMarshaller.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/marshallers/CalendarToStringMarshaller.java
@@ -14,11 +14,12 @@
  */
 package software.amazon.awssdk.mapper.dynamodb.marshallers;
 
+import software.amazon.awssdk.mapper.dynamodb.MapperDateUtils;
+
 import java.util.Calendar;
 
 import software.amazon.awssdk.mapper.dynamodb.ArgumentMarshaller.StringAttributeMarshaller;
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
-import com.amazonaws.util.DateUtils;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 /**
  * A marshaller that marshals Java {@code Calendar} objects into DynamoDB
@@ -38,7 +39,7 @@ public class CalendarToStringMarshaller implements StringAttributeMarshaller {
 
     @Override
     public AttributeValue marshall(Object obj) {
-        return new AttributeValue().withS(
-                DateUtils.formatISO8601Date(((Calendar) obj).getTime()));
+        return AttributeValue.builder().s(
+                MapperDateUtils.formatISO8601Date(((Calendar) obj).getTime())).build();
     }
 }

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/marshallers/CollectionToListMarshaller.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/marshallers/CollectionToListMarshaller.java
@@ -20,7 +20,7 @@ import java.util.List;
 
 import software.amazon.awssdk.mapper.dynamodb.ArgumentMarshaller;
 import software.amazon.awssdk.mapper.dynamodb.ArgumentMarshaller.ListAttributeMarshaller;
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 public class CollectionToListMarshaller implements ListAttributeMarshaller {
 
@@ -56,7 +56,7 @@ public class CollectionToListMarshaller implements ListAttributeMarshaller {
         for (Object o : objects) {
             AttributeValue value;
             if (o == null) {
-                value = new AttributeValue().withNULL(true);
+                value = AttributeValue.builder().nul(true).build();
             } else {
                 value = memberMarshaller.marshall(o);
             }
@@ -64,9 +64,7 @@ public class CollectionToListMarshaller implements ListAttributeMarshaller {
             values.add(value);
         }
 
-        AttributeValue result = new AttributeValue();
-        result.setL(values);
-        return result;
+        return AttributeValue.builder().l(values).build();
     }
 
     public ArgumentMarshaller getMemberMarshaller() {

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/marshallers/CustomMarshaller.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/marshallers/CustomMarshaller.java
@@ -17,7 +17,7 @@ package software.amazon.awssdk.mapper.dynamodb.marshallers;
 import software.amazon.awssdk.mapper.dynamodb.ArgumentMarshaller.StringAttributeMarshaller;
 import software.amazon.awssdk.mapper.dynamodb.DynamoDBMappingException;
 import software.amazon.awssdk.mapper.dynamodb.DynamoDBMarshaller;
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 /**
  * A marshaller that delegates to an instance of a
@@ -48,7 +48,7 @@ public class CustomMarshaller implements StringAttributeMarshaller {
         if (stringValue == null) {
             return null;
         } else {
-            return new AttributeValue(stringValue);
+            return AttributeValue.builder().s(stringValue).build();
         }
     }
 

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/marshallers/DateSetToStringSetMarshaller.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/marshallers/DateSetToStringSetMarshaller.java
@@ -14,14 +14,15 @@
  */
 package software.amazon.awssdk.mapper.dynamodb.marshallers;
 
+import software.amazon.awssdk.mapper.dynamodb.MapperDateUtils;
+
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Set;
 
 import software.amazon.awssdk.mapper.dynamodb.ArgumentMarshaller.StringSetAttributeMarshaller;
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
-import com.amazonaws.util.DateUtils;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 /**
  * A marshaller that marshals sets of Java {@code Date} objects into DynamoDB
@@ -47,9 +48,9 @@ public class DateSetToStringSetMarshaller
 
         List<String> timestamps = new ArrayList<String>(dates.size());
         for (Date date : dates) {
-            timestamps.add(DateUtils.formatISO8601Date(date));
+            timestamps.add(MapperDateUtils.formatISO8601Date(date));
         }
 
-        return new AttributeValue().withSS(timestamps);
+        return AttributeValue.builder().ss(timestamps).build();
     }
 }

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/marshallers/DateToStringMarshaller.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/marshallers/DateToStringMarshaller.java
@@ -14,11 +14,12 @@
  */
 package software.amazon.awssdk.mapper.dynamodb.marshallers;
 
+import software.amazon.awssdk.mapper.dynamodb.MapperDateUtils;
+
 import java.util.Date;
 
 import software.amazon.awssdk.mapper.dynamodb.ArgumentMarshaller.StringAttributeMarshaller;
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
-import com.amazonaws.util.DateUtils;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 /**
  * A marshaller that marshals Java {@code Date} objects into DynamoDB Strings
@@ -38,7 +39,7 @@ public class DateToStringMarshaller implements StringAttributeMarshaller {
 
     @Override
     public AttributeValue marshall(Object obj) {
-        return new AttributeValue().withS(
-                DateUtils.formatISO8601Date((Date) obj));
+        return AttributeValue.builder().s(
+                MapperDateUtils.formatISO8601Date((Date) obj)).build();
     }
 }

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/marshallers/MapToMapMarshaller.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/marshallers/MapToMapMarshaller.java
@@ -19,7 +19,7 @@ import java.util.Map;
 
 import software.amazon.awssdk.mapper.dynamodb.ArgumentMarshaller;
 import software.amazon.awssdk.mapper.dynamodb.ArgumentMarshaller.MapAttributeMarshaller;
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 public class MapToMapMarshaller implements MapAttributeMarshaller {
 
@@ -59,7 +59,7 @@ public class MapToMapMarshaller implements MapAttributeMarshaller {
         for (Map.Entry<String, ?> entry : map.entrySet()) {
             AttributeValue value;
             if (entry.getValue() == null) {
-                value = new AttributeValue().withNULL(true);
+                value = AttributeValue.builder().nul(true).build();
             } else {
                 value = memberMarshaller.marshall(entry.getValue());
             }
@@ -67,9 +67,7 @@ public class MapToMapMarshaller implements MapAttributeMarshaller {
             values.put(entry.getKey(), value);
         }
 
-        AttributeValue result = new AttributeValue();
-        result.setM(values);
-        return result;
+        return AttributeValue.builder().m(values).build();
     }
 
     public ArgumentMarshaller getMemberMarshaller() {

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/marshallers/NumberSetToNumberSetMarshaller.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/marshallers/NumberSetToNumberSetMarshaller.java
@@ -19,7 +19,7 @@ import java.util.List;
 import java.util.Set;
 
 import software.amazon.awssdk.mapper.dynamodb.ArgumentMarshaller.NumberSetAttributeMarshaller;
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 /**
  * A marshaller that marshals sets of Java {@code Number}s into DynamoDB
@@ -48,6 +48,6 @@ public class NumberSetToNumberSetMarshaller
             numberAttributes.add(n.toString());
         }
 
-        return new AttributeValue().withNS(numberAttributes);
+        return AttributeValue.builder().ns(numberAttributes).build();
     }
 }

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/marshallers/NumberToNumberMarshaller.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/marshallers/NumberToNumberMarshaller.java
@@ -15,7 +15,7 @@
 package software.amazon.awssdk.mapper.dynamodb.marshallers;
 
 import software.amazon.awssdk.mapper.dynamodb.ArgumentMarshaller.NumberAttributeMarshaller;
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 /**
  * A marshaller that marshals any Java {@code Number} to a DynamoDB number.
@@ -35,6 +35,6 @@ public class NumberToNumberMarshaller implements NumberAttributeMarshaller {
     @Override
     public AttributeValue marshall(Object obj) {
         Number number = (Number) obj;
-        return new AttributeValue().withN(number.toString());
+        return AttributeValue.builder().n(number.toString()).build();
     }
 }

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/marshallers/ObjectSetToStringSetMarshaller.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/marshallers/ObjectSetToStringSetMarshaller.java
@@ -22,7 +22,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import software.amazon.awssdk.mapper.dynamodb.ArgumentMarshaller.StringSetAttributeMarshaller;
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 /**
  * A legacy marshaller that marshals sets of arbitrary Java objects into
@@ -63,6 +63,6 @@ public class ObjectSetToStringSetMarshaller
             strings.add(String.valueOf(o));
         }
 
-        return new AttributeValue().withSS(strings);
+        return AttributeValue.builder().ss(strings).build();
     }
 }

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/marshallers/ObjectToMapMarshaller.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/marshallers/ObjectToMapMarshaller.java
@@ -18,7 +18,7 @@ import java.util.Map;
 
 import software.amazon.awssdk.mapper.dynamodb.ArgumentMarshaller.MapAttributeMarshaller;
 import software.amazon.awssdk.mapper.dynamodb.ItemConverter;
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 public class ObjectToMapMarshaller implements MapAttributeMarshaller {
 
@@ -45,6 +45,6 @@ public class ObjectToMapMarshaller implements MapAttributeMarshaller {
     @Override
     public AttributeValue marshall(Object obj) {
         Map<String, AttributeValue> values = converter.convert(obj);
-        return new AttributeValue().withM(values);
+        return AttributeValue.builder().m(values).build();
     }
 }

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/marshallers/ObjectToStringMarshaller.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/marshallers/ObjectToStringMarshaller.java
@@ -15,7 +15,7 @@
 package software.amazon.awssdk.mapper.dynamodb.marshallers;
 
 import software.amazon.awssdk.mapper.dynamodb.ArgumentMarshaller.StringAttributeMarshaller;
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 /**
 * A marshaller that marshals Java {@code Object} objects into DynamoDB
@@ -37,6 +37,6 @@ public class ObjectToStringMarshaller implements StringAttributeMarshaller {
 
     @Override
     public AttributeValue marshall(Object obj) {
-        return new AttributeValue().withS(obj.toString());
+        return AttributeValue.builder().s(obj.toString()).build();
     }
 }

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/marshallers/S3LinkToStringMarshaller.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/marshallers/S3LinkToStringMarshaller.java
@@ -16,7 +16,7 @@ package software.amazon.awssdk.mapper.dynamodb.marshallers;
 
 import software.amazon.awssdk.mapper.dynamodb.ArgumentMarshaller.StringAttributeMarshaller;
 import software.amazon.awssdk.mapper.dynamodb.S3Link;
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 /**
  * A marshaller that marshals {@code S3Link} objects to DynamoDB Strings,
@@ -44,6 +44,6 @@ public class S3LinkToStringMarshaller implements StringAttributeMarshaller {
             return null;
         }
 
-        return new AttributeValue().withS(s3link.toJson());
+        return AttributeValue.builder().s(s3link.toJson()).build();
     }
 }

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/marshallers/StringSetToStringSetMarshaller.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/marshallers/StringSetToStringSetMarshaller.java
@@ -19,7 +19,7 @@ import java.util.List;
 import java.util.Set;
 
 import software.amazon.awssdk.mapper.dynamodb.ArgumentMarshaller.StringSetAttributeMarshaller;
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 /**
  * A marshaller that marshals sets of Java {@code String}s to DynamoDB
@@ -48,6 +48,6 @@ public class StringSetToStringSetMarshaller
             strings.add(s);
         }
 
-        return new AttributeValue().withSS(strings);
+        return AttributeValue.builder().ss(strings).build();
     }
 }

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/marshallers/StringToStringMarshaller.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/marshallers/StringToStringMarshaller.java
@@ -15,7 +15,7 @@
 package software.amazon.awssdk.mapper.dynamodb.marshallers;
 
 import software.amazon.awssdk.mapper.dynamodb.ArgumentMarshaller.StringAttributeMarshaller;
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 /**
  * A marshaller that marshals Java {@code String} objects to DynamoDB Strings.
@@ -40,6 +40,6 @@ public class StringToStringMarshaller implements StringAttributeMarshaller {
             return null;
         }
 
-        return new AttributeValue().withS(string);
+        return AttributeValue.builder().s(string).build();
     }
 }

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/marshallers/UUIDSetToStringSetMarshaller.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/marshallers/UUIDSetToStringSetMarshaller.java
@@ -20,7 +20,7 @@ import java.util.Set;
 import java.util.UUID;
 
 import software.amazon.awssdk.mapper.dynamodb.ArgumentMarshaller.StringSetAttributeMarshaller;
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 /**
  * A marshaller that marshals sets of Java {@code Object} objects into
@@ -51,6 +51,6 @@ public class UUIDSetToStringSetMarshaller
             strings.add(uuid.toString());
         }
 
-        return new AttributeValue().withSS(strings);
+        return AttributeValue.builder().ss(strings).build();
     }
 }

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/BSUnmarshaller.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/BSUnmarshaller.java
@@ -18,13 +18,13 @@ import java.lang.reflect.Method;
 
 import software.amazon.awssdk.mapper.dynamodb.ArgumentUnmarshaller;
 import software.amazon.awssdk.mapper.dynamodb.DynamoDBMappingException;
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 abstract class BSUnmarshaller implements ArgumentUnmarshaller {
 
     @Override
     public void typeCheck(AttributeValue value, Method setter) {
-        if ( value.getBS() == null ) {
+        if ( !value.hasBs() ) {
             throw new DynamoDBMappingException("Expected BS in value " + value + " when invoking " + setter);
         }
     }

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/BUnmarshaller.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/BUnmarshaller.java
@@ -18,13 +18,13 @@ import java.lang.reflect.Method;
 
 import software.amazon.awssdk.mapper.dynamodb.ArgumentUnmarshaller;
 import software.amazon.awssdk.mapper.dynamodb.DynamoDBMappingException;
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 abstract class BUnmarshaller implements ArgumentUnmarshaller {
 
     @Override
     public void typeCheck(AttributeValue value, Method setter) {
-        if ( value.getB() == null ) {
+        if ( value.b() == null ) {
             throw new DynamoDBMappingException("Expected B in value " + value + " when invoking " + setter);
         }
     }

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/BigDecimalSetUnmarshaller.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/BigDecimalSetUnmarshaller.java
@@ -18,7 +18,7 @@ import java.math.BigDecimal;
 import java.util.HashSet;
 import java.util.Set;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 /**
  * An unmarshaller that unmarshals DynamoDB NumberSets into sets of Java
@@ -39,7 +39,7 @@ public class BigDecimalSetUnmarshaller extends NSUnmarshaller {
     @Override
     public Object unmarshall(AttributeValue value) {
         Set<BigDecimal> result = new HashSet<BigDecimal>();
-        for (String s : value.getNS()) {
+        for (String s : value.ns()) {
             result.add(new BigDecimal(s));
         }
         return result;

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/BigDecimalUnmarshaller.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/BigDecimalUnmarshaller.java
@@ -16,7 +16,7 @@ package software.amazon.awssdk.mapper.dynamodb.unmarshallers;
 
 import java.math.BigDecimal;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 /**
  * An unmarshaller that unmarshals DynamoDB Numbers into Java
@@ -36,6 +36,6 @@ public class BigDecimalUnmarshaller extends NUnmarshaller {
 
     @Override
     public Object unmarshall(AttributeValue value) {
-        return new BigDecimal(value.getN());
+        return new BigDecimal(value.n());
     }
 }

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/BigIntegerSetUnmarshaller.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/BigIntegerSetUnmarshaller.java
@@ -18,7 +18,7 @@ import java.math.BigInteger;
 import java.util.HashSet;
 import java.util.Set;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 /**
  * An unmarshaller that unmarshals DynamoDB NumberSets into sets of Java
@@ -39,7 +39,7 @@ public class BigIntegerSetUnmarshaller extends NSUnmarshaller {
     @Override
     public Object unmarshall(AttributeValue value) {
         Set<BigInteger> result = new HashSet<BigInteger>();
-        for (String s : value.getNS()) {
+        for (String s : value.ns()) {
             result.add(new BigInteger(s));
         }
         return result;

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/BigIntegerUnmarshaller.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/BigIntegerUnmarshaller.java
@@ -16,7 +16,7 @@ package software.amazon.awssdk.mapper.dynamodb.unmarshallers;
 
 import java.math.BigInteger;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 /**
  * An unmarshaller that unmarshals DynamoDB Numbers into Java
@@ -36,6 +36,6 @@ public class BigIntegerUnmarshaller extends NUnmarshaller {
 
     @Override
     public Object unmarshall(AttributeValue value) {
-        return new BigInteger(value.getN());
+        return new BigInteger(value.n());
     }
 }

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/BooleanSetUnmarshaller.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/BooleanSetUnmarshaller.java
@@ -21,7 +21,7 @@ import java.util.Set;
 
 import software.amazon.awssdk.mapper.dynamodb.ArgumentUnmarshaller;
 import software.amazon.awssdk.mapper.dynamodb.DynamoDBMappingException;
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 /**
  * A special unmarshaller for Set&lt;Boolean>, which the V1 schema stores as
@@ -42,7 +42,7 @@ public class BooleanSetUnmarshaller implements ArgumentUnmarshaller {
 
     @Override
     public void typeCheck(AttributeValue value, Method setter) {
-        if (value.getNS() == null && value.getL() == null) {
+        if (!value.hasNs() && !value.hasL()) {
             throw new DynamoDBMappingException(
                     "Expected either L or NS in value " + value
                     + " when invoking " + setter);
@@ -51,10 +51,10 @@ public class BooleanSetUnmarshaller implements ArgumentUnmarshaller {
 
     @Override
     public Object unmarshall(AttributeValue value) {
-        if (value.getL() != null) {
-            return unmarshallList(value.getL());
+        if (value.hasL()) {
+            return unmarshallList(value.l());
         } else {
-            return unmarshallNS(value.getNS());
+            return unmarshallNS(value.ns());
         }
     }
 
@@ -63,10 +63,10 @@ public class BooleanSetUnmarshaller implements ArgumentUnmarshaller {
 
         for (AttributeValue value : values) {
             Boolean bool;
-            if (Boolean.TRUE.equals(value.isNULL())) {
+            if (Boolean.TRUE.equals(value.nul())) {
                 bool = null;
             } else {
-                bool = value.getBOOL();
+                bool = value.bool();
                 if (bool == null) {
                     throw new DynamoDBMappingException(
                             value + " is not a boolean");

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/BooleanUnmarshaller.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/BooleanUnmarshaller.java
@@ -18,7 +18,7 @@ import java.lang.reflect.Method;
 
 import software.amazon.awssdk.mapper.dynamodb.ArgumentUnmarshaller;
 import software.amazon.awssdk.mapper.dynamodb.DynamoDBMappingException;
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 /**
  * An unmarshaller that unmarshals DynamoDB Bools (or Numbers) into Java
@@ -41,7 +41,7 @@ public class BooleanUnmarshaller implements ArgumentUnmarshaller {
 
     @Override
     public void typeCheck(AttributeValue value, Method setter) {
-        if (value.getN() == null && value.getBOOL() == null) {
+        if (value.n() == null && value.bool() == null) {
             throw new DynamoDBMappingException(
                     "Expected either N or BOOL in value " + value
                     + " when invoking " + setter);
@@ -50,13 +50,13 @@ public class BooleanUnmarshaller implements ArgumentUnmarshaller {
 
     @Override
     public Object unmarshall(AttributeValue value) {
-        if (value.getBOOL() != null) {
-            return value.getBOOL();
+        if (value.bool() != null) {
+            return value.bool();
         }
-        if ("1".equals(value.getN())) {
+        if ("1".equals(value.n())) {
             return Boolean.TRUE;
         }
-        if ("0".equals(value.getN())) {
+        if ("0".equals(value.n())) {
             return Boolean.FALSE;
         }
 

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/ByteArraySetUnmarshaller.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/ByteArraySetUnmarshaller.java
@@ -17,6 +17,7 @@ package software.amazon.awssdk.mapper.dynamodb.unmarshallers;
 import java.util.HashSet;
 import java.util.Set;
 
+import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 /**
@@ -39,7 +40,7 @@ public class ByteArraySetUnmarshaller extends BSUnmarshaller {
     public Object unmarshall(AttributeValue value) {
         Set<byte[]> result = new HashSet<byte[]>();
 
-        for (software.amazon.awssdk.core.SdkBytes sdkBytes : value.bs()) {
+        for (SdkBytes sdkBytes : value.bs()) {
             result.add(sdkBytes.asByteArray());
         }
 

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/ByteArraySetUnmarshaller.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/ByteArraySetUnmarshaller.java
@@ -18,7 +18,7 @@ import java.nio.ByteBuffer;
 import java.util.HashSet;
 import java.util.Set;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 /**
  * An unmarshaller that unmarshals BinarySet values as sets of Java
@@ -40,7 +40,8 @@ public class ByteArraySetUnmarshaller extends BSUnmarshaller {
     public Object unmarshall(AttributeValue value) {
         Set<byte[]> result = new HashSet<byte[]>();
 
-        for (ByteBuffer buffer : value.getBS()) {
+        for (software.amazon.awssdk.core.SdkBytes sdkBytes : value.bs()) {
+            ByteBuffer buffer = sdkBytes.asByteBuffer();
             if (buffer.hasArray()) {
                 result.add(buffer.array());
             } else {

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/ByteArraySetUnmarshaller.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/ByteArraySetUnmarshaller.java
@@ -14,7 +14,6 @@
  */
 package software.amazon.awssdk.mapper.dynamodb.unmarshallers;
 
-import java.nio.ByteBuffer;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -41,14 +40,7 @@ public class ByteArraySetUnmarshaller extends BSUnmarshaller {
         Set<byte[]> result = new HashSet<byte[]>();
 
         for (software.amazon.awssdk.core.SdkBytes sdkBytes : value.bs()) {
-            ByteBuffer buffer = sdkBytes.asByteBuffer();
-            if (buffer.hasArray()) {
-                result.add(buffer.array());
-            } else {
-                byte[] array = new byte[buffer.remaining()];
-                buffer.get(array);
-                result.add(array);
-            }
+            result.add(sdkBytes.asByteArray());
         }
 
         return result;

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/ByteArrayUnmarshaller.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/ByteArrayUnmarshaller.java
@@ -16,7 +16,7 @@ package software.amazon.awssdk.mapper.dynamodb.unmarshallers;
 
 import java.nio.ByteBuffer;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 /**
  * An unmarshaller that unmarshals Binary values as Java {@code byte[]}s.
@@ -35,7 +35,7 @@ public class ByteArrayUnmarshaller extends BUnmarshaller {
 
     @Override
     public Object unmarshall(AttributeValue value) {
-        ByteBuffer buffer = value.getB();
+        ByteBuffer buffer = value.b().asByteBuffer();
 
         if (buffer.hasArray()) {
             return buffer.array();

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/ByteArrayUnmarshaller.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/ByteArrayUnmarshaller.java
@@ -14,8 +14,6 @@
  */
 package software.amazon.awssdk.mapper.dynamodb.unmarshallers;
 
-import java.nio.ByteBuffer;
-
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 /**
@@ -35,14 +33,6 @@ public class ByteArrayUnmarshaller extends BUnmarshaller {
 
     @Override
     public Object unmarshall(AttributeValue value) {
-        ByteBuffer buffer = value.b().asByteBuffer();
-
-        if (buffer.hasArray()) {
-            return buffer.array();
-        }
-
-        byte[] array = new byte[buffer.remaining()];
-        buffer.get(array);
-        return array;
+        return value.b().asByteArray();
     }
 }

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/ByteBufferSetUnmarshaller.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/ByteBufferSetUnmarshaller.java
@@ -19,6 +19,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.mapper.dynamodb.MapperBinaryUtils;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 /**
@@ -41,8 +42,7 @@ public class ByteBufferSetUnmarshaller extends BSUnmarshaller {
     public Object unmarshall(AttributeValue value) {
         Set<ByteBuffer> result = new HashSet<ByteBuffer>();
         for (SdkBytes sdkBytes : value.bs()) {
-            // Writable copy for v1 parity; SdkBytes.asByteBuffer() would be read-only.
-            result.add(ByteBuffer.wrap(sdkBytes.asByteArray()));
+            result.add(MapperBinaryUtils.toWritableByteBuffer(sdkBytes));
         }
         return result;
     }

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/ByteBufferSetUnmarshaller.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/ByteBufferSetUnmarshaller.java
@@ -16,8 +16,9 @@ package software.amazon.awssdk.mapper.dynamodb.unmarshallers;
 
 import java.nio.ByteBuffer;
 import java.util.HashSet;
+import java.util.Set;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 /**
  * An unmarshaller that unmarshals BinarySet values as sets of Java
@@ -37,6 +38,10 @@ public class ByteBufferSetUnmarshaller extends BSUnmarshaller {
 
     @Override
     public Object unmarshall(AttributeValue value) {
-        return new HashSet<ByteBuffer>(value.getBS());
+        Set<ByteBuffer> result = new HashSet<ByteBuffer>();
+        for (software.amazon.awssdk.core.SdkBytes sdkBytes : value.bs()) {
+            result.add(sdkBytes.asByteBuffer());
+        }
+        return result;
     }
 }

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/ByteBufferSetUnmarshaller.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/ByteBufferSetUnmarshaller.java
@@ -40,7 +40,8 @@ public class ByteBufferSetUnmarshaller extends BSUnmarshaller {
     public Object unmarshall(AttributeValue value) {
         Set<ByteBuffer> result = new HashSet<ByteBuffer>();
         for (software.amazon.awssdk.core.SdkBytes sdkBytes : value.bs()) {
-            result.add(sdkBytes.asByteBuffer());
+            // Writable copy for v1 parity; SdkBytes.asByteBuffer() would be read-only.
+            result.add(ByteBuffer.wrap(sdkBytes.asByteArray()));
         }
         return result;
     }

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/ByteBufferSetUnmarshaller.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/ByteBufferSetUnmarshaller.java
@@ -18,6 +18,7 @@ import java.nio.ByteBuffer;
 import java.util.HashSet;
 import java.util.Set;
 
+import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 /**
@@ -39,7 +40,7 @@ public class ByteBufferSetUnmarshaller extends BSUnmarshaller {
     @Override
     public Object unmarshall(AttributeValue value) {
         Set<ByteBuffer> result = new HashSet<ByteBuffer>();
-        for (software.amazon.awssdk.core.SdkBytes sdkBytes : value.bs()) {
+        for (SdkBytes sdkBytes : value.bs()) {
             // Writable copy for v1 parity; SdkBytes.asByteBuffer() would be read-only.
             result.add(ByteBuffer.wrap(sdkBytes.asByteArray()));
         }

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/ByteBufferUnmarshaller.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/ByteBufferUnmarshaller.java
@@ -14,6 +14,8 @@
  */
 package software.amazon.awssdk.mapper.dynamodb.unmarshallers;
 
+import java.nio.ByteBuffer;
+
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 /**
@@ -33,6 +35,9 @@ public class ByteBufferUnmarshaller extends BUnmarshaller {
 
     @Override
     public Object unmarshall(AttributeValue value) {
-        return value.b().asByteBuffer();
+        // v2 SdkBytes.asByteBuffer() returns a read-only buffer; v1 getB() returned a
+        // writable one. Return a writable defensive copy to preserve v1 behavior for
+        // callers that mutate the returned buffer. asByteArray() already copies the bytes.
+        return ByteBuffer.wrap(value.b().asByteArray());
     }
 }

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/ByteBufferUnmarshaller.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/ByteBufferUnmarshaller.java
@@ -14,7 +14,7 @@
  */
 package software.amazon.awssdk.mapper.dynamodb.unmarshallers;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 /**
  * An unmarshaller that unmarshals Binary values as Java {@code ByteBuffer}s.
@@ -33,6 +33,6 @@ public class ByteBufferUnmarshaller extends BUnmarshaller {
 
     @Override
     public Object unmarshall(AttributeValue value) {
-        return value.getB();
+        return value.b().asByteBuffer();
     }
 }

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/ByteBufferUnmarshaller.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/ByteBufferUnmarshaller.java
@@ -14,8 +14,7 @@
  */
 package software.amazon.awssdk.mapper.dynamodb.unmarshallers;
 
-import java.nio.ByteBuffer;
-
+import software.amazon.awssdk.mapper.dynamodb.MapperBinaryUtils;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 /**
@@ -35,9 +34,6 @@ public class ByteBufferUnmarshaller extends BUnmarshaller {
 
     @Override
     public Object unmarshall(AttributeValue value) {
-        // v2 SdkBytes.asByteBuffer() returns a read-only buffer; v1 getB() returned a
-        // writable one. Return a writable defensive copy to preserve v1 behavior for
-        // callers that mutate the returned buffer. asByteArray() already copies the bytes.
-        return ByteBuffer.wrap(value.b().asByteArray());
+        return MapperBinaryUtils.toWritableByteBuffer(value.b());
     }
 }

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/ByteSetUnmarshaller.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/ByteSetUnmarshaller.java
@@ -17,7 +17,7 @@ package software.amazon.awssdk.mapper.dynamodb.unmarshallers;
 import java.util.HashSet;
 import java.util.Set;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 /**
  * An unmarshaller that unmarshals DynamoDB NumberSets into sets of Java
@@ -38,7 +38,7 @@ public class ByteSetUnmarshaller extends NSUnmarshaller {
     @Override
     public Object unmarshall(AttributeValue value) {
         Set<Byte> result = new HashSet<Byte>();
-        for (String s : value.getNS()) {
+        for (String s : value.ns()) {
             result.add(Byte.valueOf(s));
         }
         return result;

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/ByteUnmarshaller.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/ByteUnmarshaller.java
@@ -14,7 +14,7 @@
  */
 package software.amazon.awssdk.mapper.dynamodb.unmarshallers;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 /**
  * An unmarshaller that unmarshals DynamoDB Numbers into Java
@@ -34,6 +34,6 @@ public class ByteUnmarshaller extends NUnmarshaller {
 
     @Override
     public Object unmarshall(AttributeValue value) {
-        return Byte.valueOf(value.getN());
+        return Byte.valueOf(value.n());
     }
 }

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/CalendarSetUnmarshaller.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/CalendarSetUnmarshaller.java
@@ -14,13 +14,14 @@
  */
 package software.amazon.awssdk.mapper.dynamodb.unmarshallers;
 
+import software.amazon.awssdk.mapper.dynamodb.MapperDateUtils;
+
 import java.util.Calendar;
 import java.util.GregorianCalendar;
 import java.util.HashSet;
 import java.util.Set;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
-import com.amazonaws.util.DateUtils;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 /**
  * An unmarshaller that unmarshals sets of ISO-8601-formatted dates as sets of
@@ -42,9 +43,9 @@ public class CalendarSetUnmarshaller extends SSUnmarshaller {
     public Object unmarshall(AttributeValue value) {
         Set<Calendar> result = new HashSet<Calendar>();
 
-        for (String s : value.getSS()) {
+        for (String s : value.ss()) {
             Calendar cal = GregorianCalendar.getInstance();
-            cal.setTime(DateUtils.parseISO8601Date(s));
+            cal.setTime(MapperDateUtils.parseISO8601Date(s));
             result.add(cal);
         }
 

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/CalendarUnmarshaller.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/CalendarUnmarshaller.java
@@ -14,11 +14,12 @@
  */
 package software.amazon.awssdk.mapper.dynamodb.unmarshallers;
 
+import software.amazon.awssdk.mapper.dynamodb.MapperDateUtils;
+
 import java.util.Calendar;
 import java.util.GregorianCalendar;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
-import com.amazonaws.util.DateUtils;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 /**
  * An unmarshaller that unmarshals ISO-8601-formatted dates as Java
@@ -39,7 +40,7 @@ public class CalendarUnmarshaller extends SUnmarshaller {
     @Override
     public Object unmarshall(AttributeValue value) {
         Calendar cal = GregorianCalendar.getInstance();
-        cal.setTime(DateUtils.parseISO8601Date(value.getS()));
+        cal.setTime(MapperDateUtils.parseISO8601Date(value.s()));
         return cal;
     }
 }

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/CustomUnmarshaller.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/CustomUnmarshaller.java
@@ -16,7 +16,7 @@ package software.amazon.awssdk.mapper.dynamodb.unmarshallers;
 
 import software.amazon.awssdk.mapper.dynamodb.DynamoDBMappingException;
 import software.amazon.awssdk.mapper.dynamodb.DynamoDBMarshaller;
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 /**
  * An unmarshaller that delegates to an instance of a
@@ -46,7 +46,7 @@ public class CustomUnmarshaller extends SUnmarshaller {
         DynamoDBMarshaller unmarshaller =
                 createUnmarshaller(unmarshallerClass);
 
-        return unmarshaller.unmarshall(targetClass, value.getS());
+        return unmarshaller.unmarshall(targetClass, value.s());
     }
 
     @SuppressWarnings({ "rawtypes" })

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/DateSetUnmarshaller.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/DateSetUnmarshaller.java
@@ -14,12 +14,13 @@
  */
 package software.amazon.awssdk.mapper.dynamodb.unmarshallers;
 
+import software.amazon.awssdk.mapper.dynamodb.MapperDateUtils;
+
 import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
-import com.amazonaws.util.DateUtils;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 /**
  * An unmarshaller that unmarshals sets of ISO-8601-formatted dates as sets of
@@ -41,8 +42,8 @@ public class DateSetUnmarshaller extends SSUnmarshaller {
     public Object unmarshall(AttributeValue value) {
         Set<Date> result = new HashSet<Date>();
 
-        for (String s : value.getSS()) {
-            result.add(DateUtils.parseISO8601Date(s));
+        for (String s : value.ss()) {
+            result.add(MapperDateUtils.parseISO8601Date(s));
         }
 
         return result;

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/DateUnmarshaller.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/DateUnmarshaller.java
@@ -14,8 +14,9 @@
  */
 package software.amazon.awssdk.mapper.dynamodb.unmarshallers;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
-import com.amazonaws.util.DateUtils;
+import software.amazon.awssdk.mapper.dynamodb.MapperDateUtils;
+
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 /**
  * An unmarshaller that unmarshals ISO-8601-formatted dates as Java
@@ -35,6 +36,6 @@ public class DateUnmarshaller extends SUnmarshaller {
 
     @Override
     public Object unmarshall(AttributeValue value) {
-        return DateUtils.parseISO8601Date(value.getS());
+        return MapperDateUtils.parseISO8601Date(value.s());
     }
 }

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/DoubleSetUnmarshaller.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/DoubleSetUnmarshaller.java
@@ -17,7 +17,7 @@ package software.amazon.awssdk.mapper.dynamodb.unmarshallers;
 import java.util.HashSet;
 import java.util.Set;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 /**
  * An unmarshaller that unmarshals DynamoDB NumberSets into sets of Java
@@ -38,7 +38,7 @@ public class DoubleSetUnmarshaller extends NSUnmarshaller {
     @Override
     public Object unmarshall(AttributeValue value) {
         Set<Double> result = new HashSet<Double>();
-        for (String s : value.getNS()) {
+        for (String s : value.ns()) {
             result.add(Double.valueOf(s));
         }
         return result;

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/DoubleUnmarshaller.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/DoubleUnmarshaller.java
@@ -14,7 +14,7 @@
  */
 package software.amazon.awssdk.mapper.dynamodb.unmarshallers;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 /**
  * An unmarshaller that unmarshals DynamoDB Numbers into Java {@code Double}s.
@@ -33,6 +33,6 @@ public class DoubleUnmarshaller extends NUnmarshaller {
 
     @Override
     public Object unmarshall(AttributeValue value) {
-        return Double.valueOf(value.getN());
+        return Double.valueOf(value.n());
     }
 }

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/FloatSetUnmarshaller.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/FloatSetUnmarshaller.java
@@ -17,7 +17,7 @@ package software.amazon.awssdk.mapper.dynamodb.unmarshallers;
 import java.util.HashSet;
 import java.util.Set;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 /**
  * An unmarshaller that unmarshals DynamoDB NumberSets into sets of Java
@@ -38,7 +38,7 @@ public class FloatSetUnmarshaller extends NSUnmarshaller {
     @Override
     public Object unmarshall(AttributeValue value) {
         Set<Float> result = new HashSet<Float>();
-        for (String s : value.getNS()) {
+        for (String s : value.ns()) {
             result.add(Float.valueOf(s));
         }
         return result;

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/FloatUnmarshaller.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/FloatUnmarshaller.java
@@ -14,7 +14,7 @@
  */
 package software.amazon.awssdk.mapper.dynamodb.unmarshallers;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 /**
  * An unmarshaller that unmarshals DynamoDB Numbers into Java
@@ -34,6 +34,6 @@ public class FloatUnmarshaller extends NUnmarshaller {
 
     @Override
     public Object unmarshall(AttributeValue value) {
-        return Float.valueOf(value.getN());
+        return Float.valueOf(value.n());
     }
 }

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/IntegerSetUnmarshaller.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/IntegerSetUnmarshaller.java
@@ -17,7 +17,7 @@ package software.amazon.awssdk.mapper.dynamodb.unmarshallers;
 import java.util.HashSet;
 import java.util.Set;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 /**
  * An unmarshaller that unmarshals DynamoDB NumberSets into sets of Java
@@ -38,7 +38,7 @@ public class IntegerSetUnmarshaller extends NSUnmarshaller {
     @Override
     public Object unmarshall(AttributeValue value) {
         Set<Integer> result = new HashSet<Integer>();
-        for (String s : value.getNS()) {
+        for (String s : value.ns()) {
             result.add(Integer.valueOf(s));
         }
         return result;

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/IntegerUnmarshaller.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/IntegerUnmarshaller.java
@@ -14,7 +14,7 @@
  */
 package software.amazon.awssdk.mapper.dynamodb.unmarshallers;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 /**
  * An unmarshaller that unmarshals DynamoDB Numbers into Java
@@ -34,6 +34,6 @@ public class IntegerUnmarshaller extends NUnmarshaller {
 
     @Override
     public Object unmarshall(AttributeValue value) {
-        return Integer.valueOf(value.getN());
+        return Integer.valueOf(value.n());
     }
 }

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/LUnmarshaller.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/LUnmarshaller.java
@@ -18,13 +18,13 @@ import java.lang.reflect.Method;
 
 import software.amazon.awssdk.mapper.dynamodb.ArgumentUnmarshaller;
 import software.amazon.awssdk.mapper.dynamodb.DynamoDBMappingException;
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 abstract class LUnmarshaller implements ArgumentUnmarshaller {
 
     @Override
     public void typeCheck(AttributeValue value, Method setter) {
-        if ( value.getL() == null ) {
+        if ( !value.hasL() ) {
             throw new DynamoDBMappingException("Expected L in value " + value + " when invoking " + setter);
         }
     }

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/ListUnmarshaller.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/ListUnmarshaller.java
@@ -19,7 +19,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import software.amazon.awssdk.mapper.dynamodb.ArgumentUnmarshaller;
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 /**
  * An unmarshaller that unmarshals Lists into Java {@code Lists}.
@@ -47,7 +47,7 @@ public class ListUnmarshaller extends LUnmarshaller {
 
     @Override
     public Object unmarshall(AttributeValue value) throws ParseException {
-        List<AttributeValue> values = value.getL();
+        List<AttributeValue> values = value.l();
         List<Object> objects = new ArrayList<Object>(values.size());
 
         for (AttributeValue v : values) {

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/LongSetUnmarshaller.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/LongSetUnmarshaller.java
@@ -17,7 +17,7 @@ package software.amazon.awssdk.mapper.dynamodb.unmarshallers;
 import java.util.HashSet;
 import java.util.Set;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 /**
  * An unmarshaller that unmarshals DynamoDB NumberSets into sets of Java
@@ -38,7 +38,7 @@ public class LongSetUnmarshaller extends NSUnmarshaller {
     @Override
     public Object unmarshall(AttributeValue value) {
         Set<Long> result = new HashSet<Long>();
-        for (String s : value.getNS()) {
+        for (String s : value.ns()) {
             result.add(Long.valueOf(s));
         }
         return result;

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/LongUnmarshaller.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/LongUnmarshaller.java
@@ -14,7 +14,7 @@
  */
 package software.amazon.awssdk.mapper.dynamodb.unmarshallers;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 /**
  * An unmarshaller that unmarshals DynamoDB Numbers into Java
@@ -34,6 +34,6 @@ public class LongUnmarshaller extends NUnmarshaller {
 
     @Override
     public Object unmarshall(AttributeValue value) {
-        return Long.valueOf(value.getN());
+        return Long.valueOf(value.n());
     }
 }

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/MUnmarshaller.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/MUnmarshaller.java
@@ -18,13 +18,13 @@ import java.lang.reflect.Method;
 
 import software.amazon.awssdk.mapper.dynamodb.ArgumentUnmarshaller;
 import software.amazon.awssdk.mapper.dynamodb.DynamoDBMappingException;
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 abstract class MUnmarshaller implements ArgumentUnmarshaller {
 
     @Override
     public void typeCheck(AttributeValue value, Method setter) {
-        if ( value.getM() == null ) {
+        if ( !value.hasM() ) {
             throw new DynamoDBMappingException("Expected M in value " + value + " when invoking " + setter);
         }
     }

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/MapUnmarshaller.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/MapUnmarshaller.java
@@ -19,7 +19,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import software.amazon.awssdk.mapper.dynamodb.ArgumentUnmarshaller;
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 public class MapUnmarshaller extends MUnmarshaller {
 
@@ -44,7 +44,7 @@ public class MapUnmarshaller extends MUnmarshaller {
 
     @Override
     public Object unmarshall(AttributeValue value) throws ParseException {
-        Map<String, AttributeValue> map = value.getM();
+        Map<String, AttributeValue> map = value.m();
         Map<String, Object> result = new HashMap<String, Object>();
 
         for (Map.Entry<String, AttributeValue> entry : map.entrySet()) {

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/NSUnmarshaller.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/NSUnmarshaller.java
@@ -18,13 +18,13 @@ import java.lang.reflect.Method;
 
 import software.amazon.awssdk.mapper.dynamodb.ArgumentUnmarshaller;
 import software.amazon.awssdk.mapper.dynamodb.DynamoDBMappingException;
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 abstract class NSUnmarshaller implements ArgumentUnmarshaller {
 
     @Override
     public void typeCheck(AttributeValue value, Method setter) {
-        if ( value.getNS() == null ) {
+        if ( !value.hasNs() ) {
             throw new DynamoDBMappingException("Expected NS in value " + value + " when invoking " + setter);
         }
     }

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/NUnmarshaller.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/NUnmarshaller.java
@@ -18,13 +18,13 @@ import java.lang.reflect.Method;
 
 import software.amazon.awssdk.mapper.dynamodb.ArgumentUnmarshaller;
 import software.amazon.awssdk.mapper.dynamodb.DynamoDBMappingException;
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 abstract class NUnmarshaller implements ArgumentUnmarshaller {
 
     @Override
     public void typeCheck(AttributeValue value, Method setter) {
-        if ( value.getN() == null ) {
+        if ( value.n() == null ) {
             throw new DynamoDBMappingException("Expected N in value " + value + " when invoking " + setter);
         }
     }

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/NullableUnmarshaller.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/NullableUnmarshaller.java
@@ -18,7 +18,7 @@ import java.lang.reflect.Method;
 import java.text.ParseException;
 
 import software.amazon.awssdk.mapper.dynamodb.ArgumentUnmarshaller;
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 public class NullableUnmarshaller implements ArgumentUnmarshaller {
 
@@ -33,14 +33,14 @@ public class NullableUnmarshaller implements ArgumentUnmarshaller {
 
     @Override
     public void typeCheck(AttributeValue value, Method setter) {
-        if (value.isNULL() == null) {
+        if (value.nul() == null) {
             wrapped.typeCheck(value, setter);
         }
     }
 
     @Override
     public Object unmarshall(AttributeValue value) throws ParseException {
-        if (value.isNULL() != null) {
+        if (value.nul() != null) {
             return null;
         }
         return wrapped.unmarshall(value);

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/ObjectSetUnmarshaller.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/ObjectSetUnmarshaller.java
@@ -21,7 +21,7 @@ import java.util.Set;
 
 import software.amazon.awssdk.mapper.dynamodb.ArgumentUnmarshaller;
 import software.amazon.awssdk.mapper.dynamodb.DynamoDBMappingException;
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 public class ObjectSetUnmarshaller extends LUnmarshaller {
 
@@ -47,7 +47,7 @@ public class ObjectSetUnmarshaller extends LUnmarshaller {
 
     @Override
     public Object unmarshall(AttributeValue value) throws ParseException {
-        List<AttributeValue> values = value.getL();
+        List<AttributeValue> values = value.l();
 
         // As in the LinkedHashSet(Collection) constructor.
         int size = Math.max(values.size() * 2, 11);

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/ObjectUnmarshaller.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/ObjectUnmarshaller.java
@@ -18,7 +18,7 @@ import java.text.ParseException;
 import java.util.Map;
 
 import software.amazon.awssdk.mapper.dynamodb.ItemConverter;
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 public class ObjectUnmarshaller extends MUnmarshaller {
 
@@ -50,7 +50,7 @@ public class ObjectUnmarshaller extends MUnmarshaller {
 
     @Override
     public Object unmarshall(AttributeValue value) throws ParseException {
-        Map<String, AttributeValue> map = value.getM();
+        Map<String, AttributeValue> map = value.m();
         return converter.unconvert(clazz, map);
     }
 }

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/S3LinkUnmarshaller.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/S3LinkUnmarshaller.java
@@ -16,7 +16,7 @@ package software.amazon.awssdk.mapper.dynamodb.unmarshallers;
 
 import software.amazon.awssdk.mapper.dynamodb.S3ClientCache;
 import software.amazon.awssdk.mapper.dynamodb.S3Link;
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 public class S3LinkUnmarshaller extends SUnmarshaller {
 
@@ -45,6 +45,6 @@ public class S3LinkUnmarshaller extends SUnmarshaller {
                     + "load S3Link");
         }
 
-        return S3Link.fromJson(clientCache, value.getS());
+        return S3Link.fromJson(clientCache, value.s());
     }
 }

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/SSUnmarshaller.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/SSUnmarshaller.java
@@ -18,13 +18,13 @@ import java.lang.reflect.Method;
 
 import software.amazon.awssdk.mapper.dynamodb.ArgumentUnmarshaller;
 import software.amazon.awssdk.mapper.dynamodb.DynamoDBMappingException;
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 abstract class SSUnmarshaller implements ArgumentUnmarshaller {
 
     @Override
     public void typeCheck(AttributeValue value, Method setter) {
-        if ( value.getSS() == null ) {
+        if ( !value.hasSs() ) {
             throw new DynamoDBMappingException("Expected SS in value " + value + " when invoking " + setter);
         }
     }

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/SUnmarshaller.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/SUnmarshaller.java
@@ -18,13 +18,13 @@ import java.lang.reflect.Method;
 
 import software.amazon.awssdk.mapper.dynamodb.ArgumentUnmarshaller;
 import software.amazon.awssdk.mapper.dynamodb.DynamoDBMappingException;
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 abstract class SUnmarshaller implements ArgumentUnmarshaller {
 
     @Override
     public void typeCheck(AttributeValue value, Method setter) {
-        if ( value.getS() == null ) {
+        if ( value.s() == null ) {
             throw new DynamoDBMappingException("Expected S in value " + value + " when invoking " + setter);
         }
     }

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/ShortSetUnmarshaller.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/ShortSetUnmarshaller.java
@@ -17,7 +17,7 @@ package software.amazon.awssdk.mapper.dynamodb.unmarshallers;
 import java.util.HashSet;
 import java.util.Set;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 /**
  * An unmarshaller that unmarshals DynamoDB NumberSets into sets of Java
@@ -38,7 +38,7 @@ public class ShortSetUnmarshaller extends NSUnmarshaller {
     @Override
     public Object unmarshall(AttributeValue value) {
         Set<Short> result = new HashSet<Short>();
-        for (String s : value.getNS()) {
+        for (String s : value.ns()) {
             result.add(Short.valueOf(s));
         }
         return result;

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/ShortUnmarshaller.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/ShortUnmarshaller.java
@@ -14,7 +14,7 @@
  */
 package software.amazon.awssdk.mapper.dynamodb.unmarshallers;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 /**
  * An unmarshaller that unmarshals DynamoDB Numbers into Java
@@ -34,6 +34,6 @@ public class ShortUnmarshaller extends NUnmarshaller {
 
     @Override
     public Object unmarshall(AttributeValue value) {
-        return Short.valueOf(value.getN());
+        return Short.valueOf(value.n());
     }
 }

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/StringSetUnmarshaller.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/StringSetUnmarshaller.java
@@ -16,7 +16,7 @@ package software.amazon.awssdk.mapper.dynamodb.unmarshallers;
 
 import java.util.HashSet;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 /**
  * An unmarshaller that unmarshals DynamoDB StringSets as sets of Java
@@ -36,6 +36,6 @@ public class StringSetUnmarshaller extends SSUnmarshaller {
 
     @Override
     public Object unmarshall(AttributeValue value) {
-        return new HashSet<String>(value.getSS());
+        return new HashSet<String>(value.ss());
     }
 }

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/StringUnmarshaller.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/StringUnmarshaller.java
@@ -14,7 +14,7 @@
  */
 package software.amazon.awssdk.mapper.dynamodb.unmarshallers;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 /**
  * An unmarshaller that unmarshals DynamoDB Strings as Java {@code String}
@@ -34,6 +34,6 @@ public class StringUnmarshaller extends SUnmarshaller {
 
     @Override
     public Object unmarshall(AttributeValue value) {
-        return value.getS();
+        return value.s();
     }
 }

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/UUIDSetUnmarshaller.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/UUIDSetUnmarshaller.java
@@ -18,7 +18,7 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 /**
  * An unmarshaller that unmarshals sets of UUIDs as sets of
@@ -42,7 +42,7 @@ public class UUIDSetUnmarshaller extends SSUnmarshaller {
     public Set<UUID> unmarshall(AttributeValue value) {
         Set<UUID> result = new HashSet<UUID>();
 
-        for (String s : value.getSS()) {
+        for (String s : value.ss()) {
             result.add(UUID.fromString(s));
         }
 

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/UUIDUnmarshaller.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/UUIDUnmarshaller.java
@@ -16,7 +16,7 @@ package software.amazon.awssdk.mapper.dynamodb.unmarshallers;
 
 import java.util.UUID;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 /**
  * An unmarshaller that unmarshals UUIDs as Java
@@ -38,6 +38,6 @@ public class UUIDUnmarshaller extends SUnmarshaller {
 
     @Override
     public UUID unmarshall(AttributeValue value) {
-        return UUID.fromString(value.getS());
+        return UUID.fromString(value.s());
     }
 }

--- a/services-custom/dynamodb-mapper/src/test/java/software/amazon/awssdk/mapper/dynamodb/AttributeTransformerChainTest.java
+++ b/services-custom/dynamodb-mapper/src/test/java/software/amazon/awssdk/mapper/dynamodb/AttributeTransformerChainTest.java
@@ -19,7 +19,7 @@ import java.util.*;
 import org.junit.*;
 
 import software.amazon.awssdk.mapper.dynamodb.AttributeTransformer.Parameters;
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 public class AttributeTransformerChainTest {
     @Test
@@ -68,8 +68,8 @@ public class AttributeTransformerChainTest {
         Map<String, AttributeValue> values =
             new HashMap<String, AttributeValue>();
 
-        values.put("test1", new AttributeValue("foo"));
-        values.put("test2", new AttributeValue("bar"));
+        values.put("test1", AttributeValue.builder().s("foo").build());
+        values.put("test2", AttributeValue.builder().s("bar").build());
 
         Parameters<?> params = new TestParameters<Object>(values);
 
@@ -78,8 +78,8 @@ public class AttributeTransformerChainTest {
         Assert.assertNotNull(result);
         Assert.assertEquals(2, result.size());
 
-        Assert.assertEquals("foo.one.two", result.get("test1").getS());
-        Assert.assertEquals("bar.one.two", result.get("test2").getS());
+        Assert.assertEquals("foo.one.two", result.get("test1").s());
+        Assert.assertEquals("bar.one.two", result.get("test2").s());
     }
 
     @Test
@@ -94,8 +94,8 @@ public class AttributeTransformerChainTest {
         Map<String, AttributeValue> values =
             new HashMap<String, AttributeValue>();
 
-        values.put("test1", new AttributeValue("foo.one.two"));
-        values.put("test2", new AttributeValue("bar.one.two"));
+        values.put("test1", AttributeValue.builder().s("foo.one.two").build());
+        values.put("test2", AttributeValue.builder().s("bar.one.two").build());
 
         Parameters<?> params = new TestParameters<Object>(values);
 
@@ -104,8 +104,8 @@ public class AttributeTransformerChainTest {
         Assert.assertNotNull(result);
         Assert.assertEquals(2, result.size());
 
-        Assert.assertEquals("foo", result.get("test1").getS());
-        Assert.assertEquals("bar", result.get("test2").getS());
+        Assert.assertEquals("foo", result.get("test1").s());
+        Assert.assertEquals("bar", result.get("test2").s());
     }
 
     @Test
@@ -120,8 +120,8 @@ public class AttributeTransformerChainTest {
         Map<String, AttributeValue> values =
             new HashMap<String, AttributeValue>();
 
-        values.put("test1", new AttributeValue("foo"));
-        values.put("test2", new AttributeValue("bar"));
+        values.put("test1", AttributeValue.builder().s("foo").build());
+        values.put("test2", AttributeValue.builder().s("bar").build());
 
         Parameters<?> params = new TestParameters<Object>(values);
 
@@ -175,14 +175,14 @@ public class AttributeTransformerChainTest {
         }
 
         private AttributeValue transform(AttributeValue value) {
-            return new AttributeValue(value.getS() + appendMe);
+            return AttributeValue.builder().s(value.s() + appendMe).build();
         }
 
         private AttributeValue untransform(AttributeValue value) {
-            String s = value.getS();
+            String s = value.s();
             if (s.endsWith(appendMe)) {
-                return new AttributeValue(
-                    s.substring(0, s.length() - appendMe.length()));
+                return AttributeValue.builder().s(
+                    s.substring(0, s.length() - appendMe.length())).build();
             } else {
                 return value;
             }

--- a/services-custom/dynamodb-mapper/src/test/java/software/amazon/awssdk/mapper/dynamodb/CachingMarshallerSetTest.java
+++ b/services-custom/dynamodb-mapper/src/test/java/software/amazon/awssdk/mapper/dynamodb/CachingMarshallerSetTest.java
@@ -24,7 +24,7 @@ import org.junit.Test;
 
 import software.amazon.awssdk.mapper.dynamodb.ConversionSchemas.CachingMarshallerSet;
 import software.amazon.awssdk.mapper.dynamodb.ConversionSchemas.MarshallerSet;
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import software.amazon.awssdk.mapper.dynamodb.pojos.TestClass;
 
 public class CachingMarshallerSetTest {

--- a/services-custom/dynamodb-mapper/src/test/java/software/amazon/awssdk/mapper/dynamodb/CachingUnmarshallerSetTest.java
+++ b/services-custom/dynamodb-mapper/src/test/java/software/amazon/awssdk/mapper/dynamodb/CachingUnmarshallerSetTest.java
@@ -24,7 +24,7 @@ import org.junit.Test;
 
 import software.amazon.awssdk.mapper.dynamodb.ConversionSchemas.CachingUnmarshallerSet;
 import software.amazon.awssdk.mapper.dynamodb.ConversionSchemas.UnmarshallerSet;
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import software.amazon.awssdk.mapper.dynamodb.pojos.TestClass;
 
 public class CachingUnmarshallerSetTest {

--- a/services-custom/dynamodb-mapper/src/test/java/software/amazon/awssdk/mapper/dynamodb/ConversionToAttributeValuesTest.java
+++ b/services-custom/dynamodb-mapper/src/test/java/software/amazon/awssdk/mapper/dynamodb/ConversionToAttributeValuesTest.java
@@ -14,7 +14,7 @@
  */
 package software.amazon.awssdk.mapper.dynamodb;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/services-custom/dynamodb-mapper/src/test/java/software/amazon/awssdk/mapper/dynamodb/IncompatibleSubclassTest.java
+++ b/services-custom/dynamodb-mapper/src/test/java/software/amazon/awssdk/mapper/dynamodb/IncompatibleSubclassTest.java
@@ -18,7 +18,7 @@ import java.util.Map;
 
 import org.junit.Test;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 /**
  * Verify that we fail fast in case of incompatible subclasses that try to

--- a/services-custom/dynamodb-mapper/src/test/java/software/amazon/awssdk/mapper/dynamodb/MapperBinaryUtilsTest.java
+++ b/services-custom/dynamodb-mapper/src/test/java/software/amazon/awssdk/mapper/dynamodb/MapperBinaryUtilsTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package software.amazon.awssdk.mapper.dynamodb;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+
+import java.nio.ByteBuffer;
+
+import org.junit.Test;
+
+import software.amazon.awssdk.core.SdkBytes;
+
+/**
+ * Tests {@link MapperBinaryUtils#toWritableByteBuffer(SdkBytes)}, which reproduces the v1 mapper's
+ * behavior of returning a writable {@link ByteBuffer} for binary attributes.
+ */
+public class MapperBinaryUtilsTest {
+
+    @Test
+    public void toWritableByteBuffer_nullInput_returnsNull() {
+        assertNull(MapperBinaryUtils.toWritableByteBuffer(null));
+    }
+
+    @Test
+    public void toWritableByteBuffer_preservesContents() {
+        byte[] bytes = {1, 2, 3, 4};
+        ByteBuffer result = MapperBinaryUtils.toWritableByteBuffer(SdkBytes.fromByteArray(bytes));
+
+        byte[] actual = new byte[result.remaining()];
+        result.get(actual);
+        assertArrayEquals(bytes, actual);
+    }
+
+    @Test
+    public void toWritableByteBuffer_returnsWritableBuffer() {
+        ByteBuffer result = MapperBinaryUtils.toWritableByteBuffer(SdkBytes.fromUtf8String("data"));
+
+        assertFalse(result.isReadOnly());
+        result.put(0, (byte) 'X');
+        assertEquals((byte) 'X', result.get(0));
+    }
+
+    @Test
+    public void toWritableByteBuffer_returnsIndependentCopy() {
+        SdkBytes source = SdkBytes.fromByteArray(new byte[] {1, 2, 3});
+        ByteBuffer result = MapperBinaryUtils.toWritableByteBuffer(source);
+
+        result.put(0, (byte) 99);
+
+        // Mutating the returned buffer must not corrupt the source SdkBytes.
+        assertArrayEquals(new byte[] {1, 2, 3}, source.asByteArray());
+    }
+}

--- a/services-custom/dynamodb-mapper/src/test/java/software/amazon/awssdk/mapper/dynamodb/MapperDateUtilsTest.java
+++ b/services-custom/dynamodb-mapper/src/test/java/software/amazon/awssdk/mapper/dynamodb/MapperDateUtilsTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package software.amazon.awssdk.mapper.dynamodb;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.SimpleTimeZone;
+
+import org.junit.Test;
+
+/**
+ * Tests ISO-8601 parsing and formatting in {@link MapperDateUtils}, including fractional seconds,
+ * UTC offsets, and year boundary edge cases.
+ */
+public class MapperDateUtilsTest {
+
+    @Test
+    public void formatIso8601Date() throws ParseException {
+        Date date = new Date();
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
+        sdf.setTimeZone(new SimpleTimeZone(0, "GMT"));
+        String expected = sdf.format(date);
+        String actual = MapperDateUtils.formatISO8601Date(date);
+        assertEquals(expected, actual);
+
+        Date expectedDate = sdf.parse(expected);
+        Date actualDate = MapperDateUtils.parseISO8601Date(actual);
+        assertEquals(expectedDate, actualDate);
+    }
+
+    @Test
+    public void formatISO8601Date_zeroMilliseconds_keepsFractionalSeconds() {
+        Date date = new Date(0L);
+        assertEquals("1970-01-01T00:00:00.000Z", MapperDateUtils.formatISO8601Date(date));
+    }
+
+    @Test
+    public void parseIso8601Date_usingAlternativeFormat() throws ParseException {
+        Date date = new Date();
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+        sdf.setTimeZone(new SimpleTimeZone(0, "GMT"));
+        String formatted = sdf.format(date);
+
+        Date expectedDate = sdf.parse(formatted);
+        Date actualDate = MapperDateUtils.parseISO8601Date(formatted);
+        assertEquals(expectedDate, actualDate);
+    }
+
+    @Test
+    public void iso8601_withUTCOffset() throws ParseException {
+        String input = "2021-05-10T17:12:13-07:00";
+        Date actualDate = MapperDateUtils.parseISO8601Date(input);
+
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX");
+        sdf.setTimeZone(new SimpleTimeZone(0, "GMT"));
+        assertEquals(sdf.parse(input), actualDate);
+    }
+
+    @Test
+    public void parseIso8601Date_spotFleetPlusZeroSuffix_isNormalized() throws ParseException {
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
+        sdf.setTimeZone(new SimpleTimeZone(0, "GMT"));
+        Date expected = sdf.parse("2014-03-06T14:28:58.123Z");
+        assertEquals(expected, MapperDateUtils.parseISO8601Date("2014-03-06T14:28:58.123+0000"));
+    }
+
+    @Test(expected=IllegalArgumentException.class)
+    public void invalidDate() throws ParseException {
+        final String input = "2014-03-06T14:28:58.000Z.000Z";
+        MapperDateUtils.parseISO8601Date(input);
+    }
+
+    @Test
+    public void testIssue233() throws ParseException {
+        // https://github.com/aws/aws-sdk-java/issues/233
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
+        sdf.setTimeZone(new SimpleTimeZone(0, "GMT"));
+        final String edgeCase = "292278994-08-17T07:12:55.807Z";
+        Date expected = sdf.parse(edgeCase);
+        String formatted = MapperDateUtils.formatISO8601Date(expected);
+        assertEquals(edgeCase, formatted);
+        Date parsed = MapperDateUtils.parseISO8601Date(edgeCase);
+        assertEquals(expected, parsed);
+        String reformatted = MapperDateUtils.formatISO8601Date(parsed);
+        assertEquals(edgeCase, reformatted);
+    }
+
+    @Test
+    public void testIssueDaysDiff() throws ParseException {
+        // https://github.com/aws/aws-sdk-java/issues/233
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
+        sdf.setTimeZone(new SimpleTimeZone(0, "GMT"));
+        String edgeCase = "292278994-08-17T07:12:55.807Z";
+        String testCase = "292278993-08-17T07:12:55.807Z";
+        Date od = sdf.parse(edgeCase);
+        Date testd = sdf.parse(testCase);
+        long diff = od.getTime() - testd.getTime();
+        assertTrue(diff == 365L*24*60*60*1000);
+    }
+
+    @Test
+    public void testIssue233Overflows() throws ParseException {
+        // 1 milli second passed the max time. Fails for JT <2.9, succeeds on >=2.9.
+        testOverflow("292278994-08-17T07:12:55.808Z", true);
+
+        // 1 year passed the max year
+        testOverflow("292278995-01-17T07:12:55.807Z", false);
+    }
+
+    private void testOverflow(String edgeCase, boolean successExpected) {
+        try {
+            Date parsed = MapperDateUtils.parseISO8601Date(edgeCase);
+            if (!successExpected) {
+                // We should have failed!
+                fail("Unexpected success: " + edgeCase + " --> " + parsed);
+            }
+        } catch (IllegalArgumentException ex) {
+            if (successExpected) {
+                fail("Unexpected failure: " + edgeCase);
+            }
+        }
+    }
+}

--- a/services-custom/dynamodb-mapper/src/test/java/software/amazon/awssdk/mapper/dynamodb/S3LinkTest.java
+++ b/services-custom/dynamodb-mapper/src/test/java/software/amazon/awssdk/mapper/dynamodb/S3LinkTest.java
@@ -15,6 +15,7 @@
 package software.amazon.awssdk.mapper.dynamodb;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -22,9 +23,8 @@ import org.junit.Test;
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.internal.StaticCredentialsProvider;
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClient;
 import com.amazonaws.services.s3.model.Region;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 
 public class S3LinkTest
 {
@@ -33,7 +33,7 @@ public class S3LinkTest
     @Before
     public void setUp() {
         AWSCredentials credentials = new BasicAWSCredentials("mock", "mock");
-        AmazonDynamoDB db = new AmazonDynamoDBClient(credentials);
+        DynamoDbClient db = mock(DynamoDbClient.class);
         mapper = new DynamoDBMapper(db, new StaticCredentialsProvider(credentials));
     }
 

--- a/services-custom/dynamodb-mapper/src/test/java/software/amazon/awssdk/mapper/dynamodb/StandardModelFactoriesEdgeCasesTest.java
+++ b/services-custom/dynamodb-mapper/src/test/java/software/amazon/awssdk/mapper/dynamodb/StandardModelFactoriesEdgeCasesTest.java
@@ -30,6 +30,10 @@ import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import software.amazon.awssdk.mapper.dynamodb.pojos.AutoKeyAndVal;
 import software.amazon.awssdk.mapper.dynamodb.pojos.TestClass;
 
+/**
+ * Regression coverage for v1/v2 converter parity on edge inputs, beyond the single
+ * representative value each type gets in the other {@code StandardModelFactories*} tests.
+ */
 public class StandardModelFactoriesEdgeCasesTest {
 
     private static final DynamoDBMapperConfig V1_CONFIG = new DynamoDBMapperConfig.Builder()

--- a/services-custom/dynamodb-mapper/src/test/java/software/amazon/awssdk/mapper/dynamodb/StandardModelFactoriesEdgeCasesTest.java
+++ b/services-custom/dynamodb-mapper/src/test/java/software/amazon/awssdk/mapper/dynamodb/StandardModelFactoriesEdgeCasesTest.java
@@ -24,7 +24,7 @@ import java.math.BigInteger;
 import org.junit.Assert;
 import org.junit.Test;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import software.amazon.awssdk.mapper.dynamodb.pojos.AutoKeyAndVal;
 import software.amazon.awssdk.mapper.dynamodb.pojos.TestClass;
 
@@ -76,14 +76,14 @@ public class StandardModelFactoriesEdgeCasesTest {
 
     @Test
     public void convert_unicodeString_preserved() {
-        assertEquals("こんにちは", convert("getString", "こんにちは").getS());
-        assertEquals("emoji-😀", convert("getString", "emoji-😀").getS());
+        assertEquals("こんにちは", convert("getString", "こんにちは").s());
+        assertEquals("emoji-😀", convert("getString", "emoji-😀").s());
     }
 
     @Test
     public void unconvert_unicodeString_preserved() {
         assertEquals("こんにちは",
-                unconvert("getString", "setString", new AttributeValue("こんにちは")));
+                unconvert("getString", "setString", AttributeValue.builder().s("こんにちは").build()));
     }
 
     @Test
@@ -93,30 +93,30 @@ public class StandardModelFactoriesEdgeCasesTest {
 
     @Test
     public void convert_numericBoundaries_exactStrings() {
-        assertEquals(String.valueOf(Integer.MIN_VALUE), convert("getInt", Integer.MIN_VALUE).getN());
-        assertEquals(String.valueOf(Integer.MAX_VALUE), convert("getInt", Integer.MAX_VALUE).getN());
-        assertEquals(String.valueOf(Long.MIN_VALUE), convert("getLong", Long.MIN_VALUE).getN());
-        assertEquals(String.valueOf(Long.MAX_VALUE), convert("getLong", Long.MAX_VALUE).getN());
+        assertEquals(String.valueOf(Integer.MIN_VALUE), convert("getInt", Integer.MIN_VALUE).n());
+        assertEquals(String.valueOf(Integer.MAX_VALUE), convert("getInt", Integer.MAX_VALUE).n());
+        assertEquals(String.valueOf(Long.MIN_VALUE), convert("getLong", Long.MIN_VALUE).n());
+        assertEquals(String.valueOf(Long.MAX_VALUE), convert("getLong", Long.MAX_VALUE).n());
     }
 
     @Test
     public void convert_bigNumbers_precisionPreserved() {
         BigInteger big = new BigInteger("99999999999999999999");
-        assertEquals("99999999999999999999", convert("getBigInt", big).getN());
+        assertEquals("99999999999999999999", convert("getBigInt", big).n());
 
         BigDecimal dec = new BigDecimal("12345.6789");
-        assertEquals("12345.6789", convert("getBigDecimal", dec).getN());
+        assertEquals("12345.6789", convert("getBigDecimal", dec).n());
     }
 
     @Test
     public void convert_bigDecimal_scalePreserved() {
-        assertEquals("43.0", convert("getBigDecimal", new BigDecimal("43.0")).getN());
+        assertEquals("43.0", convert("getBigDecimal", new BigDecimal("43.0")).n());
     }
 
     @Test
     public void unconvert_integralType_fromDecimalString_throws() {
         try {
-            unconvert("getInt", "setInt", new AttributeValue().withN("1.0"));
+            unconvert("getInt", "setInt", AttributeValue.builder().n("1.0").build());
             fail("Expected NumberFormatException for decimal string on integral type");
         } catch (NumberFormatException e) {
             // expected
@@ -125,9 +125,9 @@ public class StandardModelFactoriesEdgeCasesTest {
 
     @Test
     public void convert_nonFiniteDouble() {
-        assertEquals("NaN", convert("getDouble", Double.NaN).getN());
-        assertEquals("Infinity", convert("getDouble", Double.POSITIVE_INFINITY).getN());
-        assertEquals("-Infinity", convert("getDouble", Double.NEGATIVE_INFINITY).getN());
+        assertEquals("NaN", convert("getDouble", Double.NaN).n());
+        assertEquals("Infinity", convert("getDouble", Double.POSITIVE_INFINITY).n());
+        assertEquals("-Infinity", convert("getDouble", Double.NEGATIVE_INFINITY).n());
     }
 
     public enum Color { RED, GREEN, BLUE }
@@ -141,20 +141,20 @@ public class StandardModelFactoriesEdgeCasesTest {
     @Test
     public void convert_enum_asString() {
         DynamoDBMapperTableModel<EnumPojo> model = table(new EnumPojo());
-        assertEquals("GREEN", model.field("val").convert(Color.GREEN).getS());
+        assertEquals("GREEN", model.field("val").convert(Color.GREEN).s());
     }
 
     @Test
     public void unconvert_enum_fromString() {
         DynamoDBMapperTableModel<EnumPojo> model = table(new EnumPojo());
-        assertEquals(Color.BLUE, model.field("val").unconvert(new AttributeValue("BLUE")));
+        assertEquals(Color.BLUE, model.field("val").unconvert(AttributeValue.builder().s("BLUE").build()));
     }
 
     @Test
     public void unconvert_enum_unknownValue_throws() {
         DynamoDBMapperTableModel<EnumPojo> model = table(new EnumPojo());
         try {
-            model.field("val").unconvert(new AttributeValue("PURPLE"));
+            model.field("val").unconvert(AttributeValue.builder().s("PURPLE").build());
             fail("Expected exception for unknown enum constant");
         } catch (RuntimeException e) {
             // expected
@@ -198,9 +198,9 @@ public class StandardModelFactoriesEdgeCasesTest {
         DynamoDBMapperTableModel<JsonPojo> model = table(new JsonPojo());
         AttributeValue av = model.field("val").convert(payload);
 
-        Assert.assertNotNull(av.getS());
-        Assert.assertTrue(av.getS().contains("widget"));
-        Assert.assertTrue(av.getS().contains("7"));
+        Assert.assertNotNull(av.s());
+        Assert.assertTrue(av.s().contains("widget"));
+        Assert.assertTrue(av.s().contains("7"));
     }
 
     @Test

--- a/services-custom/dynamodb-mapper/src/test/java/software/amazon/awssdk/mapper/dynamodb/StandardModelFactoriesEdgeCasesTest.java
+++ b/services-custom/dynamodb-mapper/src/test/java/software/amazon/awssdk/mapper/dynamodb/StandardModelFactoriesEdgeCasesTest.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package software.amazon.awssdk.mapper.dynamodb;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.lang.reflect.Method;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.mapper.dynamodb.pojos.AutoKeyAndVal;
+import software.amazon.awssdk.mapper.dynamodb.pojos.TestClass;
+
+public class StandardModelFactoriesEdgeCasesTest {
+
+    private static final DynamoDBMapperConfig V1_CONFIG = new DynamoDBMapperConfig.Builder()
+        .withTypeConverterFactory(DynamoDBMapperConfig.DEFAULT.getTypeConverterFactory())
+        .withConversionSchema(ConversionSchemas.V1)
+        .build();
+
+    private static final DynamoDBMapperConfig V2_CONFIG = new DynamoDBMapperConfig.Builder()
+        .withTypeConverterFactory(DynamoDBMapperConfig.DEFAULT.getTypeConverterFactory())
+        .withConversionSchema(ConversionSchemas.V2)
+        .build();
+
+    private static final DynamoDBMapperModelFactory factory = StandardModelFactories.of(S3Link.Factory.of(null));
+    private static final DynamoDBMapperModelFactory.TableFactory v1Models = factory.getTableFactory(V1_CONFIG);
+    private static final DynamoDBMapperModelFactory.TableFactory v2Models = factory.getTableFactory(V2_CONFIG);
+
+    private AttributeValue convert(String getter, Object value) {
+        try {
+            Method gm = TestClass.class.getMethod(getter);
+            StandardAnnotationMaps.FieldMap<Object> map = StandardAnnotationMaps.of(gm, null);
+            return v1Models.getTable(TestClass.class).field(map.attributeName()).convert(value);
+        } catch (RuntimeException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private Object unconvert(String getter, String setter, AttributeValue value) {
+        try {
+            Method gm = TestClass.class.getMethod(getter);
+            Method sm = TestClass.class.getMethod(setter, gm.getReturnType());
+            StandardAnnotationMaps.FieldMap<Object> map = StandardAnnotationMaps.of(gm, null);
+            return v2Models.getTable(TestClass.class).field(map.attributeName()).unconvert(value);
+        } catch (RuntimeException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> DynamoDBMapperTableModel<T> table(T object) {
+        return v2Models.getTable((Class<T>) object.getClass());
+    }
+
+    @Test
+    public void convert_unicodeString_preserved() {
+        assertEquals("こんにちは", convert("getString", "こんにちは").getS());
+        assertEquals("emoji-😀", convert("getString", "emoji-😀").getS());
+    }
+
+    @Test
+    public void unconvert_unicodeString_preserved() {
+        assertEquals("こんにちは",
+                unconvert("getString", "setString", new AttributeValue("こんにちは")));
+    }
+
+    @Test
+    public void convert_emptyString_isDropped() {
+        Assert.assertNull(convert("getString", ""));
+    }
+
+    @Test
+    public void convert_numericBoundaries_exactStrings() {
+        assertEquals(String.valueOf(Integer.MIN_VALUE), convert("getInt", Integer.MIN_VALUE).getN());
+        assertEquals(String.valueOf(Integer.MAX_VALUE), convert("getInt", Integer.MAX_VALUE).getN());
+        assertEquals(String.valueOf(Long.MIN_VALUE), convert("getLong", Long.MIN_VALUE).getN());
+        assertEquals(String.valueOf(Long.MAX_VALUE), convert("getLong", Long.MAX_VALUE).getN());
+    }
+
+    @Test
+    public void convert_bigNumbers_precisionPreserved() {
+        BigInteger big = new BigInteger("99999999999999999999");
+        assertEquals("99999999999999999999", convert("getBigInt", big).getN());
+
+        BigDecimal dec = new BigDecimal("12345.6789");
+        assertEquals("12345.6789", convert("getBigDecimal", dec).getN());
+    }
+
+    @Test
+    public void convert_bigDecimal_scalePreserved() {
+        assertEquals("43.0", convert("getBigDecimal", new BigDecimal("43.0")).getN());
+    }
+
+    @Test
+    public void unconvert_integralType_fromDecimalString_throws() {
+        try {
+            unconvert("getInt", "setInt", new AttributeValue().withN("1.0"));
+            fail("Expected NumberFormatException for decimal string on integral type");
+        } catch (NumberFormatException e) {
+            // expected
+        }
+    }
+
+    @Test
+    public void convert_nonFiniteDouble() {
+        assertEquals("NaN", convert("getDouble", Double.NaN).getN());
+        assertEquals("Infinity", convert("getDouble", Double.POSITIVE_INFINITY).getN());
+        assertEquals("-Infinity", convert("getDouble", Double.NEGATIVE_INFINITY).getN());
+    }
+
+    public enum Color { RED, GREEN, BLUE }
+
+    public static class EnumPojo extends AutoKeyAndVal<Color> {
+        @DynamoDBTypeConvertedEnum
+        public Color getVal() { return super.getVal(); }
+        public void setVal(Color val) { super.setVal(val); }
+    }
+
+    @Test
+    public void convert_enum_asString() {
+        DynamoDBMapperTableModel<EnumPojo> model = table(new EnumPojo());
+        assertEquals("GREEN", model.field("val").convert(Color.GREEN).getS());
+    }
+
+    @Test
+    public void unconvert_enum_fromString() {
+        DynamoDBMapperTableModel<EnumPojo> model = table(new EnumPojo());
+        assertEquals(Color.BLUE, model.field("val").unconvert(new AttributeValue("BLUE")));
+    }
+
+    @Test
+    public void unconvert_enum_unknownValue_throws() {
+        DynamoDBMapperTableModel<EnumPojo> model = table(new EnumPojo());
+        try {
+            model.field("val").unconvert(new AttributeValue("PURPLE"));
+            fail("Expected exception for unknown enum constant");
+        } catch (RuntimeException e) {
+            // expected
+        }
+    }
+
+    public static class JsonPayload {
+        private String name;
+        private int count;
+        public String getName() { return name; }
+        public void setName(String name) { this.name = name; }
+        public int getCount() { return count; }
+        public void setCount(int count) { this.count = count; }
+        @Override
+        public boolean equals(Object o) {
+            if (!(o instanceof JsonPayload)) {
+                return false;
+            }
+            JsonPayload that = (JsonPayload) o;
+            return count == that.count
+                   && (name == null ? that.name == null : name.equals(that.name));
+        }
+        @Override
+        public int hashCode() {
+            return (name == null ? 0 : name.hashCode()) * 31 + count;
+        }
+    }
+
+    public static class JsonPojo extends AutoKeyAndVal<JsonPayload> {
+        @DynamoDBTypeConvertedJson
+        public JsonPayload getVal() { return super.getVal(); }
+        public void setVal(JsonPayload val) { super.setVal(val); }
+    }
+
+    @Test
+    public void convert_json_asString() {
+        JsonPayload payload = new JsonPayload();
+        payload.setName("widget");
+        payload.setCount(7);
+
+        DynamoDBMapperTableModel<JsonPojo> model = table(new JsonPojo());
+        AttributeValue av = model.field("val").convert(payload);
+
+        Assert.assertNotNull(av.getS());
+        Assert.assertTrue(av.getS().contains("widget"));
+        Assert.assertTrue(av.getS().contains("7"));
+    }
+
+    @Test
+    public void json_roundTrip() {
+        JsonPayload payload = new JsonPayload();
+        payload.setName("widget");
+        payload.setCount(7);
+
+        DynamoDBMapperTableModel<JsonPojo> model = table(new JsonPojo());
+        AttributeValue av = model.field("val").convert(payload);
+        Object back = model.field("val").unconvert(av);
+
+        assertEquals(payload, back);
+    }
+}

--- a/services-custom/dynamodb-mapper/src/test/java/software/amazon/awssdk/mapper/dynamodb/StandardModelFactoriesEdgeCasesTest.java
+++ b/services-custom/dynamodb-mapper/src/test/java/software/amazon/awssdk/mapper/dynamodb/StandardModelFactoriesEdgeCasesTest.java
@@ -20,10 +20,12 @@ import static org.junit.Assert.fail;
 import java.lang.reflect.Method;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.nio.ByteBuffer;
 
 import org.junit.Assert;
 import org.junit.Test;
 
+import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import software.amazon.awssdk.mapper.dynamodb.pojos.AutoKeyAndVal;
 import software.amazon.awssdk.mapper.dynamodb.pojos.TestClass;
@@ -75,24 +77,24 @@ public class StandardModelFactoriesEdgeCasesTest {
     }
 
     @Test
-    public void convert_unicodeString_preserved() {
+    public void convert_withUnicodeString_preservesCharacters() {
         assertEquals("こんにちは", convert("getString", "こんにちは").s());
         assertEquals("emoji-😀", convert("getString", "emoji-😀").s());
     }
 
     @Test
-    public void unconvert_unicodeString_preserved() {
+    public void unconvert_withUnicodeString_preservesCharacters() {
         assertEquals("こんにちは",
                 unconvert("getString", "setString", AttributeValue.builder().s("こんにちは").build()));
     }
 
     @Test
-    public void convert_emptyString_isDropped() {
+    public void convert_withEmptyString_returnsNull() {
         Assert.assertNull(convert("getString", ""));
     }
 
     @Test
-    public void convert_numericBoundaries_exactStrings() {
+    public void convert_withNumericBoundaries_producesExactStrings() {
         assertEquals(String.valueOf(Integer.MIN_VALUE), convert("getInt", Integer.MIN_VALUE).n());
         assertEquals(String.valueOf(Integer.MAX_VALUE), convert("getInt", Integer.MAX_VALUE).n());
         assertEquals(String.valueOf(Long.MIN_VALUE), convert("getLong", Long.MIN_VALUE).n());
@@ -100,7 +102,7 @@ public class StandardModelFactoriesEdgeCasesTest {
     }
 
     @Test
-    public void convert_bigNumbers_precisionPreserved() {
+    public void convert_withBigNumbers_preservesPrecision() {
         BigInteger big = new BigInteger("99999999999999999999");
         assertEquals("99999999999999999999", convert("getBigInt", big).n());
 
@@ -109,12 +111,12 @@ public class StandardModelFactoriesEdgeCasesTest {
     }
 
     @Test
-    public void convert_bigDecimal_scalePreserved() {
+    public void convert_withBigDecimal_preservesScale() {
         assertEquals("43.0", convert("getBigDecimal", new BigDecimal("43.0")).n());
     }
 
     @Test
-    public void unconvert_integralType_fromDecimalString_throws() {
+    public void unconvert_withDecimalStringOnIntegralType_throwsNumberFormatException() {
         try {
             unconvert("getInt", "setInt", AttributeValue.builder().n("1.0").build());
             fail("Expected NumberFormatException for decimal string on integral type");
@@ -124,7 +126,7 @@ public class StandardModelFactoriesEdgeCasesTest {
     }
 
     @Test
-    public void convert_nonFiniteDouble() {
+    public void convert_withNonFiniteDouble_producesExactStrings() {
         assertEquals("NaN", convert("getDouble", Double.NaN).n());
         assertEquals("Infinity", convert("getDouble", Double.POSITIVE_INFINITY).n());
         assertEquals("-Infinity", convert("getDouble", Double.NEGATIVE_INFINITY).n());
@@ -139,19 +141,19 @@ public class StandardModelFactoriesEdgeCasesTest {
     }
 
     @Test
-    public void convert_enum_asString() {
+    public void convert_withEnum_producesString() {
         DynamoDBMapperTableModel<EnumPojo> model = table(new EnumPojo());
         assertEquals("GREEN", model.field("val").convert(Color.GREEN).s());
     }
 
     @Test
-    public void unconvert_enum_fromString() {
+    public void unconvert_withEnumString_producesEnum() {
         DynamoDBMapperTableModel<EnumPojo> model = table(new EnumPojo());
         assertEquals(Color.BLUE, model.field("val").unconvert(AttributeValue.builder().s("BLUE").build()));
     }
 
     @Test
-    public void unconvert_enum_unknownValue_throws() {
+    public void unconvert_withUnknownEnumValue_throwsException() {
         DynamoDBMapperTableModel<EnumPojo> model = table(new EnumPojo());
         try {
             model.field("val").unconvert(AttributeValue.builder().s("PURPLE").build());
@@ -190,7 +192,7 @@ public class StandardModelFactoriesEdgeCasesTest {
     }
 
     @Test
-    public void convert_json_asString() {
+    public void convert_withJsonPayload_producesString() {
         JsonPayload payload = new JsonPayload();
         payload.setName("widget");
         payload.setCount(7);
@@ -204,7 +206,7 @@ public class StandardModelFactoriesEdgeCasesTest {
     }
 
     @Test
-    public void json_roundTrip() {
+    public void convertAndUnconvert_withJsonPayload_roundTrips() {
         JsonPayload payload = new JsonPayload();
         payload.setName("widget");
         payload.setCount(7);
@@ -214,5 +216,19 @@ public class StandardModelFactoriesEdgeCasesTest {
         Object back = model.field("val").unconvert(av);
 
         assertEquals(payload, back);
+    }
+
+    @Test
+    public void unconvert_withByteBuffer_returnsWritableBuffer() {
+        // v1 parity: v1 getB() returned a writable buffer. v2 SdkBytes.asByteBuffer() is
+        // read-only, so the unmarshaller returns a writable copy for callers that mutate it.
+        DynamoDBMapperTableModel<TestClass> model = v2Models.getTable(TestClass.class);
+        AttributeValue stored = AttributeValue.builder().b(SdkBytes.fromUtf8String("data")).build();
+
+        ByteBuffer result = (ByteBuffer) model.field("byteBuffer").unconvert(stored);
+
+        Assert.assertFalse("returned buffer is writable (v1 parity)", result.isReadOnly());
+        result.put(0, (byte) 'X');
+        assertEquals((byte) 'X', result.get(0));
     }
 }

--- a/services-custom/dynamodb-mapper/src/test/java/software/amazon/awssdk/mapper/dynamodb/StandardModelFactoriesOverrideTest.java
+++ b/services-custom/dynamodb-mapper/src/test/java/software/amazon/awssdk/mapper/dynamodb/StandardModelFactoriesOverrideTest.java
@@ -14,7 +14,7 @@
  */
 package software.amazon.awssdk.mapper.dynamodb;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 import java.lang.reflect.Method;
 

--- a/services-custom/dynamodb-mapper/src/test/java/software/amazon/awssdk/mapper/dynamodb/StandardModelFactoriesTest.java
+++ b/services-custom/dynamodb-mapper/src/test/java/software/amazon/awssdk/mapper/dynamodb/StandardModelFactoriesTest.java
@@ -22,9 +22,9 @@ import software.amazon.awssdk.mapper.dynamodb.pojos.AutoKeyAndVal;
 import software.amazon.awssdk.mapper.dynamodb.pojos.Currency;
 import software.amazon.awssdk.mapper.dynamodb.pojos.DateRange;
 import software.amazon.awssdk.mapper.dynamodb.pojos.KeyAndVal;
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import com.amazonaws.services.dynamodbv2.model.KeyType;
-import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType;
+import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -126,8 +126,8 @@ public class StandardModelFactoriesTest {
         final DynamoDBMapperTableModel<Object> model = getTable(obj);
         final DynamoDBMapperFieldModel<Object,AttributeValue> val = model.field("val");
         assertEquals(DynamoDBAttributeType.N, val.attributeType());
-        assertEquals("123", val.convert(new AttributeValue().withN("123")).getN());
-        assertEquals("123", val.unconvert(new AttributeValue().withN("123")).getN());
+        assertEquals("123", val.convert(AttributeValue.builder().n("123").build()).n());
+        assertEquals("123", val.unconvert(AttributeValue.builder().n("123").build()).n());
     }
 
     @Test
@@ -142,11 +142,11 @@ public class StandardModelFactoriesTest {
         assertEquals(DynamoDBAttributeType.M, val.attributeType());
 
         Map<String,AttributeValue> map = new HashMap<String,AttributeValue>();
-        map.put("A", new AttributeValue().withN("123"));
+        map.put("A", AttributeValue.builder().n("123").build());
         map = Collections.unmodifiableMap(map);
 
-        assertEquals("123", val.convert(new AttributeValue().withM(map)).getM().get("A").getN());
-        assertEquals("123", val.unconvert(new AttributeValue().withM(map)).getM().get("A").getN());
+        assertEquals("123", val.convert(AttributeValue.builder().m(map).build()).m().get("A").n());
+        assertEquals("123", val.unconvert(AttributeValue.builder().m(map).build()).m().get("A").n());
     }
 
     /**
@@ -164,8 +164,8 @@ public class StandardModelFactoriesTest {
         final DynamoDBMapperTableModel<Object> model = getTable(obj);
         final DynamoDBMapperFieldModel<Object,TimeZone> val = model.field("val");
         assertEquals(DynamoDBAttributeType.S, val.attributeType());
-        assertEquals("America/New_York", val.convert(TimeZone.getTimeZone("America/New_York")).getS());
-        assertEquals("America/New_York", val.unconvert(new AttributeValue().withS("America/New_York")).getID());
+        assertEquals("America/New_York", val.convert(TimeZone.getTimeZone("America/New_York")).s());
+        assertEquals("America/New_York", val.unconvert(AttributeValue.builder().s("America/New_York").build()).getID());
     }
 
     /**
@@ -183,8 +183,8 @@ public class StandardModelFactoriesTest {
         final DynamoDBMapperTableModel<Object> model = getTable(obj);
         final DynamoDBMapperFieldModel<Object,Locale> val = model.field("val");
         assertEquals(DynamoDBAttributeType.S, val.attributeType());
-        assertEquals("en-CA", val.convert(new Locale("en","CA")).getS());
-        assertEquals("en-CA", val.unconvert(new AttributeValue().withS("en-CA")).toString().replaceAll("_","-"));
+        assertEquals("en-CA", val.convert(new Locale("en","CA")).s());
+        assertEquals("en-CA", val.unconvert(AttributeValue.builder().s("en-CA").build()).toString().replaceAll("_","-"));
     }
 
     /**
@@ -203,7 +203,7 @@ public class StandardModelFactoriesTest {
         assertEquals(DynamoDBAttributeType.B, model.field("val").attributeType());
         final UUID val = UUID.randomUUID();
         final AttributeValue converted = model.field("val").convert(val);
-        assertNotNull(converted.getB());
+        assertNotNull(converted.b());
         assertEquals(val, model.field("val").unconvert(converted));
     }
 
@@ -254,10 +254,10 @@ public class StandardModelFactoriesTest {
         final DynamoDBMapperTableModel<Object> model = getTable(obj);
         final DynamoDBMapperFieldModel<Object,Boolean> val = model.field("val");
         assertEquals(DynamoDBAttributeType.S, val.attributeType());
-        assertEquals("Y", val.convert(Boolean.TRUE).getS());
-        assertEquals(Boolean.TRUE, val.unconvert(new AttributeValue().withS("Y")));
-        assertEquals("N", val.convert(Boolean.FALSE).getS());
-        assertEquals(Boolean.FALSE, val.unconvert(new AttributeValue().withS("N")));
+        assertEquals("Y", val.convert(Boolean.TRUE).s());
+        assertEquals(Boolean.TRUE, val.unconvert(AttributeValue.builder().s("Y").build()));
+        assertEquals("N", val.convert(Boolean.FALSE).s());
+        assertEquals(Boolean.FALSE, val.unconvert(AttributeValue.builder().s("N").build()));
         assertEquals(null, val.convert(null));
     }
 

--- a/services-custom/dynamodb-mapper/src/test/java/software/amazon/awssdk/mapper/dynamodb/StandardModelFactoriesV1Test.java
+++ b/services-custom/dynamodb-mapper/src/test/java/software/amazon/awssdk/mapper/dynamodb/StandardModelFactoriesV1Test.java
@@ -33,7 +33,8 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import com.amazonaws.auth.AWSCredentialsProvider;
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import software.amazon.awssdk.mapper.dynamodb.pojos.SubClass;
 import software.amazon.awssdk.mapper.dynamodb.pojos.TestClass;
 import software.amazon.awssdk.mapper.dynamodb.pojos.UnannotatedSubClass;
@@ -55,115 +56,115 @@ public class StandardModelFactoriesV1Test {
 
     @Test
     public void testBoolean() {
-        assertEquals("1", convert("getBoolean", true).getN());
-        assertEquals("0", convert("getBoolean", false).getN());
-        assertEquals("1", convert("getBoxedBoolean", true).getN());
-        assertEquals("0", convert("getBoxedBoolean", false).getN());
+        assertEquals("1", convert("getBoolean", true).n());
+        assertEquals("0", convert("getBoolean", false).n());
+        assertEquals("1", convert("getBoxedBoolean", true).n());
+        assertEquals("0", convert("getBoxedBoolean", false).n());
 
-        assertEquals(true, convert("getNativeBoolean", true).getBOOL());
-        assertEquals(false, convert("getNativeBoolean", false).getBOOL());
+        assertEquals(true, convert("getNativeBoolean", true).bool());
+        assertEquals(false, convert("getNativeBoolean", false).bool());
     }
 
     @Test
     public void testString() {
-        assertEquals("abc", convert("getString", "abc").getS());
+        assertEquals("abc", convert("getString", "abc").s());
 
         assertEquals(RandomUUIDMarshaller.randomUUID,
-                convert("getCustomString", "abc").getS());
+                convert("getCustomString", "abc").s());
     }
 
     @Test
     public void testUuid() {
         UUID uuid = UUID.randomUUID();
-        assertEquals(uuid.toString(), convert("getUuid", uuid).getS());
+        assertEquals(uuid.toString(), convert("getUuid", uuid).s());
     }
 
     @Test
     public void testDate() {
         assertEquals("1970-01-01T00:00:00.000Z",
-                convert("getDate", new Date(0)).getS());
+                convert("getDate", new Date(0)).s());
 
         Calendar c = GregorianCalendar.getInstance();
         c.setTimeInMillis(0);
 
         assertEquals("1970-01-01T00:00:00.000Z",
-                convert("getCalendar", c).getS());
+                convert("getCalendar", c).s());
     }
 
     @Test
     public void testNumbers() {
-        assertEquals("0", convert("getByte", (byte) 0).getN());
-        assertEquals("1", convert("getByte", (byte) 1).getN());
-        assertEquals("0", convert("getBoxedByte", (byte) 0).getN());
-        assertEquals("1", convert("getBoxedByte", (byte) 1).getN());
+        assertEquals("0", convert("getByte", (byte) 0).n());
+        assertEquals("1", convert("getByte", (byte) 1).n());
+        assertEquals("0", convert("getBoxedByte", (byte) 0).n());
+        assertEquals("1", convert("getBoxedByte", (byte) 1).n());
 
-        assertEquals("0", convert("getShort", (short) 0).getN());
-        assertEquals("1", convert("getShort", (short) 1).getN());
-        assertEquals("0", convert("getBoxedShort", (short) 0).getN());
-        assertEquals("1", convert("getBoxedShort", (short) 1).getN());
+        assertEquals("0", convert("getShort", (short) 0).n());
+        assertEquals("1", convert("getShort", (short) 1).n());
+        assertEquals("0", convert("getBoxedShort", (short) 0).n());
+        assertEquals("1", convert("getBoxedShort", (short) 1).n());
 
-        assertEquals("0", convert("getInt", 0).getN());
-        assertEquals("1", convert("getInt", 1).getN());
-        assertEquals("0", convert("getBoxedInt", 0).getN());
-        assertEquals("1", convert("getBoxedInt", 1).getN());
+        assertEquals("0", convert("getInt", 0).n());
+        assertEquals("1", convert("getInt", 1).n());
+        assertEquals("0", convert("getBoxedInt", 0).n());
+        assertEquals("1", convert("getBoxedInt", 1).n());
 
-        assertEquals("0", convert("getLong", 0l).getN());
-        assertEquals("1", convert("getLong", 1l).getN());
-        assertEquals("0", convert("getBoxedLong", 0l).getN());
-        assertEquals("1", convert("getBoxedLong", 1l).getN());
+        assertEquals("0", convert("getLong", 0l).n());
+        assertEquals("1", convert("getLong", 1l).n());
+        assertEquals("0", convert("getBoxedLong", 0l).n());
+        assertEquals("1", convert("getBoxedLong", 1l).n());
 
-        assertEquals("0", convert("getBigInt", BigInteger.ZERO).getN());
-        assertEquals("1", convert("getBigInt", BigInteger.ONE).getN());
+        assertEquals("0", convert("getBigInt", BigInteger.ZERO).n());
+        assertEquals("1", convert("getBigInt", BigInteger.ONE).n());
 
-        assertEquals("0.0", convert("getFloat", 0f).getN());
-        assertEquals("1.0", convert("getFloat", 1f).getN());
-        assertEquals("0.0", convert("getBoxedFloat", 0f).getN());
-        assertEquals("1.0", convert("getBoxedFloat", 1f).getN());
+        assertEquals("0.0", convert("getFloat", 0f).n());
+        assertEquals("1.0", convert("getFloat", 1f).n());
+        assertEquals("0.0", convert("getBoxedFloat", 0f).n());
+        assertEquals("1.0", convert("getBoxedFloat", 1f).n());
 
-        assertEquals("0.0", convert("getDouble", 0d).getN());
-        assertEquals("1.0", convert("getDouble", 1d).getN());
-        assertEquals("0.0", convert("getBoxedDouble", 0d).getN());
-        assertEquals("1.0", convert("getBoxedDouble", 1d).getN());
+        assertEquals("0.0", convert("getDouble", 0d).n());
+        assertEquals("1.0", convert("getDouble", 1d).n());
+        assertEquals("0.0", convert("getBoxedDouble", 0d).n());
+        assertEquals("1.0", convert("getBoxedDouble", 1d).n());
 
-        assertEquals("0", convert("getBigDecimal", BigDecimal.ZERO).getN());
-        assertEquals("1", convert("getBigDecimal", BigDecimal.ONE).getN());
+        assertEquals("0", convert("getBigDecimal", BigDecimal.ZERO).n());
+        assertEquals("1", convert("getBigDecimal", BigDecimal.ONE).n());
     }
 
     @Test
     public void testBinary() {
         ByteBuffer value = ByteBuffer.wrap("value".getBytes());
-        assertEquals(value.slice(), convert("getByteArray", "value".getBytes()).getB());
-        assertEquals(value.slice(), convert("getByteBuffer", value.slice()).getB());
+        assertEquals(value.slice(), convert("getByteArray", "value".getBytes()).b().asByteBuffer());
+        assertEquals(value.slice(), convert("getByteBuffer", value.slice()).b().asByteBuffer());
     }
 
     @Test
     public void testBooleanSet() {
         assertEquals(Collections.singletonList("1"),
-                convert("getBooleanSet", Collections.singleton(true)).getNS());
+                convert("getBooleanSet", Collections.singleton(true)).ns());
 
         assertEquals(Collections.singletonList("0"),
-                convert("getBooleanSet", Collections.singleton(false)).getNS());
+                convert("getBooleanSet", Collections.singleton(false)).ns());
 
         assertEquals(Arrays.asList("0", "1"),
                 convert("getBooleanSet", new TreeSet<Boolean>() {{
                     add(true);
                     add(false);
-                }}).getNS());
+                }}).ns());
     }
 
     @Test
     public void testStringSet() {
         assertEquals(Collections.singletonList("a"),
-                convert("getStringSet", Collections.singleton("a")).getSS());
+                convert("getStringSet", Collections.singleton("a")).ss());
         assertEquals(Collections.singletonList("b"),
-                convert("getStringSet", Collections.singleton("b")).getSS());
+                convert("getStringSet", Collections.singleton("b")).ss());
 
         assertEquals(Arrays.asList("a", "b", "c"),
                 convert("getStringSet", new TreeSet<String>() {{
                     add("a");
                     add("b");
                     add("c");
-                }}).getSS());
+                }}).ss());
     }
 
     @Test
@@ -173,10 +174,10 @@ public class StandardModelFactoriesV1Test {
         final UUID three = UUID.randomUUID();
 
         assertEquals(Collections.singletonList(one.toString()),
-                convert("getUuidSet", Collections.singleton(one)).getSS());
+                convert("getUuidSet", Collections.singleton(one)).ss());
 
         assertEquals(Collections.singletonList(two.toString()),
-                convert("getUuidSet", Collections.singleton(two)).getSS());
+                convert("getUuidSet", Collections.singleton(two)).ss());
 
         assertEquals(
                 Arrays.asList(
@@ -187,50 +188,50 @@ public class StandardModelFactoriesV1Test {
                     add(one);
                     add(two);
                     add(three);
-                }}).getSS());
+                }}).ss());
     }
 
     @Test
     public void testDateSet() {
         assertEquals(Collections.singletonList("1970-01-01T00:00:00.000Z"),
                 convert("getDateSet", Collections.singleton(new Date(0)))
-                        .getSS());
+                        .ss());
 
         Calendar c = GregorianCalendar.getInstance();
         c.setTimeInMillis(0);
 
         assertEquals(Collections.singletonList("1970-01-01T00:00:00.000Z"),
                 convert("getCalendarSet", Collections.singleton(c))
-                        .getSS());
+                        .ss());
     }
 
     @Test
     public void testNumberSet() {
         assertEquals(Collections.singletonList("0"),
-                convert("getByteSet", Collections.singleton((byte) 0)).getNS());
+                convert("getByteSet", Collections.singleton((byte) 0)).ns());
         assertEquals(Collections.singletonList("0"),
-                convert("getShortSet", Collections.singleton((short) 0)).getNS());
+                convert("getShortSet", Collections.singleton((short) 0)).ns());
         assertEquals(Collections.singletonList("0"),
-                convert("getIntSet", Collections.singleton(0)).getNS());
+                convert("getIntSet", Collections.singleton(0)).ns());
         assertEquals(Collections.singletonList("0"),
-                convert("getLongSet", Collections.singleton(0l)).getNS());
+                convert("getLongSet", Collections.singleton(0l)).ns());
         assertEquals(Collections.singletonList("0"),
                 convert("getBigIntegerSet", Collections.singleton(BigInteger.ZERO))
-                    .getNS());
+                    .ns());
         assertEquals(Collections.singletonList("0.0"),
-                convert("getFloatSet", Collections.singleton(0f)).getNS());
+                convert("getFloatSet", Collections.singleton(0f)).ns());
         assertEquals(Collections.singletonList("0.0"),
-                convert("getDoubleSet", Collections.singleton(0d)).getNS());
+                convert("getDoubleSet", Collections.singleton(0d)).ns());
         assertEquals(Collections.singletonList("0"),
                 convert("getBigDecimalSet", Collections.singleton(BigDecimal.ZERO))
-                    .getNS());
+                    .ns());
 
         assertEquals(Arrays.asList("0", "1", "2"),
                 convert("getLongSet", new TreeSet<Number>() {{
                     add(0);
                     add(1);
                     add(2);
-                }}).getNS());
+                }}).ns());
     }
 
     @Test
@@ -238,19 +239,19 @@ public class StandardModelFactoriesV1Test {
         final ByteBuffer test = ByteBuffer.wrap("test".getBytes());
         final ByteBuffer test2 = ByteBuffer.wrap("test2".getBytes());
 
-        assertEquals(Collections.singletonList(test.slice()),
+        assertEquals(Collections.singletonList(SdkBytes.fromByteBuffer(test.slice())),
                 convert("getByteArraySet", Collections.singleton("test".getBytes()))
-                    .getBS());
+                    .bs());
 
-        assertEquals(Collections.singletonList(test.slice()),
+        assertEquals(Collections.singletonList(SdkBytes.fromByteBuffer(test.slice())),
                 convert("getByteBufferSet", Collections.singleton(test.slice()))
-                    .getBS());
+                    .bs());
 
-        assertEquals(Arrays.asList(test.slice(), test2.slice()),
+        assertEquals(Arrays.asList(SdkBytes.fromByteBuffer(test.slice()), SdkBytes.fromByteBuffer(test2.slice())),
                 convert("getByteBufferSet",new TreeSet<ByteBuffer>() {{
                     add(test.slice());
                     add(test2.slice());
-                }}).getBS());
+                }}).bs());
     }
 
     @Test
@@ -263,7 +264,7 @@ public class StandardModelFactoriesV1Test {
         };
 
         assertEquals(Collections.singletonList("hello"),
-                convert("getObjectSet", Collections.singleton(o)).getSS());
+                convert("getObjectSet", Collections.singleton(o)).ss());
     }
 
     @Test
@@ -313,7 +314,7 @@ public class StandardModelFactoriesV1Test {
                      + "\"bucket\":\"bucket\","
                      + "\"key\":\"key\","
                      + "\"region\":null}}",
-                convert("getS3Link", link).getS());
+                convert("getS3Link", link).s());
     }
 
     private AttributeValue convert(String getter, Object value) {

--- a/services-custom/dynamodb-mapper/src/test/java/software/amazon/awssdk/mapper/dynamodb/StandardModelFactoriesV2CompatibleTest.java
+++ b/services-custom/dynamodb-mapper/src/test/java/software/amazon/awssdk/mapper/dynamodb/StandardModelFactoriesV2CompatibleTest.java
@@ -35,7 +35,8 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import com.amazonaws.auth.AWSCredentialsProvider;
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import software.amazon.awssdk.mapper.dynamodb.pojos.SubClass;
 import software.amazon.awssdk.mapper.dynamodb.pojos.TestClass;
 import software.amazon.awssdk.mapper.dynamodb.pojos.UnannotatedSubClass;
@@ -57,115 +58,115 @@ public class StandardModelFactoriesV2CompatibleTest {
 
     @Test
     public void testBoolean() {
-        assertEquals("1", convert("getBoolean", true).getN());
-        assertEquals("0", convert("getBoolean", false).getN());
-        assertEquals("1", convert("getBoxedBoolean", true).getN());
-        assertEquals("0", convert("getBoxedBoolean", false).getN());
+        assertEquals("1", convert("getBoolean", true).n());
+        assertEquals("0", convert("getBoolean", false).n());
+        assertEquals("1", convert("getBoxedBoolean", true).n());
+        assertEquals("0", convert("getBoxedBoolean", false).n());
 
-        assertEquals(true, convert("getNativeBoolean", true).getBOOL());
-        assertEquals(false, convert("getNativeBoolean", false).getBOOL());
+        assertEquals(true, convert("getNativeBoolean", true).bool());
+        assertEquals(false, convert("getNativeBoolean", false).bool());
     }
 
     @Test
     public void testString() {
-        assertEquals("abc", convert("getString", "abc").getS());
+        assertEquals("abc", convert("getString", "abc").s());
 
         assertEquals(RandomUUIDMarshaller.randomUUID,
-                convert("getCustomString", "abc").getS());
+                convert("getCustomString", "abc").s());
     }
 
     @Test
     public void testUuid() {
         UUID uuid = UUID.randomUUID();
-        assertEquals(uuid.toString(), convert("getUuid", uuid).getS());
+        assertEquals(uuid.toString(), convert("getUuid", uuid).s());
     }
 
     @Test
     public void testDate() {
         assertEquals("1970-01-01T00:00:00.000Z",
-                convert("getDate", new Date(0)).getS());
+                convert("getDate", new Date(0)).s());
 
         Calendar c = GregorianCalendar.getInstance();
         c.setTimeInMillis(0);
 
         assertEquals("1970-01-01T00:00:00.000Z",
-                convert("getCalendar", c).getS());
+                convert("getCalendar", c).s());
     }
 
     @Test
     public void testNumbers() {
-        assertEquals("0", convert("getByte", (byte) 0).getN());
-        assertEquals("1", convert("getByte", (byte) 1).getN());
-        assertEquals("0", convert("getBoxedByte", (byte) 0).getN());
-        assertEquals("1", convert("getBoxedByte", (byte) 1).getN());
+        assertEquals("0", convert("getByte", (byte) 0).n());
+        assertEquals("1", convert("getByte", (byte) 1).n());
+        assertEquals("0", convert("getBoxedByte", (byte) 0).n());
+        assertEquals("1", convert("getBoxedByte", (byte) 1).n());
 
-        assertEquals("0", convert("getShort", (short) 0).getN());
-        assertEquals("1", convert("getShort", (short) 1).getN());
-        assertEquals("0", convert("getBoxedShort", (short) 0).getN());
-        assertEquals("1", convert("getBoxedShort", (short) 1).getN());
+        assertEquals("0", convert("getShort", (short) 0).n());
+        assertEquals("1", convert("getShort", (short) 1).n());
+        assertEquals("0", convert("getBoxedShort", (short) 0).n());
+        assertEquals("1", convert("getBoxedShort", (short) 1).n());
 
-        assertEquals("0", convert("getInt", 0).getN());
-        assertEquals("1", convert("getInt", 1).getN());
-        assertEquals("0", convert("getBoxedInt", 0).getN());
-        assertEquals("1", convert("getBoxedInt", 1).getN());
+        assertEquals("0", convert("getInt", 0).n());
+        assertEquals("1", convert("getInt", 1).n());
+        assertEquals("0", convert("getBoxedInt", 0).n());
+        assertEquals("1", convert("getBoxedInt", 1).n());
 
-        assertEquals("0", convert("getLong", 0l).getN());
-        assertEquals("1", convert("getLong", 1l).getN());
-        assertEquals("0", convert("getBoxedLong", 0l).getN());
-        assertEquals("1", convert("getBoxedLong", 1l).getN());
+        assertEquals("0", convert("getLong", 0l).n());
+        assertEquals("1", convert("getLong", 1l).n());
+        assertEquals("0", convert("getBoxedLong", 0l).n());
+        assertEquals("1", convert("getBoxedLong", 1l).n());
 
-        assertEquals("0", convert("getBigInt", BigInteger.ZERO).getN());
-        assertEquals("1", convert("getBigInt", BigInteger.ONE).getN());
+        assertEquals("0", convert("getBigInt", BigInteger.ZERO).n());
+        assertEquals("1", convert("getBigInt", BigInteger.ONE).n());
 
-        assertEquals("0.0", convert("getFloat", 0f).getN());
-        assertEquals("1.0", convert("getFloat", 1f).getN());
-        assertEquals("0.0", convert("getBoxedFloat", 0f).getN());
-        assertEquals("1.0", convert("getBoxedFloat", 1f).getN());
+        assertEquals("0.0", convert("getFloat", 0f).n());
+        assertEquals("1.0", convert("getFloat", 1f).n());
+        assertEquals("0.0", convert("getBoxedFloat", 0f).n());
+        assertEquals("1.0", convert("getBoxedFloat", 1f).n());
 
-        assertEquals("0.0", convert("getDouble", 0d).getN());
-        assertEquals("1.0", convert("getDouble", 1d).getN());
-        assertEquals("0.0", convert("getBoxedDouble", 0d).getN());
-        assertEquals("1.0", convert("getBoxedDouble", 1d).getN());
+        assertEquals("0.0", convert("getDouble", 0d).n());
+        assertEquals("1.0", convert("getDouble", 1d).n());
+        assertEquals("0.0", convert("getBoxedDouble", 0d).n());
+        assertEquals("1.0", convert("getBoxedDouble", 1d).n());
 
-        assertEquals("0", convert("getBigDecimal", BigDecimal.ZERO).getN());
-        assertEquals("1", convert("getBigDecimal", BigDecimal.ONE).getN());
+        assertEquals("0", convert("getBigDecimal", BigDecimal.ZERO).n());
+        assertEquals("1", convert("getBigDecimal", BigDecimal.ONE).n());
     }
 
     @Test
     public void testBinary() {
         ByteBuffer value = ByteBuffer.wrap("value".getBytes());
-        assertEquals(value.slice(), convert("getByteArray", "value".getBytes()).getB());
-        assertEquals(value.slice(), convert("getByteBuffer", value.slice()).getB());
+        assertEquals(value.slice(), convert("getByteArray", "value".getBytes()).b().asByteBuffer());
+        assertEquals(value.slice(), convert("getByteBuffer", value.slice()).b().asByteBuffer());
     }
 
     @Test
     public void testBooleanSet() {
         assertEquals(Collections.singletonList("1"),
-                convert("getBooleanSet", Collections.singleton(true)).getNS());
+                convert("getBooleanSet", Collections.singleton(true)).ns());
 
         assertEquals(Collections.singletonList("0"),
-                convert("getBooleanSet", Collections.singleton(false)).getNS());
+                convert("getBooleanSet", Collections.singleton(false)).ns());
 
         assertEquals(Arrays.asList("0", "1"),
                 convert("getBooleanSet", new TreeSet<Boolean>() {{
                     add(true);
                     add(false);
-                }}).getNS());
+                }}).ns());
     }
 
     @Test
     public void testStringSet() {
         assertEquals(Collections.singletonList("a"),
-                convert("getStringSet", Collections.singleton("a")).getSS());
+                convert("getStringSet", Collections.singleton("a")).ss());
         assertEquals(Collections.singletonList("b"),
-                convert("getStringSet", Collections.singleton("b")).getSS());
+                convert("getStringSet", Collections.singleton("b")).ss());
 
         assertEquals(Arrays.asList("a", "b", "c"),
                 convert("getStringSet", new TreeSet<String>() {{
                     add("a");
                     add("b");
                     add("c");
-                }}).getSS());
+                }}).ss());
     }
 
     @Test
@@ -175,10 +176,10 @@ public class StandardModelFactoriesV2CompatibleTest {
         final UUID three = UUID.randomUUID();
 
         assertEquals(Collections.singletonList(one.toString()),
-                convert("getUuidSet", Collections.singleton(one)).getSS());
+                convert("getUuidSet", Collections.singleton(one)).ss());
 
         assertEquals(Collections.singletonList(two.toString()),
-                convert("getUuidSet", Collections.singleton(two)).getSS());
+                convert("getUuidSet", Collections.singleton(two)).ss());
 
         assertEquals(
                 Arrays.asList(
@@ -189,50 +190,50 @@ public class StandardModelFactoriesV2CompatibleTest {
                     add(one);
                     add(two);
                     add(three);
-                }}).getSS());
+                }}).ss());
     }
 
     @Test
     public void testDateSet() {
         assertEquals(Collections.singletonList("1970-01-01T00:00:00.000Z"),
                 convert("getDateSet", Collections.singleton(new Date(0)))
-                        .getSS());
+                        .ss());
 
         Calendar c = GregorianCalendar.getInstance();
         c.setTimeInMillis(0);
 
         assertEquals(Collections.singletonList("1970-01-01T00:00:00.000Z"),
                 convert("getCalendarSet", Collections.singleton(c))
-                        .getSS());
+                        .ss());
     }
 
     @Test
     public void testNumberSet() {
         assertEquals(Collections.singletonList("0"),
-                convert("getByteSet", Collections.singleton((byte) 0)).getNS());
+                convert("getByteSet", Collections.singleton((byte) 0)).ns());
         assertEquals(Collections.singletonList("0"),
-                convert("getShortSet", Collections.singleton((short) 0)).getNS());
+                convert("getShortSet", Collections.singleton((short) 0)).ns());
         assertEquals(Collections.singletonList("0"),
-                convert("getIntSet", Collections.singleton(0)).getNS());
+                convert("getIntSet", Collections.singleton(0)).ns());
         assertEquals(Collections.singletonList("0"),
-                convert("getLongSet", Collections.singleton(0l)).getNS());
+                convert("getLongSet", Collections.singleton(0l)).ns());
         assertEquals(Collections.singletonList("0"),
                 convert("getBigIntegerSet", Collections.singleton(BigInteger.ZERO))
-                    .getNS());
+                    .ns());
         assertEquals(Collections.singletonList("0.0"),
-                convert("getFloatSet", Collections.singleton(0f)).getNS());
+                convert("getFloatSet", Collections.singleton(0f)).ns());
         assertEquals(Collections.singletonList("0.0"),
-                convert("getDoubleSet", Collections.singleton(0d)).getNS());
+                convert("getDoubleSet", Collections.singleton(0d)).ns());
         assertEquals(Collections.singletonList("0"),
                 convert("getBigDecimalSet", Collections.singleton(BigDecimal.ZERO))
-                    .getNS());
+                    .ns());
 
         assertEquals(Arrays.asList("0", "1", "2"),
                 convert("getLongSet", new TreeSet<Number>() {{
                     add(0);
                     add(1);
                     add(2);
-                }}).getNS());
+                }}).ns());
     }
 
     @Test
@@ -240,19 +241,19 @@ public class StandardModelFactoriesV2CompatibleTest {
         final ByteBuffer test = ByteBuffer.wrap("test".getBytes());
         final ByteBuffer test2 = ByteBuffer.wrap("test2".getBytes());
 
-        assertEquals(Collections.singletonList(test.slice()),
+        assertEquals(Collections.singletonList(SdkBytes.fromByteBuffer(test.slice())),
                 convert("getByteArraySet", Collections.singleton("test".getBytes()))
-                    .getBS());
+                    .bs());
 
-        assertEquals(Collections.singletonList(test.slice()),
+        assertEquals(Collections.singletonList(SdkBytes.fromByteBuffer(test.slice())),
                 convert("getByteBufferSet", Collections.singleton(test.slice()))
-                    .getBS());
+                    .bs());
 
-        assertEquals(Arrays.asList(test.slice(), test2.slice()),
+        assertEquals(Arrays.asList(SdkBytes.fromByteBuffer(test.slice()), SdkBytes.fromByteBuffer(test2.slice())),
                 convert("getByteBufferSet",new TreeSet<ByteBuffer>() {{
                     add(test.slice());
                     add(test2.slice());
-                }}).getBS());
+                }}).bs());
     }
 
     @Test
@@ -265,76 +266,76 @@ public class StandardModelFactoriesV2CompatibleTest {
         };
 
         assertEquals(Collections.singletonList("hello"),
-                convert("getObjectSet", Collections.singleton(o)).getSS());
+                convert("getObjectSet", Collections.singleton(o)).ss());
     }
 
     @Test
     public void testList() {
         assertEquals(Arrays.asList(
-                    new AttributeValue("a"),
-                    new AttributeValue("b"),
-                    new AttributeValue("c")),
-                convert("getList", Arrays.asList("a", "b", "c")).getL());
+                    AttributeValue.builder().s("a").build(),
+                    AttributeValue.builder().s("b").build(),
+                    AttributeValue.builder().s("c").build()),
+                convert("getList", Arrays.asList("a", "b", "c")).l());
 
-        assertEquals(Arrays.asList(new AttributeValue().withNULL(true)),
-                convert("getList", Collections.<String>singletonList(null)).getL());
+        assertEquals(Arrays.asList(AttributeValue.builder().nul(true).build()),
+                convert("getList", Collections.<String>singletonList(null)).l());
     }
 
     @Test
     public void testSetList() {
         assertEquals(Arrays.asList(
-                    new AttributeValue().withSS("a"),
-                    new AttributeValue().withSS("b"),
-                    new AttributeValue().withSS("c")),
+                    AttributeValue.builder().ss("a").build(),
+                    AttributeValue.builder().ss("b").build(),
+                    AttributeValue.builder().ss("c").build()),
                 convert("getSetList", Arrays.asList(
                         Collections.singleton("a"),
                         Collections.singleton("b"),
-                        Collections.singleton("c"))).getL());
+                        Collections.singleton("c"))).l());
     }
 
     @Test
     public void testMap() {
         assertEquals(new HashMap<String, AttributeValue>() {{
-                put("a", new AttributeValue("b"));
-                put("c", new AttributeValue("d"));
-                put("e", new AttributeValue("f"));
+                put("a", AttributeValue.builder().s("b").build());
+                put("c", AttributeValue.builder().s("d").build());
+                put("e", AttributeValue.builder().s("f").build());
             }},
             convert("getMap", new HashMap<String, String>() {{
                 put("a", "b");
                 put("c", "d");
                 put("e", "f");
-            }}).getM());
+            }}).m());
 
-        assertEquals(Collections.singletonMap("a", new AttributeValue().withNULL(true)),
-                convert("getMap", Collections.<String, String>singletonMap("a", null)).getM());
+        assertEquals(Collections.singletonMap("a", AttributeValue.builder().nul(true).build()),
+                convert("getMap", Collections.<String, String>singletonMap("a", null)).m());
     }
 
     @Test
     public void testSetMap() {
         assertEquals(new HashMap<String, AttributeValue>() {{
-                put("a", new AttributeValue().withSS("a", "b"));
+                put("a", AttributeValue.builder().ss("a", "b").build());
             }},
             convert("getSetMap", new HashMap<String, Set<String>>() {{
                 put("a", new TreeSet<String>(Arrays.asList("a", "b")));
-            }}).getM());
+            }}).m());
 
         assertEquals(new HashMap<String, AttributeValue>() {{
-                put("a", new AttributeValue().withSS("a"));
-                put("b", new AttributeValue().withNULL(true));
+                put("a", AttributeValue.builder().ss("a").build());
+                put("b", AttributeValue.builder().nul(true).build());
             }},
             convert("getSetMap", new HashMap<String, Set<String>>() {{
                 put("a", new TreeSet<String>(Arrays.asList("a")));
                 put("b", null);
-            }}).getM());
+            }}).m());
     }
 
     @Test
     public void testObject() {
         assertEquals(new HashMap<String, AttributeValue>() {{
-                put("name", new AttributeValue("name"));
-                put("value", new AttributeValue().withN("123"));
+                put("name", AttributeValue.builder().s("name").build());
+                put("value", AttributeValue.builder().n("123").build());
             }},
-            convert("getObject", new SubClass()).getM());
+            convert("getObject", new SubClass()).m());
     }
 
     @Test
@@ -357,7 +358,7 @@ public class StandardModelFactoriesV2CompatibleTest {
                      + "\"bucket\":\"bucket\","
                      + "\"key\":\"key\","
                      + "\"region\":null}}",
-                convert("getS3Link", link).getS());
+                convert("getS3Link", link).s());
     }
 
     private AttributeValue convert(String getter, Object value) {

--- a/services-custom/dynamodb-mapper/src/test/java/software/amazon/awssdk/mapper/dynamodb/StandardModelFactoriesV2Test.java
+++ b/services-custom/dynamodb-mapper/src/test/java/software/amazon/awssdk/mapper/dynamodb/StandardModelFactoriesV2Test.java
@@ -37,7 +37,8 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import com.amazonaws.auth.AWSCredentialsProvider;
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import software.amazon.awssdk.mapper.dynamodb.pojos.SubClass;
 import software.amazon.awssdk.mapper.dynamodb.pojos.TestClass;
 import software.amazon.awssdk.mapper.dynamodb.pojos.UnannotatedSubClass;
@@ -60,84 +61,84 @@ public class StandardModelFactoriesV2Test {
     @Test
     public void testBoolean() {
         // These are all native booleans by default in the v2 schema
-        assertEquals(true, convert("getBoolean", true).getBOOL());
-        assertEquals(false, convert("getBoolean", false).getBOOL());
-        assertEquals(true, convert("getBoxedBoolean", true).getBOOL());
-        assertEquals(false, convert("getBoxedBoolean", false).getBOOL());
-        assertEquals(true, convert("getNativeBoolean", true).getBOOL());
-        assertEquals(false, convert("getNativeBoolean", false).getBOOL());
+        assertEquals(true, convert("getBoolean", true).bool());
+        assertEquals(false, convert("getBoolean", false).bool());
+        assertEquals(true, convert("getBoxedBoolean", true).bool());
+        assertEquals(false, convert("getBoxedBoolean", false).bool());
+        assertEquals(true, convert("getNativeBoolean", true).bool());
+        assertEquals(false, convert("getNativeBoolean", false).bool());
     }
 
     @Test
     public void testString() {
-        assertEquals("abc", convert("getString", "abc").getS());
+        assertEquals("abc", convert("getString", "abc").s());
 
         assertEquals(RandomUUIDMarshaller.randomUUID,
-                convert("getCustomString", "abc").getS());
+                convert("getCustomString", "abc").s());
     }
 
     @Test
     public void testUuid() {
         UUID uuid = UUID.randomUUID();
-        assertEquals(uuid.toString(), convert("getUuid", uuid).getS());
+        assertEquals(uuid.toString(), convert("getUuid", uuid).s());
     }
 
     @Test
     public void testDate() {
         assertEquals("1970-01-01T00:00:00.000Z",
-                convert("getDate", new Date(0)).getS());
+                convert("getDate", new Date(0)).s());
 
         Calendar c = GregorianCalendar.getInstance();
         c.setTimeInMillis(0);
 
         assertEquals("1970-01-01T00:00:00.000Z",
-                convert("getCalendar", c).getS());
+                convert("getCalendar", c).s());
     }
 
     @Test
     public void testNumbers() {
-        assertEquals("0", convert("getByte", (byte) 0).getN());
-        assertEquals("1", convert("getByte", (byte) 1).getN());
-        assertEquals("0", convert("getBoxedByte", (byte) 0).getN());
-        assertEquals("1", convert("getBoxedByte", (byte) 1).getN());
+        assertEquals("0", convert("getByte", (byte) 0).n());
+        assertEquals("1", convert("getByte", (byte) 1).n());
+        assertEquals("0", convert("getBoxedByte", (byte) 0).n());
+        assertEquals("1", convert("getBoxedByte", (byte) 1).n());
 
-        assertEquals("0", convert("getShort", (short) 0).getN());
-        assertEquals("1", convert("getShort", (short) 1).getN());
-        assertEquals("0", convert("getBoxedShort", (short) 0).getN());
-        assertEquals("1", convert("getBoxedShort", (short) 1).getN());
+        assertEquals("0", convert("getShort", (short) 0).n());
+        assertEquals("1", convert("getShort", (short) 1).n());
+        assertEquals("0", convert("getBoxedShort", (short) 0).n());
+        assertEquals("1", convert("getBoxedShort", (short) 1).n());
 
-        assertEquals("0", convert("getInt", 0).getN());
-        assertEquals("1", convert("getInt", 1).getN());
-        assertEquals("0", convert("getBoxedInt", 0).getN());
-        assertEquals("1", convert("getBoxedInt", 1).getN());
+        assertEquals("0", convert("getInt", 0).n());
+        assertEquals("1", convert("getInt", 1).n());
+        assertEquals("0", convert("getBoxedInt", 0).n());
+        assertEquals("1", convert("getBoxedInt", 1).n());
 
-        assertEquals("0", convert("getLong", 0l).getN());
-        assertEquals("1", convert("getLong", 1l).getN());
-        assertEquals("0", convert("getBoxedLong", 0l).getN());
-        assertEquals("1", convert("getBoxedLong", 1l).getN());
+        assertEquals("0", convert("getLong", 0l).n());
+        assertEquals("1", convert("getLong", 1l).n());
+        assertEquals("0", convert("getBoxedLong", 0l).n());
+        assertEquals("1", convert("getBoxedLong", 1l).n());
 
-        assertEquals("0", convert("getBigInt", BigInteger.ZERO).getN());
-        assertEquals("1", convert("getBigInt", BigInteger.ONE).getN());
+        assertEquals("0", convert("getBigInt", BigInteger.ZERO).n());
+        assertEquals("1", convert("getBigInt", BigInteger.ONE).n());
 
-        assertEquals("0.0", convert("getFloat", 0f).getN());
-        assertEquals("1.0", convert("getFloat", 1f).getN());
-        assertEquals("0.0", convert("getBoxedFloat", 0f).getN());
-        assertEquals("1.0", convert("getBoxedFloat", 1f).getN());
+        assertEquals("0.0", convert("getFloat", 0f).n());
+        assertEquals("1.0", convert("getFloat", 1f).n());
+        assertEquals("0.0", convert("getBoxedFloat", 0f).n());
+        assertEquals("1.0", convert("getBoxedFloat", 1f).n());
 
-        assertEquals("0.0", convert("getDouble", 0d).getN());
-        assertEquals("1.0", convert("getDouble", 1d).getN());
-        assertEquals("0.0", convert("getBoxedDouble", 0d).getN());
-        assertEquals("1.0", convert("getBoxedDouble", 1d).getN());
+        assertEquals("0.0", convert("getDouble", 0d).n());
+        assertEquals("1.0", convert("getDouble", 1d).n());
+        assertEquals("0.0", convert("getBoxedDouble", 0d).n());
+        assertEquals("1.0", convert("getBoxedDouble", 1d).n());
 
-        assertEquals("0", convert("getBigDecimal", BigDecimal.ZERO).getN());
-        assertEquals("1", convert("getBigDecimal", BigDecimal.ONE).getN());
+        assertEquals("0", convert("getBigDecimal", BigDecimal.ZERO).n());
+        assertEquals("1", convert("getBigDecimal", BigDecimal.ONE).n());
     }
 
     @Test
     public void testBinary() {
         ByteBuffer value = ByteBuffer.wrap("value".getBytes());
-        assertEquals(value.slice(), convert("getByteArray", "value".getBytes()).getB());
-        assertEquals(value.slice(), convert("getByteBuffer", value.slice()).getB());
+        assertEquals(value.slice(), convert("getByteArray", "value".getBytes()).b().asByteBuffer());
+        assertEquals(value.slice(), convert("getByteBuffer", value.slice()).b().asByteBuffer());
     }
 
     @Test
@@ -147,23 +148,23 @@ public class StandardModelFactoriesV2Test {
         AttributeValue value =
                 convert("getBooleanSet", Collections.singleton(true));
 
-        Assert.assertEquals(1, value.getL().size());
-        Assert.assertEquals(true, value.getL().get(0).getBOOL());
+        Assert.assertEquals(1, value.l().size());
+        Assert.assertEquals(true, value.l().get(0).bool());
     }
 
     @Test
     public void testStringSet() {
         assertEquals(Collections.singletonList("a"),
-                convert("getStringSet", Collections.singleton("a")).getSS());
+                convert("getStringSet", Collections.singleton("a")).ss());
         assertEquals(Collections.singletonList("b"),
-                convert("getStringSet", Collections.singleton("b")).getSS());
+                convert("getStringSet", Collections.singleton("b")).ss());
 
         assertEquals(Arrays.asList("a", "b", "c"),
                 convert("getStringSet", new TreeSet<String>() {{
                     add("a");
                     add("b");
                     add("c");
-                }}).getSS());
+                }}).ss());
     }
 
     @Test
@@ -173,10 +174,10 @@ public class StandardModelFactoriesV2Test {
         final UUID three = UUID.randomUUID();
 
         assertEquals(Collections.singletonList(one.toString()),
-                convert("getUuidSet", Collections.singleton(one)).getSS());
+                convert("getUuidSet", Collections.singleton(one)).ss());
 
         assertEquals(Collections.singletonList(two.toString()),
-                convert("getUuidSet", Collections.singleton(two)).getSS());
+                convert("getUuidSet", Collections.singleton(two)).ss());
 
         assertEquals(
                 Arrays.asList(
@@ -187,50 +188,50 @@ public class StandardModelFactoriesV2Test {
                     add(one);
                     add(two);
                     add(three);
-                }}).getSS());
+                }}).ss());
     }
 
     @Test
     public void testDateSet() {
         assertEquals(Collections.singletonList("1970-01-01T00:00:00.000Z"),
                 convert("getDateSet", Collections.singleton(new Date(0)))
-                        .getSS());
+                        .ss());
 
         Calendar c = GregorianCalendar.getInstance();
         c.setTimeInMillis(0);
 
         assertEquals(Collections.singletonList("1970-01-01T00:00:00.000Z"),
                 convert("getCalendarSet", Collections.singleton(c))
-                        .getSS());
+                        .ss());
     }
 
     @Test
     public void testNumberSet() {
         assertEquals(Collections.singletonList("0"),
-                convert("getByteSet", Collections.singleton((byte) 0)).getNS());
+                convert("getByteSet", Collections.singleton((byte) 0)).ns());
         assertEquals(Collections.singletonList("0"),
-                convert("getShortSet", Collections.singleton((short) 0)).getNS());
+                convert("getShortSet", Collections.singleton((short) 0)).ns());
         assertEquals(Collections.singletonList("0"),
-                convert("getIntSet", Collections.singleton(0)).getNS());
+                convert("getIntSet", Collections.singleton(0)).ns());
         assertEquals(Collections.singletonList("0"),
-                convert("getLongSet", Collections.singleton(0l)).getNS());
+                convert("getLongSet", Collections.singleton(0l)).ns());
         assertEquals(Collections.singletonList("0"),
                 convert("getBigIntegerSet", Collections.singleton(BigInteger.ZERO))
-                    .getNS());
+                    .ns());
         assertEquals(Collections.singletonList("0.0"),
-                convert("getFloatSet", Collections.singleton(0f)).getNS());
+                convert("getFloatSet", Collections.singleton(0f)).ns());
         assertEquals(Collections.singletonList("0.0"),
-                convert("getDoubleSet", Collections.singleton(0d)).getNS());
+                convert("getDoubleSet", Collections.singleton(0d)).ns());
         assertEquals(Collections.singletonList("0"),
                 convert("getBigDecimalSet", Collections.singleton(BigDecimal.ZERO))
-                    .getNS());
+                    .ns());
 
         assertEquals(Arrays.asList("0", "1", "2"),
                 convert("getLongSet", new TreeSet<Number>() {{
                     add(0);
                     add(1);
                     add(2);
-                }}).getNS());
+                }}).ns());
     }
 
     @Test
@@ -238,19 +239,19 @@ public class StandardModelFactoriesV2Test {
         final ByteBuffer test = ByteBuffer.wrap("test".getBytes());
         final ByteBuffer test2 = ByteBuffer.wrap("test2".getBytes());
 
-        assertEquals(Collections.singletonList(test.slice()),
+        assertEquals(Collections.singletonList(SdkBytes.fromByteBuffer(test.slice())),
                 convert("getByteArraySet", Collections.singleton("test".getBytes()))
-                    .getBS());
+                    .bs());
 
-        assertEquals(Collections.singletonList(test.slice()),
+        assertEquals(Collections.singletonList(SdkBytes.fromByteBuffer(test.slice())),
                 convert("getByteBufferSet", Collections.singleton(test.slice()))
-                    .getBS());
+                    .bs());
 
-        assertEquals(Arrays.asList(test.slice(), test2.slice()),
+        assertEquals(Arrays.asList(SdkBytes.fromByteBuffer(test.slice()), SdkBytes.fromByteBuffer(test2.slice())),
                 convert("getByteBufferSet",new TreeSet<ByteBuffer>() {{
                     add(test.slice());
                     add(test2.slice());
-                }}).getBS());
+                }}).bs());
     }
 
     @Test
@@ -258,27 +259,27 @@ public class StandardModelFactoriesV2Test {
         AttributeValue value =
                 convert("getObjectSet", Collections.singleton(new SubClass()));
 
-        assertEquals(1, value.getL().size());
+        assertEquals(1, value.l().size());
         assertEquals(new HashMap<String, AttributeValue>() {{
-                put("name", new AttributeValue("name"));
-                put("value", new AttributeValue().withN("123"));
+                put("name", AttributeValue.builder().s("name").build());
+                put("value", AttributeValue.builder().n("123").build());
             }},
-            value.getL().get(0).getM());
+            value.l().get(0).m());
 
-        assertEquals(Arrays.asList(new AttributeValue().withNULL(true)),
-                convert("getObjectSet", Collections.<SubClass>singleton(null)).getL());
+        assertEquals(Arrays.asList(AttributeValue.builder().nul(true).build()),
+                convert("getObjectSet", Collections.<SubClass>singleton(null)).l());
     }
 
     @Test
     public void testList() {
         assertEquals(Arrays.asList(
-                    new AttributeValue("a"),
-                    new AttributeValue("b"),
-                    new AttributeValue("c")),
-                convert("getList", Arrays.asList("a", "b", "c")).getL());
+                    AttributeValue.builder().s("a").build(),
+                    AttributeValue.builder().s("b").build(),
+                    AttributeValue.builder().s("c").build()),
+                convert("getList", Arrays.asList("a", "b", "c")).l());
 
-        assertEquals(Arrays.asList(new AttributeValue().withNULL(true)),
-                convert("getList", Collections.<String>singletonList(null)).getL());
+        assertEquals(Arrays.asList(AttributeValue.builder().nul(true).build()),
+                convert("getList", Collections.<String>singletonList(null)).l());
     }
 
     @Test
@@ -287,72 +288,72 @@ public class StandardModelFactoriesV2Test {
                 "getObjectList",
                 Collections.singletonList(new SubClass()));
 
-        assertEquals(1, value.getL().size());
+        assertEquals(1, value.l().size());
         assertEquals(new HashMap<String, AttributeValue>() {{
-                put("name", new AttributeValue("name"));
-                put("value", new AttributeValue().withN("123"));
+                put("name", AttributeValue.builder().s("name").build());
+                put("value", AttributeValue.builder().n("123").build());
             }},
-            value.getL().get(0).getM());
+            value.l().get(0).m());
     }
 
     @Test
     public void testSetList() {
         assertEquals(
-                Arrays.asList(new AttributeValue().withSS("a")),
+                Arrays.asList(AttributeValue.builder().ss("a").build()),
                 convert("getSetList", Arrays.asList(
-                        Collections.<String>singleton("a"))).getL());
+                        Collections.<String>singleton("a"))).l());
 
         List<Set<String>> list = new ArrayList<Set<String>>();
         list.add(null);
 
         assertEquals(
-                Arrays.asList(new AttributeValue().withNULL(true)),
-                convert("getSetList", list).getL());
+                Arrays.asList(AttributeValue.builder().nul(true).build()),
+                convert("getSetList", list).l());
     }
 
     @Test
     public void testMap() {
         assertEquals(new HashMap<String, AttributeValue>() {{
-                put("a", new AttributeValue("b"));
-                put("c", new AttributeValue("d"));
-                put("e", new AttributeValue("f"));
+                put("a", AttributeValue.builder().s("b").build());
+                put("c", AttributeValue.builder().s("d").build());
+                put("e", AttributeValue.builder().s("f").build());
             }},
             convert("getMap", new HashMap<String, String>() {{
                 put("a", "b");
                 put("c", "d");
                 put("e", "f");
-            }}).getM());
+            }}).m());
 
-        assertEquals(Collections.singletonMap("a", new AttributeValue().withNULL(true)),
-                convert("getMap", Collections.<String, String>singletonMap("a", null)).getM());
+        assertEquals(Collections.singletonMap("a", AttributeValue.builder().nul(true).build()),
+                convert("getMap", Collections.<String, String>singletonMap("a", null)).m());
     }
 
     @Test
     public void testSetMap() {
         assertEquals(new HashMap<String, AttributeValue>() {{
-                put("a", new AttributeValue().withSS("a", "b"));
+                put("a", AttributeValue.builder().ss("a", "b").build());
             }},
             convert("getSetMap", new HashMap<String, Set<String>>() {{
                 put("a", new TreeSet<String>(Arrays.asList("a", "b")));
-            }}).getM());
+            }}).m());
 
         assertEquals(new HashMap<String, AttributeValue>() {{
-                put("a", new AttributeValue().withSS("a"));
-                put("b", new AttributeValue().withNULL(true));
+                put("a", AttributeValue.builder().ss("a").build());
+                put("b", AttributeValue.builder().nul(true).build());
             }},
             convert("getSetMap", new HashMap<String, Set<String>>() {{
                 put("a", new TreeSet<String>(Arrays.asList("a")));
                 put("b", null);
-            }}).getM());
+            }}).m());
     }
 
     @Test
     public void testObject() {
         assertEquals(new HashMap<String, AttributeValue>() {{
-                put("name", new AttributeValue("name"));
-                put("value", new AttributeValue().withN("123"));
+                put("name", AttributeValue.builder().s("name").build());
+                put("value", AttributeValue.builder().n("123").build());
             }},
-            convert("getObject", new SubClass()).getM());
+            convert("getObject", new SubClass()).m());
     }
 
     @Test
@@ -375,7 +376,7 @@ public class StandardModelFactoriesV2Test {
                      + "\"bucket\":\"bucket\","
                      + "\"key\":\"key\","
                      + "\"region\":null}}",
-                convert("getS3Link", link).getS());
+                convert("getS3Link", link).s());
     }
 
     private AttributeValue convert(String getter, Object value) {

--- a/services-custom/dynamodb-mapper/src/test/java/software/amazon/awssdk/mapper/dynamodb/StandardModelFactoriesV2UnconvertTest.java
+++ b/services-custom/dynamodb-mapper/src/test/java/software/amazon/awssdk/mapper/dynamodb/StandardModelFactoriesV2UnconvertTest.java
@@ -35,7 +35,8 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import com.amazonaws.auth.AWSCredentialsProvider;
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import software.amazon.awssdk.mapper.dynamodb.pojos.SubClass;
 import software.amazon.awssdk.mapper.dynamodb.pojos.TestClass;
 import software.amazon.awssdk.mapper.dynamodb.pojos.UnannotatedSubClass;
@@ -59,95 +60,95 @@ public class StandardModelFactoriesV2UnconvertTest {
     @Test
     public void testBoolean() {
         assertEquals(false, unconvert("getBoolean", "setBoolean",
-                new AttributeValue().withN("0")));
+                AttributeValue.builder().n("0").build()));
 
         assertEquals(true, unconvert("getBoolean", "setBoolean",
-                new AttributeValue().withN("1")));
+                AttributeValue.builder().n("1").build()));
 
         assertEquals(false, unconvert("getBoolean", "setBoolean",
-                new AttributeValue().withBOOL(false)));
+                AttributeValue.builder().bool(false).build()));
 
         assertEquals(true, unconvert("getBoolean", "setBoolean",
-                new AttributeValue().withBOOL(true)));
+                AttributeValue.builder().bool(true).build()));
 
         assertEquals(false, unconvert("getBoxedBoolean", "setBoxedBoolean",
-                new AttributeValue().withN("0")));
+                AttributeValue.builder().n("0").build()));
 
         assertEquals(true, unconvert("getBoxedBoolean", "setBoxedBoolean",
-                new AttributeValue().withN("1")));
+                AttributeValue.builder().n("1").build()));
 
         assertEquals(false, unconvert("getBoxedBoolean", "setBoxedBoolean",
-                new AttributeValue().withBOOL(false)));
+                AttributeValue.builder().bool(false).build()));
 
         assertEquals(true, unconvert("getBoxedBoolean", "setBoxedBoolean",
-                new AttributeValue().withBOOL(true)));
+                AttributeValue.builder().bool(true).build()));
     }
 
     @Test
     public void testString() {
         assertEquals("test", unconvert("getString", "setString",
-                new AttributeValue("test")));
+                AttributeValue.builder().s("test").build()));
 
         Assert.assertNull(unconvert("getCustomString", "setCustomString",
-                new AttributeValue("ignoreme")));
+                AttributeValue.builder().s("ignoreme").build()));
     }
 
     @Test
     public void testUuid() {
         UUID uuid = UUID.randomUUID();
         assertEquals(uuid, unconvert("getUuid", "setUuid",
-                new AttributeValue(uuid.toString())));
+                AttributeValue.builder().s(uuid.toString()).build()));
     }
 
     @Test
     public void testDate() {
         assertEquals(new Date(0), unconvert("getDate", "setDate",
-                new AttributeValue("1970-01-01T00:00:00.000Z")));
+                AttributeValue.builder().s("1970-01-01T00:00:00.000Z").build()));
 
         Calendar c = GregorianCalendar.getInstance();
         c.setTimeInMillis(0);
 
         assertEquals(c, unconvert("getCalendar", "setCalendar",
-                new AttributeValue("1970-01-01T00:00:00.000Z")));
+                AttributeValue.builder().s("1970-01-01T00:00:00.000Z").build()));
     }
 
     @Test
     public void testNumbers() {
         assertEquals((byte) 1, unconvert("getByte", "setByte",
-                new AttributeValue().withN("1")));
+                AttributeValue.builder().n("1").build()));
         assertEquals((byte) 1, unconvert("getBoxedByte", "setBoxedByte",
-                new AttributeValue().withN("1")));
+                AttributeValue.builder().n("1").build()));
 
         assertEquals((short) 1, unconvert("getShort", "setShort",
-                new AttributeValue().withN("1")));
+                AttributeValue.builder().n("1").build()));
         assertEquals((short) 1, unconvert("getBoxedShort", "setBoxedShort",
-                new AttributeValue().withN("1")));
+                AttributeValue.builder().n("1").build()));
 
         assertEquals(1, unconvert("getInt", "setInt",
-                new AttributeValue().withN("1")));
+                AttributeValue.builder().n("1").build()));
         assertEquals(1, unconvert("getBoxedInt", "setBoxedInt",
-                new AttributeValue().withN("1")));
+                AttributeValue.builder().n("1").build()));
 
         assertEquals(1l, unconvert("getLong", "setLong",
-                new AttributeValue().withN("1")));
+                AttributeValue.builder().n("1").build()));
         assertEquals(1l, unconvert("getBoxedLong", "setBoxedLong",
-                new AttributeValue().withN("1")));
+                AttributeValue.builder().n("1").build()));
 
         assertEquals(BigInteger.ONE, unconvert("getBigInt", "setBigInt",
-                new AttributeValue().withN("1")));
+                AttributeValue.builder().n("1").build()));
 
         assertEquals(1.5f, unconvert("getFloat", "setFloat",
-                new AttributeValue().withN("1.5")));
+                AttributeValue.builder().n("1.5").build()));
         assertEquals(1.5f, unconvert("getBoxedFloat", "setBoxedFloat",
-                new AttributeValue().withN("1.5")));
+                AttributeValue.builder().n("1.5").build()));
 
         assertEquals(1.5d, unconvert("getDouble", "setDouble",
-                new AttributeValue().withN("1.5")));
+                AttributeValue.builder().n("1.5").build()));
         assertEquals(1.5d, unconvert("getBoxedDouble", "setBoxedDouble",
-                new AttributeValue().withN("1.5")));
+                AttributeValue.builder().n("1.5").build()));
 
         assertEquals(BigDecimal.ONE, unconvert("getBigDecimal", "setBigDecimal",
-                new AttributeValue().withN("1")));
+                AttributeValue.builder().n("1").build()));
     }
 
     @Test
@@ -155,153 +156,153 @@ public class StandardModelFactoriesV2UnconvertTest {
         ByteBuffer test = ByteBuffer.wrap("test".getBytes());
         Assert.assertTrue(Arrays.equals("test".getBytes(), (byte[]) unconvert(
                 "getByteArray", "setByteArray",
-                new AttributeValue().withB(test.slice()))));
+                AttributeValue.builder().b(SdkBytes.fromByteBuffer(test.slice())).build())));
 
         assertEquals(test.slice(), unconvert("getByteBuffer", "setByteBuffer",
-                new AttributeValue().withB(test.slice())));
+                AttributeValue.builder().b(SdkBytes.fromByteBuffer(test.slice())).build()));
     }
 
     @Test
     public void testBooleanSet() {
         assertEquals(new HashSet<Boolean>() {{ add(true); }},
                 unconvert("getBooleanSet", "setBooleanSet",
-                        new AttributeValue().withNS("1")));
+                        AttributeValue.builder().ns("1").build()));
 
         assertEquals(new HashSet<Boolean>() {{ add(false); }},
                 unconvert("getBooleanSet", "setBooleanSet",
-                        new AttributeValue().withNS("0")));
+                        AttributeValue.builder().ns("0").build()));
 
         assertEquals(new HashSet<Boolean>() {{ add(true); add(false); }},
                 unconvert("getBooleanSet", "setBooleanSet",
-                        new AttributeValue().withNS("0", "1")));
+                        AttributeValue.builder().ns("0", "1").build()));
 
         assertEquals(new HashSet<Boolean>() {{ add(true); }},
                 unconvert("getBooleanSet", "setBooleanSet",
-                        new AttributeValue().withL(
-                                new AttributeValue().withBOOL(true))));
+                        AttributeValue.builder().l(
+                                AttributeValue.builder().bool(true).build()).build()));
 
         assertEquals(new HashSet<Boolean>() {{ add(false); }},
                 unconvert("getBooleanSet", "setBooleanSet",
-                        new AttributeValue().withL(
-                                new AttributeValue().withBOOL(false))));
+                        AttributeValue.builder().l(
+                                AttributeValue.builder().bool(false).build()).build()));
 
         assertEquals(new HashSet<Boolean>() {{ add(false); add(true); }},
                 unconvert("getBooleanSet", "setBooleanSet",
-                        new AttributeValue().withL(
-                                new AttributeValue().withBOOL(false),
-                                new AttributeValue().withBOOL(true))));
+                        AttributeValue.builder().l(
+                                AttributeValue.builder().bool(false).build(),
+                                AttributeValue.builder().bool(true).build()).build()));
 
         assertEquals(new HashSet<Boolean>() {{ add(null); }},
                 unconvert("getBooleanSet", "setBooleanSet",
-                        new AttributeValue().withL(
-                                new AttributeValue().withNULL(true))));
+                        AttributeValue.builder().l(
+                                AttributeValue.builder().nul(true).build()).build()));
     }
 
     @Test
     public void testStringSet() {
         Assert.assertNull(unconvert("getStringSet", "setStringSet",
-                new AttributeValue().withNULL(true)));
+                AttributeValue.builder().nul(true).build()));
 
         assertEquals(new HashSet<String>() {{ add("a"); add("b"); }},
                 unconvert("getStringSet", "setStringSet",
-                        new AttributeValue().withSS("a", "b")));
+                        AttributeValue.builder().ss("a", "b").build()));
     }
 
     @Test
     public void testUuidSet() {
         Assert.assertNull(unconvert("getUuidSet", "setUuidSet",
-                new AttributeValue().withNULL(true)));
+                AttributeValue.builder().nul(true).build()));
 
         final UUID one = UUID.randomUUID();
         final UUID two = UUID.randomUUID();
 
         assertEquals(new HashSet<UUID>() {{ add(one); add(two); }},
                 unconvert("getUuidSet", "setUuidSet",
-                        new AttributeValue().withSS(
+                        AttributeValue.builder().ss(
                                 one.toString(),
-                                two.toString())));
+                                two.toString()).build()));
     }
 
     @Test
     public void testDateSet() {
         assertEquals(Collections.singleton(new Date(0)),
-                unconvert("getDateSet", "setDateSet", new AttributeValue()
-                .withSS("1970-01-01T00:00:00.000Z")));
+                unconvert("getDateSet", "setDateSet", AttributeValue.builder()
+                .ss("1970-01-01T00:00:00.000Z").build()));
 
         Calendar c = GregorianCalendar.getInstance();
         c.setTimeInMillis(0);
 
         assertEquals(Collections.singleton(c),
                 unconvert("getCalendarSet", "setCalendarSet",
-                        new AttributeValue()
-                                .withSS("1970-01-01T00:00:00.000Z")));
+                        AttributeValue.builder()
+                                .ss("1970-01-01T00:00:00.000Z").build()));
     }
 
     @Test
     public void testNumberSet() {
         Assert.assertNull(unconvert("getByteSet", "setByteSet",
-                new AttributeValue().withNULL(true)));
+                AttributeValue.builder().nul(true).build()));
         Assert.assertNull(unconvert("getShortSet", "setShortSet",
-                new AttributeValue().withNULL(true)));
+                AttributeValue.builder().nul(true).build()));
         Assert.assertNull(unconvert("getIntSet", "setIntSet",
-                new AttributeValue().withNULL(true)));
+                AttributeValue.builder().nul(true).build()));
         Assert.assertNull(unconvert("getLongSet", "setLongSet",
-                new AttributeValue().withNULL(true)));
+                AttributeValue.builder().nul(true).build()));
         Assert.assertNull(unconvert("getBigIntegerSet", "setBigIntegerSet",
-                new AttributeValue().withNULL(true)));
+                AttributeValue.builder().nul(true).build()));
         Assert.assertNull(unconvert("getFloatSet", "setFloatSet",
-                new AttributeValue().withNULL(true)));
+                AttributeValue.builder().nul(true).build()));
         Assert.assertNull(unconvert("getDoubleSet", "setDoubleSet",
-                new AttributeValue().withNULL(true)));
+                AttributeValue.builder().nul(true).build()));
         Assert.assertNull(unconvert("getBigDecimalSet", "setBigDecimalSet",
-                new AttributeValue().withNULL(true)));
+                AttributeValue.builder().nul(true).build()));
 
 
         assertEquals(new HashSet<Byte>() {{ add((byte) 1); }},
                 unconvert("getByteSet", "setByteSet",
-                        new AttributeValue().withNS("1")));
+                        AttributeValue.builder().ns("1").build()));
 
         assertEquals(new HashSet<Short>() {{ add((short) 1); }},
                 unconvert("getShortSet", "setShortSet",
-                        new AttributeValue().withNS("1")));
+                        AttributeValue.builder().ns("1").build()));
 
         assertEquals(new HashSet<Integer>() {{ add(1); }},
                 unconvert("getIntSet", "setIntSet",
-                        new AttributeValue().withNS("1")));
+                        AttributeValue.builder().ns("1").build()));
 
         assertEquals(new HashSet<Long>() {{ add(1l); }},
                 unconvert("getLongSet", "setLongSet",
-                        new AttributeValue().withNS("1")));
+                        AttributeValue.builder().ns("1").build()));
 
         assertEquals(new HashSet<BigInteger>() {{ add(BigInteger.ONE); }},
                 unconvert("getBigIntegerSet", "setBigIntegerSet",
-                        new AttributeValue().withNS("1")));
+                        AttributeValue.builder().ns("1").build()));
 
         assertEquals(new HashSet<Float>() {{ add(1.5f); }},
                 unconvert("getFloatSet", "setFloatSet",
-                        new AttributeValue().withNS("1.5")));
+                        AttributeValue.builder().ns("1.5").build()));
 
         assertEquals(new HashSet<Double>() {{ add(1.5d); }},
                 unconvert("getDoubleSet", "setDoubleSet",
-                        new AttributeValue().withNS("1.5")));
+                        AttributeValue.builder().ns("1.5").build()));
 
         assertEquals(new HashSet<BigDecimal>() {{ add(BigDecimal.ONE); }},
                 unconvert("getBigDecimalSet", "setBigDecimalSet",
-                        new AttributeValue().withNS("1")));
+                        AttributeValue.builder().ns("1").build()));
     }
 
     @Test
     public void testBinarySet() {
         Assert.assertNull(unconvert("getByteArraySet", "setByteArraySet",
-                new AttributeValue().withNULL(true)));
+                AttributeValue.builder().nul(true).build()));
         Assert.assertNull(unconvert("getByteBufferSet", "setByteBufferSet",
-                new AttributeValue().withNULL(true)));
+                AttributeValue.builder().nul(true).build()));
 
         ByteBuffer test = ByteBuffer.wrap("test".getBytes());
 
         Set<byte[]> result = (Set<byte[]>) unconvert(
                 "getByteArraySet", "setByteArraySet",
-                new AttributeValue().withBS(test.slice()));
+                AttributeValue.builder().bs(SdkBytes.fromByteBuffer(test.slice())).build());
 
         assertEquals(1, result.size());
         Assert.assertTrue(Arrays.equals(
@@ -310,25 +311,25 @@ public class StandardModelFactoriesV2UnconvertTest {
 
         Assert.assertEquals(Collections.singleton(test.slice()),
                 unconvert("getByteBufferSet", "setByteBufferSet",
-                        new AttributeValue().withBS(test.slice())));
+                        AttributeValue.builder().bs(SdkBytes.fromByteBuffer(test.slice())).build()));
     }
 
     @Test
     public void testObjectSet() {
         Object result = unconvert("getObjectSet", "setObjectSet",
-            new AttributeValue().withL(new AttributeValue().withM(
+            AttributeValue.builder().l(AttributeValue.builder().m(
                 new HashMap<String, AttributeValue>() {{
-                    put("name", new AttributeValue("name"));
-                    put("value", new AttributeValue().withN("123"));
-                    put("null", new AttributeValue().withNULL(true));
+                    put("name", AttributeValue.builder().s("name").build());
+                    put("value", AttributeValue.builder().n("123").build());
+                    put("null", AttributeValue.builder().nul(true).build());
                 }}
-        )));
+        ).build()).build());
 
         assertEquals(Collections.singleton(new SubClass()), result);
 
         result = unconvert("getObjectSet", "setObjectSet",
-                new AttributeValue().withL(
-                        new AttributeValue().withNULL(true)));
+                AttributeValue.builder().l(
+                        AttributeValue.builder().nul(true).build()).build());
 
         assertEquals(Collections.<SubClass>singleton(null), result);
     }
@@ -336,107 +337,107 @@ public class StandardModelFactoriesV2UnconvertTest {
     @Test
     public void testList() {
         Assert.assertNull(unconvert("getList", "setList",
-                new AttributeValue().withNULL(true)));
+                AttributeValue.builder().nul(true).build()));
 
         assertEquals(Arrays.asList("a", "b", "c"),
-                unconvert("getList", "setList", new AttributeValue().withL(
-                        new AttributeValue("a"),
-                        new AttributeValue("b"),
-                        new AttributeValue("c"))));
+                unconvert("getList", "setList", AttributeValue.builder().l(
+                        AttributeValue.builder().s("a").build(),
+                        AttributeValue.builder().s("b").build(),
+                        AttributeValue.builder().s("c").build()).build()));
 
         assertEquals(Arrays.asList("a", null),
-                unconvert("getList", "setList", new AttributeValue().withL(
-                        new AttributeValue("a"),
-                        new AttributeValue().withNULL(true))));
+                unconvert("getList", "setList", AttributeValue.builder().l(
+                        AttributeValue.builder().s("a").build(),
+                        AttributeValue.builder().nul(true).build()).build()));
     }
 
     @Test
     public void testObjectList() {
         Assert.assertNull(unconvert("getObjectList", "setObjectList",
-                new AttributeValue().withNULL(true)));
+                AttributeValue.builder().nul(true).build()));
 
         assertEquals(Arrays.asList(new SubClass(), null),
                 unconvert("getObjectList", "setObjectList",
-                        new AttributeValue().withL(
-                                new AttributeValue().withM(new HashMap<String, AttributeValue>() {{
-                                    put("name", new AttributeValue("name"));
-                                    put("value", new AttributeValue().withN("123"));
-                                    put("null", new AttributeValue().withNULL(true));
-                                }}),
-                                new AttributeValue().withNULL(true))));
+                        AttributeValue.builder().l(
+                                AttributeValue.builder().m(new HashMap<String, AttributeValue>() {{
+                                    put("name", AttributeValue.builder().s("name").build());
+                                    put("value", AttributeValue.builder().n("123").build());
+                                    put("null", AttributeValue.builder().nul(true).build());
+                                }}).build(),
+                                AttributeValue.builder().nul(true).build()).build()));
     }
 
     @Test
     public void testSetList() {
         Assert.assertNull(unconvert("getSetList", "setSetList",
-                new AttributeValue().withNULL(true)));
+                AttributeValue.builder().nul(true).build()));
 
         assertEquals(Arrays.asList(new Set[] { null }),
-                unconvert("getSetList", "setSetList", new AttributeValue().withL(
-                        new AttributeValue().withNULL(true))));
+                unconvert("getSetList", "setSetList", AttributeValue.builder().l(
+                        AttributeValue.builder().nul(true).build()).build()));
 
         assertEquals(Arrays.asList(Collections.singleton("a")),
-                unconvert("getSetList", "setSetList", new AttributeValue().withL(
-                        new AttributeValue().withSS("a"))));
+                unconvert("getSetList", "setSetList", AttributeValue.builder().l(
+                        AttributeValue.builder().ss("a").build()).build()));
     }
 
     @Test
     public void testMap() {
         Assert.assertNull(unconvert("getMap", "setMap",
-                new AttributeValue().withNULL(true)));
+                AttributeValue.builder().nul(true).build()));
 
         assertEquals(new HashMap<String, String>() {{
                 put("a", "b");
                 put("c", "d");
             }},
-            unconvert("getMap", "setMap", new AttributeValue().withM(
+            unconvert("getMap", "setMap", AttributeValue.builder().m(
                     new HashMap<String, AttributeValue>() {{
-                        put("a", new AttributeValue("b"));
-                        put("c", new AttributeValue("d"));
-                    }})));
+                        put("a", AttributeValue.builder().s("b").build());
+                        put("c", AttributeValue.builder().s("d").build());
+                    }}).build()));
 
         assertEquals(new HashMap<String, String>() {{
                 put("a", null);
             }},
-            unconvert("getMap", "setMap", new AttributeValue().withM(
+            unconvert("getMap", "setMap", AttributeValue.builder().m(
                     new HashMap<String, AttributeValue>() {{
-                        put("a", new AttributeValue().withNULL(true));
-                    }})));
+                        put("a", AttributeValue.builder().nul(true).build());
+                    }}).build()));
     }
 
     @Test
     public void testSetMap() {
         Assert.assertNull(unconvert("getSetMap", "setSetMap",
-                new AttributeValue().withNULL(true)));
+                AttributeValue.builder().nul(true).build()));
 
         assertEquals(new HashMap<String, Set<String>>() {{
                 put("a", null);
                 put("b", new TreeSet<String>(Arrays.asList("a", "b")));
             }},
-            unconvert("getSetMap", "setSetMap", new AttributeValue().withM(
+            unconvert("getSetMap", "setSetMap", AttributeValue.builder().m(
                     new HashMap<String, AttributeValue>() {{
-                        put("a", new AttributeValue().withNULL(true));
-                        put("b", new AttributeValue().withSS("a", "b"));
-                    }})));
+                        put("a", AttributeValue.builder().nul(true).build());
+                        put("b", AttributeValue.builder().ss("a", "b").build());
+                    }}).build()));
     }
 
     @Test
     public void testObject() {
         Assert.assertNull(unconvert("getObject", "setObject",
-                new AttributeValue().withNULL(true)));
+                AttributeValue.builder().nul(true).build()));
 
         assertEquals(new SubClass(), unconvert("getObject", "setObject",
-                new AttributeValue().withM(new HashMap<String, AttributeValue>() {{
-                    put("name", new AttributeValue("name"));
-                    put("value", new AttributeValue().withN("123"));
-                }})));
+                AttributeValue.builder().m(new HashMap<String, AttributeValue>() {{
+                    put("name", AttributeValue.builder().s("name").build());
+                    put("value", AttributeValue.builder().n("123").build());
+                }}).build()));
 
         assertEquals(new SubClass(), unconvert("getObject", "setObject",
-                new AttributeValue().withM(new HashMap<String, AttributeValue>() {{
-                    put("name", new AttributeValue("name"));
-                    put("value", new AttributeValue().withN("123"));
-                    put("null", new AttributeValue().withNULL(true));
-                }})));
+                AttributeValue.builder().m(new HashMap<String, AttributeValue>() {{
+                    put("name", AttributeValue.builder().s("name").build());
+                    put("value", AttributeValue.builder().n("123").build());
+                    put("null", AttributeValue.builder().nul(true).build());
+                }}).build()));
     }
 
     @Test
@@ -446,7 +447,7 @@ public class StandardModelFactoriesV2UnconvertTest {
                 .getMethod("setChild", UnannotatedSubClass.class);
 
         try {
-            unconvert(UnannotatedSubClass.class, getter, setter, new AttributeValue().withS(""));
+            unconvert(UnannotatedSubClass.class, getter, setter, AttributeValue.builder().s("").build());
             Assert.fail("Expected DynamoDBMappingException");
         } catch (DynamoDBMappingException e) {
         }
@@ -455,10 +456,10 @@ public class StandardModelFactoriesV2UnconvertTest {
     @Test
     public void testS3Link() {
         S3Link link = (S3Link) unconvert("getS3Link", "setS3Link",
-                        new AttributeValue("{\"s3\":{"
+                        AttributeValue.builder().s("{\"s3\":{"
                                            + "\"bucket\":\"bucket\","
                                            + "\"key\":\"key\","
-                                           + "\"region\":null}}"));
+                                           + "\"region\":null}}").build());
 
         assertEquals("bucket", link.getBucketName());
         assertEquals("key", link.getKey());

--- a/services-custom/dynamodb-mapper/src/test/java/software/amazon/awssdk/mapper/dynamodb/TestParameters.java
+++ b/services-custom/dynamodb-mapper/src/test/java/software/amazon/awssdk/mapper/dynamodb/TestParameters.java
@@ -16,7 +16,7 @@ package software.amazon.awssdk.mapper.dynamodb;
 
 import java.util.Map;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 public class TestParameters<T>
         implements AttributeTransformer.Parameters<T> {

--- a/services-custom/dynamodb-mapper/src/test/java/software/amazon/awssdk/mapper/dynamodb/UnmarshallerTest.java
+++ b/services-custom/dynamodb-mapper/src/test/java/software/amazon/awssdk/mapper/dynamodb/UnmarshallerTest.java
@@ -17,7 +17,7 @@ package software.amazon.awssdk.mapper.dynamodb;
 import java.lang.reflect.Method;
 
 import com.amazonaws.auth.AWSCredentialsProvider;
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 public class UnmarshallerTest extends StandardModelFactoriesV2UnconvertTest {
 

--- a/services-custom/dynamodb-mapper/src/test/java/software/amazon/awssdk/mapper/dynamodb/V1MarshallerTest.java
+++ b/services-custom/dynamodb-mapper/src/test/java/software/amazon/awssdk/mapper/dynamodb/V1MarshallerTest.java
@@ -16,7 +16,7 @@ package software.amazon.awssdk.mapper.dynamodb;
 
 import java.lang.reflect.Method;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 public class V1MarshallerTest extends StandardModelFactoriesV1Test {
 

--- a/services-custom/dynamodb-mapper/src/test/java/software/amazon/awssdk/mapper/dynamodb/V2CompatMarshallerTest.java
+++ b/services-custom/dynamodb-mapper/src/test/java/software/amazon/awssdk/mapper/dynamodb/V2CompatMarshallerTest.java
@@ -16,7 +16,7 @@ package software.amazon.awssdk.mapper.dynamodb;
 
 import java.lang.reflect.Method;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 public class V2CompatMarshallerTest extends StandardModelFactoriesV2CompatibleTest {
 

--- a/services-custom/dynamodb-mapper/src/test/java/software/amazon/awssdk/mapper/dynamodb/V2MarshallerTest.java
+++ b/services-custom/dynamodb-mapper/src/test/java/software/amazon/awssdk/mapper/dynamodb/V2MarshallerTest.java
@@ -16,7 +16,7 @@ package software.amazon.awssdk.mapper.dynamodb;
 
 import java.lang.reflect.Method;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 public class V2MarshallerTest extends StandardModelFactoriesV2Test {
 


### PR DESCRIPTION
## Scope

This PR ports only the converter/marshalling layer of the v1 `DynamoDBMapper` to the v2 `AttributeValue` type (`software.amazon.awssdk.services.dynamodb.model.AttributeValue`). Every operation on `DynamoDBMapper` (load, save, query, scan, batch, transaction, tableAdmin) stays on v1 and is ported in later PRs.

**The PR does not compile** - The files that stay v1 (the two operation files, the paginated list classes that feed v1 results into v2 `toParameters`, and `DynamoDBMapperFieldModel`'s query condition methods) reference v1 types that no longer line up with the v2 converter surface, so those files are red. This keeps the diff scoped to the converter layer, and the subsequent operation PRs turn it green. 

This is intentional in order to make each PR review boundary conceptually separate and limits the diff. 

## Testing approach

- **Baseline on v1** - Run existing + new test against the v1 source before porting the types to v2
    - Existing converter tests all pass against the v1 source before any change
    - Added a new edge case suite (`StandardModelFactoriesEdgeCasesTest`) to widen coverage of the boundaries this migration touches (empty vs unset collections, binary roundtrips, boolean encodings, date formats)


- **Migrate the test bodies, not the assertions.** For each ported test we changed only the mechanical v1→v2 surface in the test body (`new AttributeValue().withS(x)` → `AttributeValue.builder().s(x).build()`, `getS()` → `s()`, and so on) The assertion logic stayed the same (aside from migrating the new types needed for assertion). A green run therefore means the v2 source produces the same result the v1 source did.
- **Running them despite the red module.** The `maven-compiler-plugin` `testIncludes` allowlist in `pom.xml` compiles only the converter tests. To execute them we temporarily stubbed the operation files (and their closure), compiled, and ran the suite: 287 passed, 0 failed. The stub was then reverted, restoring the red state.

## Changes

### Mechanical swap

#### 1. `set()`/`with()` → `builder().build()`
- v1 `AttributeValue` is mutable (`new AttributeValue().withS(x)`); 
- v2 is an immutable builder (`AttributeValue.builder().s(x).build()`). 

**Question** should we use the fast `createX()` factory methods added in #7039 here in this PR?
I decided to not port these here so we can measure performance against a baseline port vs performance improvement branch later.

#### 2. null vs empty — `has` guards

v2 `.l()`/`.m()`/`.ss()`/`.ns()`/`.bs()` return empty collections (not null) when unset. v2 added `hasL()`/`hasM()`/`hasSs()`/`hasNs()`/`hasBs()` to distinguish "explicitly empty" from "unset". Guards were added in the parent `typeCheck` methods (`LUnmarshaller`, `MUnmarshaller`, `SSUnmarshaller`, etc.), which run before `unmarshall` via `ConversionSchemas` dispatch. Pattern: `value.hasSs() ? value.ss() : null`.

#### 3. Boolean legacy `"1"/"0"` encoding

Old DynamoDB stored booleans as Number `"1"/"0"` before native `BOOL` existed. The reader accepts both and produces the same `Boolean`; the writer produces the number form.

`V2CompatibleBool.get`: `if (o.bool() != null) return o.bool() ? "1" : "0"; return o.n();`

Covered by `StandardModelFactoriesV2UnconvertTest` — `n("0")`/`n("1")`, `bool(false)`/`bool(true)`, and boolean set from `ns("1")`/`ns("0")`/`ns("0","1")`.

### Needs Reviewer Feedback:

#### 3. SdkBytes boundary

v1 binary is `java.nio.ByteBuffer`; v2 binary is `software.amazon.awssdk.core.SdkBytes`. On write, `SdkBytes.fromByteBuffer(bb)` copies the buffer and leaves the caller's position untouched, matching v1.

On read, POJO fields typed `ByteBuffer` must stay mutable to match v1's `getB()`. `SdkBytes` which AttributeValue uses internally, is immutable and exposes its bytes only as a readonly buffer (via `asByteBuffer()`) so every `ByteBuffer` read site returns `ByteBuffer.wrap(sdkBytes.asByteArray())`. **The copy costs one O(n) pass per read, so this path is slower than v1**

Returning `asByteBuffer()` is arguably the better, more v2 idiomatic choice, but if a v1 customer tries to mutate a buffer between reads and writes, the immutable implementation would throw `ReadOnlyBufferException` at runtime. 

As part of future work I plan to add an opt-in feature (field annotation or mapper config flag) that returns the readonly zero copy buffer instead of the mutable copy, for callers who never mutate and want to beat v1's read performance. Same `ByteBuffer` field type, behavior selected by the flag.

**Question** - Should we pursue backwards compatibility? Or limit potential performance regression? Or add support for it via future opt in flag? (supporting both cases)

#### 5. `MapperDateUtils.java` (new file)

The date converters format and parse ISO-8601 strings through two methods on v1's `com.amazonaws.util.DateUtils`. A v2 module can't depend on that class, and v2's `software.amazon.awssdk.utils.DateUtils` isn't equivalent: it works in `java.time.Instant` rather than `Date`, and its formatter omits zero milliseconds (`...T00:00:00Z` vs v1's `...T00:00:00.000Z`), so switching to it would change the stored string form of dates and break round-trip compatibility with v1 data.

`MapperDateUtils` ports only the two methods the converters use, on v1's Joda-Time formatters, to keep that format identical. A partial port is enough since the converter layer touches nothing else in `DateUtils`.

#### 6. MapperExceptions.java (new file) 

Both marshallers wrapped errors with v1's `Throwables.failure`, which a v2 module can't depend on. Instead we ported the `failure` function helper into a new class `MapperExceptions.java`

**Breaking change:** checked exceptions now wrap in `SdkClientException` instead of v1's `AmazonClientException`. The breaking change is unavoidable, so users who are explicitly error handling the v1 exception would have to update their code beyond the promised "import swap". 

**Question** - Is the name for this new class acceptable? Should we port this method as a standalone and throw it in some other util package we have in the SDK?

---

```diff
DDB mapper v2 roadmap

** BASE PACKAGE SETUP **
+ 1. Source verbatim port ✅
+ 2. Test verbatim port ✅
+ 3. Namespace swap (main + datamodeling tests) ✅ 
+ 4. Namespace swap (remaining test packages) ✅

** PORTING OPERATIONS **
0. converters (AttributeValue seam)  <---- current PR
1. load()
2. save()
3. query() + scan()
4. deleteItem()
5. updateItem()
6. Batch operations
7. Transactions
8. Misc

** PERFORMANCE IMPROVEMENTS **
1. getTableModel caching
2. Wire "fast" createX AV factory methods to convertors
3. ByteBuffer → SdkBytes copy
4. Others

** DEPENDENCY MODERNIZATION **
1. EasyMock -> Mockito
2. Log4j 1.x -> 2.x
3. commons-logging -> SLF4J
```