### PR TITLE
Use profile when creating Signin service when using `login_session`

### DIFF
--- a/.changes/next-release/bugfix-AWSSignInService-a80fa43.json
+++ b/.changes/next-release/bugfix-AWSSignInService-a80fa43.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "AWS Sign-In Service",
+    "contributor": "",
+    "description": "Fixed an issue where credentials loaded from a login_session profile resolved the Signin client's configuration, such as region and endpoint_url, from the default profile instead of the profile that requested the credentials."
+}

--- a/services/signin/src/main/java/software/amazon/awssdk/services/signin/auth/LoginProfileCredentialsProviderFactory.java
+++ b/services/signin/src/main/java/software/amazon/awssdk/services/signin/auth/LoginProfileCredentialsProviderFactory.java
@@ -16,13 +16,17 @@
 package software.amazon.awssdk.services.signin.auth;
 
 import software.amazon.awssdk.annotations.SdkProtectedApi;
+import software.amazon.awssdk.annotations.SdkTestInternalApi;
+import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.ProfileCredentialsProviderFactory;
 import software.amazon.awssdk.auth.credentials.ProfileProviderCredentialsContext;
 import software.amazon.awssdk.profiles.Profile;
+import software.amazon.awssdk.profiles.ProfileFile;
 import software.amazon.awssdk.profiles.ProfileProperty;
 import software.amazon.awssdk.services.signin.SigninClient;
+import software.amazon.awssdk.services.signin.SigninClientBuilder;
 import software.amazon.awssdk.utils.IoUtils;
 import software.amazon.awssdk.utils.SdkAutoCloseable;
 
@@ -42,6 +46,23 @@ public class LoginProfileCredentialsProviderFactory implements ProfileCredential
         return new LoginProfileCredentialsProvider(profileProviderCredentialsContext);
     }
 
+    /**
+     * Create the {@link SigninClient} used to refresh the login session, configured from the profile that requested these
+     * credentials.
+     */
+    @SdkTestInternalApi
+    static SigninClient signinClient(ProfileProviderCredentialsContext credentialsContext) {
+        SigninClientBuilder builder = SigninClient.builder()
+                                                  .credentialsProvider(AnonymousCredentialsProvider.create());
+        ProfileFile profileFile = credentialsContext.profileFile();
+        if (profileFile != null) {
+            builder.overrideConfiguration(c -> c.defaultProfileFile(profileFile)
+                                                .defaultProfileName(credentialsContext.profile().name()));
+        }
+
+        return builder.build();
+    }
+
     private static class LoginProfileCredentialsProvider implements AwsCredentialsProvider, SdkAutoCloseable {
         private final LoginCredentialsProvider credentialsProvider;
         private final SigninClient signinClient;
@@ -51,7 +72,7 @@ public class LoginProfileCredentialsProviderFactory implements ProfileCredential
             String loginSession = profile.property(ProfileProperty.LOGIN_SESSION)
                                          .orElseThrow(() -> new IllegalArgumentException("login_session property is required"));
 
-            this.signinClient = SigninClient.create();
+            this.signinClient = signinClient(credentialsContext);
             this.credentialsProvider = LoginCredentialsProvider
                 .builder()
                 .loginSession(loginSession)

--- a/services/signin/src/test/java/software/amazon/awssdk/services/signin/auth/LoginProfileCredentialsProviderFactoryTest.java
+++ b/services/signin/src/test/java/software/amazon/awssdk/services/signin/auth/LoginProfileCredentialsProviderFactoryTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static software.amazon.awssdk.services.signin.auth.internal.DpopTestUtils.VALID_TEST_PEM;
 
+import java.net.URI;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.Optional;
@@ -33,12 +34,16 @@ import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
 import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.ProfileProviderCredentialsContext;
 import software.amazon.awssdk.auth.credentials.internal.ProfileCredentialsUtils;
+import software.amazon.awssdk.core.SdkSystemSetting;
 import software.amazon.awssdk.core.useragent.BusinessMetricFeatureId;
 import software.amazon.awssdk.profiles.ProfileFile;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.signin.SigninClient;
 import software.amazon.awssdk.services.signin.internal.AccessTokenManager;
 import software.amazon.awssdk.services.signin.internal.LoginAccessToken;
 import software.amazon.awssdk.services.signin.internal.LoginCacheDirectorySystemSetting;
 import software.amazon.awssdk.services.signin.internal.OnDiskTokenManager;
+import software.amazon.awssdk.testutils.EnvironmentVariableHelper;
 import software.amazon.awssdk.utils.StringInputStream;
 
 public class LoginProfileCredentialsProviderFactoryTest {
@@ -47,17 +52,20 @@ public class LoginProfileCredentialsProviderFactoryTest {
     @TempDir
     Path tempDir;
 
+    private final EnvironmentVariableHelper environmentVariables = new EnvironmentVariableHelper();
+
     private AccessTokenManager tokenManager;
 
     @BeforeEach
     public void setup() {
-        System.setProperty(new LoginCacheDirectorySystemSetting().property(), tempDir.toString());
+        environmentVariables.set(new LoginCacheDirectorySystemSetting(), tempDir.toString());
+        environmentVariables.remove(SdkSystemSetting.AWS_REGION);
         tokenManager = OnDiskTokenManager.create(tempDir, LOGIN_SESSION_ID);
     }
 
     @AfterEach
     public void teardown() {
-        System.clearProperty(new LoginCacheDirectorySystemSetting().property());
+        environmentVariables.reset();
     }
 
     @Test
@@ -67,15 +75,10 @@ public class LoginProfileCredentialsProviderFactoryTest {
         tokenManager.storeToken(token);
 
         ProfileFile profileFile = configFile("[profile foo]\n" +
+                                             "region=us-east-1\n" +
                                              "login_session=" + LOGIN_SESSION_ID + "\n");
 
-        AwsCredentialsProvider provider = new LoginProfileCredentialsProviderFactory().create(
-            ProfileProviderCredentialsContext
-                .builder()
-                .profile(profileFile.profile("foo").get())
-                .profileFile(profileFile)
-                .build()
-        );
+        AwsCredentialsProvider provider = new LoginProfileCredentialsProviderFactory().create(context(profileFile, "foo"));
 
         // validate the creds are from cached token file stored above
         AwsCredentials credentials = provider.resolveCredentials();
@@ -100,6 +103,7 @@ public class LoginProfileCredentialsProviderFactoryTest {
         tokenManager.storeToken(token);
 
         ProfileFile profileFile = configFile("[profile foo]\n" +
+                                             "region=us-east-1\n" +
                                              "login_session=" + LOGIN_SESSION_ID + "\n");
 
         ProfileCredentialsUtils profileCredentialsUtils = new ProfileCredentialsUtils(
@@ -120,6 +124,79 @@ public class LoginProfileCredentialsProviderFactoryTest {
         String expectedCredSource = BusinessMetricFeatureId.CREDENTIALS_PROFILE_LOGIN.value() + ","
                                     + BusinessMetricFeatureId.CREDENTIALS_LOGIN.value();
         assertEquals(expectedCredSource, resolvedCredentials.providerName().get());
+    }
+
+    @Test
+    public void signinClient_resolvesRegionFromContextProfile() {
+        ProfileFile profileFile = configFile("[default]\n" +
+                                             "region=us-east-1\n" +
+                                             "\n" +
+                                             "[profile foo]\n" +
+                                             "region=eu-west-2\n" +
+                                             "login_session=" + LOGIN_SESSION_ID + "\n");
+
+        try (SigninClient client = LoginProfileCredentialsProviderFactory.signinClient(context(profileFile, "foo"))) {
+            assertEquals(Region.EU_WEST_2, client.serviceClientConfiguration().region());
+        }
+    }
+
+    /**
+     * The profile is applied as the client's default profile, so it drives every setting the client loads from a profile, not
+     * just the region.
+     */
+    @Test
+    public void signinClient_resolvesNonRegionSettingsFromContextProfile() {
+        ProfileFile profileFile = configFile("[default]\n" +
+                                             "region=us-east-1\n" +
+                                             "\n" +
+                                             "[profile foo]\n" +
+                                             "region=us-east-1\n" +
+                                             "endpoint_url=https://signin.example.com\n" +
+                                             "login_session=" + LOGIN_SESSION_ID + "\n");
+
+        try (SigninClient client = LoginProfileCredentialsProviderFactory.signinClient(context(profileFile, "foo"))) {
+            assertEquals(URI.create("https://signin.example.com"),
+                         client.serviceClientConfiguration().endpointOverride().orElse(null));
+        }
+    }
+
+    @Test
+    public void signinClient_whenProfileFileMissingFromContext_fallsBackToDefaultConfiguration() {
+        ProfileFile profileFile = configFile("[profile foo]\n" +
+                                             "region=eu-west-2\n" +
+                                             "login_session=" + LOGIN_SESSION_ID + "\n");
+
+        ProfileProviderCredentialsContext context = ProfileProviderCredentialsContext
+            .builder()
+            .profile(profileFile.profile("foo").get())
+            .build();
+
+        environmentVariables.set(SdkSystemSetting.AWS_REGION, "us-east-1");
+        try (SigninClient client = LoginProfileCredentialsProviderFactory.signinClient(context)) {
+            assertEquals(Region.US_EAST_1, client.serviceClientConfiguration().region());
+        }
+    }
+
+    /**
+     * Region has higher-priority sources than the profile, and the profile override should not change that.
+     */
+    @Test
+    public void signinClient_whenRegionSetInSystemSettings_takesPriorityOverContextProfile() {
+        ProfileFile profileFile = configFile("[profile foo]\n" +
+                                             "region=eu-west-2\n" +
+                                             "login_session=" + LOGIN_SESSION_ID + "\n");
+
+        environmentVariables.set(SdkSystemSetting.AWS_REGION, "us-east-1");
+        try (SigninClient client = LoginProfileCredentialsProviderFactory.signinClient(context(profileFile, "foo"))) {
+            assertEquals(Region.US_EAST_1, client.serviceClientConfiguration().region());
+        }
+    }
+
+    private static ProfileProviderCredentialsContext context(ProfileFile profileFile, String profileName) {
+        return ProfileProviderCredentialsContext.builder()
+                                                .profile(profileFile.profile(profileName).get())
+                                                .profileFile(profileFile)
+                                                .build();
     }
 
     private static ProfileFile configFile(String configFile) {


### PR DESCRIPTION
Fix #7196 -  credentials loaded from a login_session profile resolved the Signin client's configuration, such as region and endpoint_url, from the default profile instead of the profile that requested the credentials.

## Motivation and Context
See #7196 - the `LoginProfileCredentialsProviderFactory` was creating its Signin service client without specifying  any profile based overrides. 

## Modifications
Plumb the context's profile file/profile name through Signin client creation.

## Testing
New and existing unit tests

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
