### PR TITLE
Allow duplicate keys in generated SIGNING_REGIONS_BY_REGION metadata

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-27d3007.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-27d3007.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "AWS SDK for Java v2",
+    "description": "Fixed an issue where duplicate signing-region endpoint keys in service metadata caused ServiceMetadata static initialization to fail with \"Duplicate keys are provided\". The generated SIGNING_REGIONS_BY_REGION map now tolerates duplicate keys.",
+    "contributor": ""
+}

--- a/codegen-lite/src/main/java/software/amazon/awssdk/codegen/lite/regions/ServiceMetadataGenerator.java
+++ b/codegen-lite/src/main/java/software/amazon/awssdk/codegen/lite/regions/ServiceMetadataGenerator.java
@@ -164,7 +164,7 @@ public class ServiceMetadataGenerator implements PoetClass {
     private CodeBlock signingRegionsByRegion(Partitions partitions) {
         Map<Partition, Service> services = getServiceData(partitions);
 
-        CodeBlock.Builder builder = CodeBlock.builder().add("$T.<$T, $T>builder()",
+        CodeBlock.Builder builder = CodeBlock.builder().add("$T.<$T, $T>builder().allowDuplicateKeys(true)",
                                                             ImmutableMap.class, serviceEndpointKeyClass(), String.class);
 
         services.forEach((partition, service) -> {

--- a/codegen-lite/src/test/resources/software/amazon/awssdk/codegen/lite/regions/s3-service-metadata.java
+++ b/codegen-lite/src/test/resources/software/amazon/awssdk/codegen/lite/regions/s3-service-metadata.java
@@ -41,6 +41,7 @@ public final class S3ServiceMetadata implements ServiceMetadata {
 
     private static final Map<ServiceEndpointKey, String> SIGNING_REGIONS_BY_REGION = ImmutableMap
         .<ServiceEndpointKey, String> builder()
+        .allowDuplicateKeys(true)
         .put(ServiceEndpointKey.builder().region(Region.of("aws-global")).build(), "us-east-1")
         .put(ServiceEndpointKey.builder().region(Region.of("fips-ca-central-1")).build(), "ca-central-1")
         .put(ServiceEndpointKey.builder().region(Region.of("fips-us-east-1")).build(), "us-east-1")

--- a/codegen-lite/src/test/resources/software/amazon/awssdk/codegen/lite/regions/sts-service-metadata.java
+++ b/codegen-lite/src/test/resources/software/amazon/awssdk/codegen/lite/regions/sts-service-metadata.java
@@ -41,6 +41,7 @@ public final class StsServiceMetadata implements ServiceMetadata {
 
     private static final Map<ServiceEndpointKey, String> SIGNING_REGIONS_BY_REGION = ImmutableMap
         .<ServiceEndpointKey, String> builder()
+        .allowDuplicateKeys(true)
         .put(ServiceEndpointKey.builder().region(Region.of("aws-global")).build(), "us-east-1")
         .put(ServiceEndpointKey.builder().region(Region.of("us-east-1-fips")).build(), "us-east-1")
         .put(ServiceEndpointKey.builder().region(Region.of("us-east-2-fips")).build(), "us-east-2")


### PR DESCRIPTION
Duplicate signing-region endpoint keys in a service's metadata cause the generated ServiceMetadata class to fail its static initializer with `IllegalArgumentException: Duplicate keys are provided`. Because metadata is loaded eagerly, this breaks any client construction, not just the affected service. The sibling HOSTNAMES_BY_REGION map already guards against this with `.allowDuplicateKeys(true)`.

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Modifications
- `ServiceMetadataGenerator.signingRegionsByRegion()` now emits `.allowDuplicateKeys(true)`, matching HOSTNAMES_BY_REGION.  
- Updated the s3/sts golden test fixtures for `RegionGenerationTest` to match.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
