### PR TITLE
test: add AsyncClientClass regression coverage

### DIFF
--- a/codegen/src/test/java/software/amazon/awssdk/codegen/poet/client/AsyncClientClassTest.java
+++ b/codegen/src/test/java/software/amazon/awssdk/codegen/poet/client/AsyncClientClassTest.java
@@ -16,6 +16,8 @@
 package software.amazon.awssdk.codegen.poet.client;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
 import static software.amazon.awssdk.codegen.poet.ClientTestModels.awsJsonServiceModels;
 import static software.amazon.awssdk.codegen.poet.ClientTestModels.awsQueryCompatibleJsonServiceModels;
 import static software.amazon.awssdk.codegen.poet.ClientTestModels.batchManagerModels;
@@ -32,10 +34,14 @@ import static software.amazon.awssdk.codegen.poet.ClientTestModels.rpcv2ServiceM
 import static software.amazon.awssdk.codegen.poet.ClientTestModels.xmlServiceModels;
 import static software.amazon.awssdk.codegen.poet.PoetMatchers.generatesTo;
 
+import com.squareup.javapoet.MethodSpec;
+import com.squareup.javapoet.TypeSpec;
+import java.io.IOException;
 import org.junit.Test;
 import software.amazon.awssdk.codegen.emitters.GeneratorTaskParams;
 import software.amazon.awssdk.codegen.model.intermediate.IntermediateModel;
 import software.amazon.awssdk.codegen.poet.ClassSpec;
+import software.amazon.awssdk.codegen.poet.PoetUtils;
 
 public class AsyncClientClassTest {
     @Test
@@ -122,7 +128,67 @@ public class AsyncClientClassTest {
         assertThat(asyncClientClass, generatesTo("test-custom-context-params-async-client-class.java"));
     }
 
+    @Test
+    public void asyncClientEndpointDiscovery_whenRequiredEndpointDiscoveryAllowsEndpointOverride_generatesFallbackAndWarning()
+        throws IOException {
+        IntermediateModel model = endpointDiscoveryModels();
+        model.getCustomizationConfig().setAllowEndpointOverrideForEndpointDiscoveryRequiredOperations(true);
+
+        String generatedClient = generateClass(createAsyncClientClass(model));
+
+        String requiredOperationOverrideFallback =
+            "if (endpointOverridden) {\n"
+            + "        endpointDiscoveryEnabled = false;\n"
+            + "      } else if (!endpointDiscoveryEnabled) {\n"
+            + "        throw new IllegalStateException(\"This operation requires endpoint discovery to be enabled, or for "
+            + "you to specify an endpoint override when the client is created.\");\n"
+            + "      }";
+        String constructorWarning =
+            "if (clientConfiguration.option(SdkClientOption.CLIENT_ENDPOINT_PROVIDER).isEndpointOverridden()) {\n"
+            + "        log.warn(\"Endpoint discovery is enabled for this client, and an endpoint override was also specified. "
+            + "This will disable endpoint discovery for methods that require it, instead using the specified endpoint override. "
+            + "This may or may not be what you intended.\");\n"
+            + "      }";
+
+        assertThat(generatedClient, containsString(requiredOperationOverrideFallback));
+        assertThat(generatedClient, containsString(constructorWarning));
+    }
+
+    @Test
+    public void asyncClientClass_withUtilitiesInstanceTypeAndExistingScheduledExecutor_addsExpectedCode() {
+        IntermediateModel utilitiesModel = awsJsonServiceModels();
+        utilitiesModel.getCustomizationConfig()
+                      .getUtilitiesMethod()
+                      .setInstanceType("software.amazon.awssdk.services.json.DefaultJsonUtilities");
+        AsyncClientClass asyncClientClassWithUtilities = createAsyncClientClass(utilitiesModel);
+
+        MethodSpec utilitiesMethod = asyncClientClassWithUtilities.utilitiesMethod();
+
+        String expectedUtilitiesStatement =
+            "return software.amazon.awssdk.services.json.DefaultJsonUtilities.create(param1,param2,param3);";
+        assertThat(utilitiesMethod.toString(), containsString(expectedUtilitiesStatement));
+
+        AsyncClientClass asyncClientClassWithWaiters = createAsyncClientClass(queryServiceModels());
+        TypeSpec.Builder typeBuilder = TypeSpec.classBuilder("Test");
+
+        asyncClientClassWithWaiters.addFields(typeBuilder);
+        asyncClientClassWithWaiters.addFields(typeBuilder);
+
+        long scheduledExecutorFieldCount = typeBuilder.build()
+                                                      .fieldSpecs
+                                                      .stream()
+                                                      .filter(f -> f.name.equals("executorService"))
+                                                      .count();
+        assertThat(scheduledExecutorFieldCount, equalTo(1L));
+    }
+
     private AsyncClientClass createAsyncClientClass(IntermediateModel model) {
         return new AsyncClientClass(GeneratorTaskParams.create(model, "sources/", "tests/", "resources/"));
+    }
+
+    private String generateClass(ClassSpec spec) throws IOException {
+        StringBuilder output = new StringBuilder();
+        PoetUtils.buildJavaFile(spec).writeTo(output);
+        return output.toString();
     }
 }


### PR DESCRIPTION

## Motivation and Context

Hey 👋

I added two regression tests for `AsyncClientClass` around async client generation behavior.

The endpoint-discovery override path, custom utilities generation, and repeated scheduled-executor field generation were not directly covered by the existing test suite.

## Modifications

* Added `asyncClientEndpointDiscovery_whenRequiredEndpointDiscoveryAllowsEndpointOverride_generatesFallbackAndWarning`.
* Added `asyncClientClass_withUtilitiesInstanceTypeAndExistingScheduledExecutor_addsExpectedCode`.

## Testing

These tests check that required endpoint discovery generates the expected fallback and warning when endpoint overrides are allowed, that utilities use the configured instance type, and that repeated field generation does not duplicate the scheduled executor.

Impact on coverage:

* Covers the endpoint-discovery [warning](https://github.com/aws/aws-sdk-java-v2/blob/f294ac6c6af6b60cc219b209f87735d1f27614e0/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/AsyncClientClass.java#L261-L268) and [fallback](https://github.com/aws/aws-sdk-java-v2/blob/f294ac6c6af6b60cc219b209f87735d1f27614e0/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/AsyncClientClass.java#L391-L398), plus [utilities generation](https://github.com/aws/aws-sdk-java-v2/blob/f294ac6c6af6b60cc219b209f87735d1f27614e0/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/AsyncClientClass.java#L510-L527) and [scheduled executor field generation](https://github.com/aws/aws-sdk-java-v2/blob/f294ac6c6af6b60cc219b209f87735d1f27614e0/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/AsyncClientClass.java#L605-L612).
* This improves line coverage for `AsyncClientClass` by about 4% and branch coverage by about 10%.

All 16 `AsyncClientClassTest` tests pass locally, and the targeted 46-module reactor package build succeeds.

## Screenshots (if appropriate)

Not applicable.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing targeted tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License

- [x] I confirm that this pull request can be released under the Apache 2 license

I hope you find these tests useful. Please let me know if you have any questions or concerns.

Thanks,
