### PR TITLE
Add AddSmithyShapes base class to translate Smithy shapes into the codegen intermediate model

### DIFF
--- a/.brazil.json
+++ b/.brazil.json
@@ -157,6 +157,7 @@
         "software.amazon.ion:ion-java": { "packageName": "Maven-software-amazon-ion_ion-java", "packageVersion": "1.x" },
         "software.amazon.smithy:smithy-model": { "packageName": "Maven-software-amazon-smithy_smithy-model", "packageVersion": "1.x" },
         "software.amazon.smithy:smithy-aws-traits": { "packageName": "Maven-software-amazon-smithy_smithy-aws-traits", "packageVersion": "1.x" },
+        "software.amazon.smithy:smithy-rules-engine": { "packageName": "Maven-software-amazon-smithy_smithy-rules-engine", "packageVersion": "1.x" },
         "software.amazon:flow": { "packageName": "AwsFlowJava", "packageVersion": "1.0" },
         "org.junit.jupiter:junit-jupiter": { "packageName": "JUnit5", "packageVersion": "5.x" },
         "org.mockito:mockito-core": { "packageName": "Mockito", "packageVersion": "3.x" },

--- a/codegen/pom.xml
+++ b/codegen/pom.xml
@@ -183,6 +183,11 @@
             <artifactId>smithy-aws-traits</artifactId>
             <version>${smithy.version}</version>
         </dependency>
+        <dependency>
+            <groupId>software.amazon.smithy</groupId>
+            <artifactId>smithy-rules-engine</artifactId>
+            <version>${smithy.version}</version>
+        </dependency>
 
         <dependency>
             <artifactId>org.eclipse.jdt.core</artifactId>

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/naming/DefaultSmithyNamingStrategy.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/naming/DefaultSmithyNamingStrategy.java
@@ -161,6 +161,11 @@ public class DefaultSmithyNamingStrategy implements NamingStrategy {
     }
 
     @Override
+    public String getPresignedUrlPackageName(String serviceName) {
+        return getCustomizedPackageName(serviceName, Constant.PACKAGE_NAME_PRESIGNEDURL_PATTERN);
+    }
+
+    @Override
     public String getAuthSchemePackageName(String serviceName) {
         return getCustomizedPackageName(serviceName, Constant.PACKAGE_NAME_AUTH_SCHEME_PATTERN);
     }

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/smithy/AddSmithyShapes.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/smithy/AddSmithyShapes.java
@@ -111,7 +111,7 @@ abstract class AddSmithyShapes {
     /**
      * Structures that appear as members of any event stream reachable from
      * the service. An event stream is a {@link UnionShape} carrying
-     * {@link StreamingTrait}. Computed once at construction
+     * {@link StreamingTrait}. Computed once at construction.
      */
     private final Set<ShapeId> eventStructures;
 

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/smithy/AddSmithyShapes.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/smithy/AddSmithyShapes.java
@@ -79,9 +79,7 @@ import software.amazon.smithy.rulesengine.traits.ContextParamTrait;
  *
  * <p>Two methods do the work: {@link #generateShapeModel} builds a shape and
  * all of its members, and {@link #generateMemberModel} builds a single
- * member. Subclasses ({@link AddSmithyInputShapes}, {@link AddSmithyOutputShapes},
- * {@link AddSmithyExceptionShapes}, {@link AddSmithyModelShapes}) select which
- * shapes to translate and implement {@code IntermediateModelShapeProcessor}
+ * member. Concrete subclasses select which shapes to translate and implement {@code IntermediateModelShapeProcessor}
  * so they compose into a processor chain.
  *
  * <p>Where the Smithy model library already computes a fact, this class asks

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/smithy/AddSmithyShapes.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/smithy/AddSmithyShapes.java
@@ -111,7 +111,7 @@ abstract class AddSmithyShapes {
     /**
      * Structures that appear as members of any event stream reachable from
      * the service. An event stream is a {@link UnionShape} carrying
-     * {@link StreamingTrait}. Computed once at construction.
+     * {@link StreamingTrait}. Computed once at construction
      */
     private final Set<ShapeId> eventStructures;
 

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/smithy/AddSmithyShapes.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/smithy/AddSmithyShapes.java
@@ -577,6 +577,7 @@ abstract class AddSmithyShapes {
                     bindingLocationName = binding.getLocationName();
                     break;
                 case QUERY:
+                case QUERY_PARAMS:
                     location = Location.QUERY_STRING;
                     bindingLocationName = binding.getLocationName();
                     break;
@@ -594,10 +595,13 @@ abstract class AddSmithyShapes {
                 case RESPONSE_CODE:
                     location = Location.STATUS_CODE;
                     break;
-                default:
-                    // No explicit location: serialized in the body (DOCUMENT) or a binding not
-                    // mapped in the first-batch scope (e.g. QUERY_PARAMS).
+                case DOCUMENT:
+                case UNBOUND:
+                    // Body member: no HTTP location. Matches C2J, where an absent `location` is null.
                     break;
+                default:
+                    throw new IllegalArgumentException(
+                        "Unhandled HTTP binding location " + binding.getLocation() + " for member " + memberName);
             }
         }
 

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/smithy/AddSmithyShapes.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/smithy/AddSmithyShapes.java
@@ -1,0 +1,630 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.codegen.smithy;
+
+import static software.amazon.awssdk.codegen.internal.Utils.capitalize;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import software.amazon.awssdk.codegen.internal.TypeUtils;
+import software.amazon.awssdk.codegen.model.config.customization.CustomizationConfig;
+import software.amazon.awssdk.codegen.model.intermediate.EnumModel;
+import software.amazon.awssdk.codegen.model.intermediate.ListModel;
+import software.amazon.awssdk.codegen.model.intermediate.MapModel;
+import software.amazon.awssdk.codegen.model.intermediate.MemberModel;
+import software.amazon.awssdk.codegen.model.intermediate.ParameterHttpMapping;
+import software.amazon.awssdk.codegen.model.intermediate.Protocol;
+import software.amazon.awssdk.codegen.model.intermediate.ReturnTypeModel;
+import software.amazon.awssdk.codegen.model.intermediate.ShapeModel;
+import software.amazon.awssdk.codegen.model.intermediate.VariableModel;
+import software.amazon.awssdk.codegen.model.service.ContextParam;
+import software.amazon.awssdk.codegen.model.service.Location;
+import software.amazon.awssdk.codegen.model.service.XmlNamespace;
+import software.amazon.awssdk.codegen.naming.NamingStrategy;
+import software.amazon.awssdk.codegen.naming.ShapeInfo;
+import software.amazon.smithy.aws.traits.clientendpointdiscovery.ClientEndpointDiscoveryIdTrait;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.knowledge.HttpBinding;
+import software.amazon.smithy.model.knowledge.HttpBindingIndex;
+import software.amazon.smithy.model.knowledge.TopDownIndex;
+import software.amazon.smithy.model.shapes.EnumShape;
+import software.amazon.smithy.model.shapes.IntEnumShape;
+import software.amazon.smithy.model.shapes.ListShape;
+import software.amazon.smithy.model.shapes.MapShape;
+import software.amazon.smithy.model.shapes.MemberShape;
+import software.amazon.smithy.model.shapes.OperationShape;
+import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.shapes.UnionShape;
+import software.amazon.smithy.model.traits.DeprecatedTrait;
+import software.amazon.smithy.model.traits.DocumentationTrait;
+import software.amazon.smithy.model.traits.EnumValueTrait;
+import software.amazon.smithy.model.traits.ErrorTrait;
+import software.amazon.smithy.model.traits.EventHeaderTrait;
+import software.amazon.smithy.model.traits.EventPayloadTrait;
+import software.amazon.smithy.model.traits.IdempotencyTokenTrait;
+import software.amazon.smithy.model.traits.RequiredTrait;
+import software.amazon.smithy.model.traits.RequiresLengthTrait;
+import software.amazon.smithy.model.traits.RetryableTrait;
+import software.amazon.smithy.model.traits.SensitiveTrait;
+import software.amazon.smithy.model.traits.StreamingTrait;
+import software.amazon.smithy.model.traits.TimestampFormatTrait;
+import software.amazon.smithy.model.traits.XmlAttributeTrait;
+import software.amazon.smithy.model.traits.XmlFlattenedTrait;
+import software.amazon.smithy.model.traits.XmlNameTrait;
+import software.amazon.smithy.model.traits.XmlNamespaceTrait;
+import software.amazon.smithy.rulesengine.traits.ContextParamTrait;
+
+/**
+ * Shared base for the Smithy shape processors. Reads a Smithy {@link Model}
+ * and {@link ServiceShape} and produces {@link ShapeModel} and
+ * {@link MemberModel} objects for the intermediate model.
+ *
+ * <p>Two methods do the work: {@link #generateShapeModel} builds a shape and
+ * all of its members, and {@link #generateMemberModel} builds a single
+ * member. Subclasses ({@link AddSmithyInputShapes}, {@link AddSmithyOutputShapes},
+ * {@link AddSmithyExceptionShapes}, {@link AddSmithyModelShapes}) select which
+ * shapes to translate and implement {@code IntermediateModelShapeProcessor}
+ * so they compose into a processor chain.
+ *
+ * <p>Where the Smithy model library already computes a fact, this class asks
+ * the library rather than deriving it by hand:
+ * <ul>
+ *   <li>{@link HttpBindingIndex} resolves HTTP bindings and applies the
+ *       Smithy rule that binding traits are honored only on top-level
+ *       operation shapes.
+ *   <li>{@code @required} membership drives the shape's {@code required}
+ *       list and each member's {@code required} flag, matching C2J's
+ *       {@code required}-list semantics.
+ *   <li>{@link TopDownIndex} enumerates the operations reachable from the
+ *       service.
+ * </ul>
+ *
+ * <p>Event stream membership has no dedicated trait, so it is computed once
+ * at construction: a union carrying {@code @streaming} is an event stream,
+ * and the structures that appear as its members are events.
+ */
+abstract class AddSmithyShapes {
+
+    private final Model model;
+    private final ServiceShape service;
+    private final NamingStrategy namingStrategy;
+    private final CustomizationConfig customConfig;
+    private final String protocol;
+    private final TypeUtils typeUtils;
+
+    /**
+     * Structures that appear as members of any event stream reachable from
+     * the service. An event stream is a {@link UnionShape} carrying
+     * {@link StreamingTrait}. Computed once at construction.
+     */
+    private final Set<ShapeId> eventStructures;
+
+    AddSmithyShapes(Model model,
+                    ServiceShape service,
+                    NamingStrategy namingStrategy,
+                    CustomizationConfig customConfig,
+                    String protocol,
+                    TypeUtils typeUtils) {
+        this.model = model;
+        this.service = service;
+        this.namingStrategy = namingStrategy;
+        this.customConfig = customConfig;
+        this.protocol = protocol;
+        this.typeUtils = typeUtils;
+        this.eventStructures = collectEventStructures(model, service);
+    }
+
+    /**
+     * Walks every operation reachable from the service and collects the
+     * structure shape ids that appear as members of an event stream. The
+     * result lets {@link #generateShapeModel} set the event flag with a
+     * simple membership check instead of a reverse lookup per shape.
+     */
+    private static Set<ShapeId> collectEventStructures(Model model, ServiceShape service) {
+        Set<ShapeId> events = new HashSet<>();
+        TopDownIndex topDown = TopDownIndex.of(model);
+        for (OperationShape op : topDown.getContainedOperations(service)) {
+            collectEventStructuresFromShape(model, op.getInputShape(), events);
+            collectEventStructuresFromShape(model, op.getOutputShape(), events);
+        }
+        return events;
+    }
+
+    private static void collectEventStructuresFromShape(Model model, ShapeId shapeId, Set<ShapeId> events) {
+        if (shapeId == null) {
+            return;
+        }
+        Shape shape = model.getShape(shapeId).orElse(null);
+        if (shape == null || !shape.isStructureShape()) {
+            return;
+        }
+        for (MemberShape member : shape.members()) {
+            Shape target = model.expectShape(member.getTarget());
+            if (target.isUnionShape() && target.hasTrait(StreamingTrait.class)) {
+                for (MemberShape eventMember : target.asUnionShape().get().members()) {
+                    events.add(eventMember.getTarget());
+                }
+            }
+        }
+    }
+
+    protected final Model getModel() {
+        return model;
+    }
+
+    protected final ServiceShape getService() {
+        return service;
+    }
+
+    protected final NamingStrategy getNamingStrategy() {
+        return namingStrategy;
+    }
+
+    protected final CustomizationConfig getCustomConfig() {
+        return customConfig;
+    }
+
+    protected final String getProtocol() {
+        return protocol;
+    }
+
+    protected final TypeUtils getTypeUtils() {
+        return typeUtils;
+    }
+
+    /**
+     * Whether HTTP binding traits ({@code @http}, {@code @httpLabel}, {@code @httpQuery},
+     * {@code @httpHeader}, {@code @httpPayload}, ...) are honored for the resolved protocol. Only
+     * the REST protocols (rest-json, rest-xml) bind members to the HTTP request; the RPC protocols
+     * (awsJson, awsQuery, ec2Query, smithy-rpc-v2-cbor) ignore these traits.
+     *
+     * <p>A Smithy model may still carry {@code @http} bindings on an RPC service (for example a
+     * service whose model is also usable via a REST protocol). C2J's RPC models omit them, so the
+     * bindings must be ignored here for the IM to match C2J.
+     */
+    protected final boolean httpBindingsHonored() {
+        return Protocol.REST_JSON.getValue().equals(protocol)
+               || Protocol.REST_XML.getValue().equals(protocol);
+    }
+
+    /**
+     * Builds a {@link ShapeModel} from a Smithy shape, including all of its
+     * members. Shape-level metadata comes from traits where a matching trait
+     * exists (documentation, deprecation, XML namespace, error and retry
+     * information) and from the shape's kind where the concept is structural
+     * (union, event stream, enum values).
+     *
+     * <p>The caller sets {@code type}, {@code marshaller}, and
+     * {@code unmarshaller} after this method returns, since those depend on
+     * whether the shape is a request, response, exception, or plain model
+     * shape.
+     *
+     * @param javaClassName the Java class name for the shape, already
+     *                      resolved by the caller through the naming strategy.
+     * @param smithyShape   the shape being translated (structure, union,
+     *                      enum, or int enum).
+     * @param bindings      HTTP bindings for the enclosing operation, resolved
+     *                      by {@link HttpBindingIndex}, when {@code smithyShape}
+     *                      is a direct operation input, output, or error;
+     *                      {@code null} for nested model shapes, which carry
+     *                      no HTTP bindings.
+     */
+    protected ShapeModel generateShapeModel(String javaClassName,
+                                            Shape smithyShape,
+                                            Map<String, HttpBinding> bindings) {
+        ShapeModel shapeModel = new ShapeModel(smithyShape.getId().getName());
+        shapeModel.setShapeName(javaClassName);
+
+        shapeModel.setDocumentation(
+            smithyShape.getTrait(DocumentationTrait.class).map(DocumentationTrait::getValue).orElse(null));
+
+        shapeModel.setVariable(new VariableModel(namingStrategy.getVariableName(javaClassName), javaClassName));
+
+        List<String> required = new ArrayList<>();
+        for (MemberShape m : smithyShape.members()) {
+            if (m.hasTrait(RequiredTrait.class)) {
+                required.add(m.getMemberName());
+            }
+        }
+        shapeModel.setRequired(required.isEmpty() ? null : required);
+
+        smithyShape.getTrait(DeprecatedTrait.class).ifPresent(dep -> {
+            shapeModel.setDeprecated(true);
+            dep.getMessage().ifPresent(shapeModel::setDeprecatedMessage);
+        });
+
+        shapeModel.withIsUnion(smithyShape.isUnionShape());
+
+
+        boolean isEventStream = smithyShape.isUnionShape() && smithyShape.hasTrait(StreamingTrait.class);
+        shapeModel.withIsEventStream(isEventStream);
+        shapeModel.withIsEvent(eventStructures.contains(smithyShape.getId()));
+
+        smithyShape.getTrait(XmlNamespaceTrait.class)
+                   .ifPresent(ns -> shapeModel.withXmlNamespace(adaptXmlNamespace(ns)));
+
+
+        if (smithyShape.hasTrait(ErrorTrait.class)) {
+            ErrorTrait error = smithyShape.expectTrait(ErrorTrait.class);
+            shapeModel.withIsFault(error.isServerError());
+            if (smithyShape.hasTrait(RetryableTrait.class)) {
+                RetryableTrait retryable = smithyShape.expectTrait(RetryableTrait.class);
+                shapeModel.withIsRetryable(true);
+                shapeModel.withIsThrottling(retryable.getThrottling());
+            }
+        }
+
+
+        boolean hasHeaderMember = false;
+        boolean hasStatusCodeMember = false;
+        boolean hasPayloadMember = false;
+        boolean hasStreamingMember = false;
+        boolean hasRequiresLength = false;
+
+        // C2J models an enum as a string shape with an `enums` list and no members, so an enum
+        // shape's members (the enum entries) are emitted as EnumModels below, not as structural
+        // members here.
+        boolean isEnumShape = smithyShape instanceof EnumShape || smithyShape instanceof IntEnumShape;
+
+        if (!isEnumShape) {
+            for (MemberShape member : smithyShape.members()) {
+                MemberModel memberModel = generateMemberModel(member, smithyShape, bindings);
+                shapeModel.addMember(memberModel);
+
+                ParameterHttpMapping http = memberModel.getHttp();
+                if (http.getLocation() == Location.HEADER) {
+                    hasHeaderMember = true;
+                } else if (http.getLocation() == Location.STATUS_CODE) {
+                    hasStatusCodeMember = true;
+                } else if (http.getIsPayload()) {
+                    hasPayloadMember = true;
+                    if (http.getIsStreaming()) {
+                        hasStreamingMember = true;
+                    }
+                    if (http.isRequiresLength()) {
+                        hasRequiresLength = true;
+                    }
+                }
+            }
+        }
+
+        shapeModel.withHasHeaderMember(hasHeaderMember)
+                  .withHasStatusCodeMember(hasStatusCodeMember)
+                  .withHasPayloadMember(hasPayloadMember)
+                  .withHasStreamingMember(hasStreamingMember)
+                  .withHasRequiresLengthMember(hasRequiresLength);
+
+        // Only string enums become an EnumModel list. C2J has no int-enum concept, so an intEnum is
+        // a plain integer shape with no generated shape (see AddSmithyModelShapes).
+        if (smithyShape instanceof EnumShape) {
+            for (MemberShape enumMember : ((EnumShape) smithyShape).members()) {
+                String value = enumMember.expectTrait(EnumValueTrait.class).expectStringValue();
+                shapeModel.addEnum(new EnumModel(namingStrategy.getEnumValueName(value), value));
+            }
+        }
+
+        return shapeModel;
+    }
+
+    /**
+     * Adapts a Smithy {@link XmlNamespaceTrait} into the codegen
+     * {@link XmlNamespace} POJO expected by templates.
+     */
+    private static XmlNamespace adaptXmlNamespace(XmlNamespaceTrait trait) {
+        XmlNamespace ns = new XmlNamespace();
+        ns.setUri(trait.getUri());
+        trait.getPrefix().ifPresent(ns::setPrefix);
+        return ns;
+    }
+
+    /**
+     * Builds a {@link MemberModel} from a Smithy member shape.
+     *
+     * @param member the member being translated.
+     * @param parentShape the enclosing shape that contains {@code member},
+     *                    used by the naming strategy for reserved-name checks.
+     * @param bindings HTTP bindings for the enclosing shape, resolved by
+     *                 {@link HttpBindingIndex}. Non-null when the enclosing
+     *                 shape is a direct operation input, output, or error.
+     *                 Pass {@code null} for nested container members (list
+     *                 element, map key, map value), which carry no HTTP
+     *                 binding.
+     */
+    protected MemberModel generateMemberModel(MemberShape member,
+                                              Shape parentShape,
+                                              Map<String, HttpBinding> bindings) {
+        return generateMemberModel(member, parentShape, bindings, false);
+    }
+
+    /**
+     * @param containerElement true when {@code member} is a synthetic list element or map key/value.
+     *                         These carry the literal Smithy names {@code member}/{@code key}/
+     *                         {@code value}, which C2J keeps lower-case; the EC2 first-character
+     *                         upper-casing that regular (camelCase) members need must not apply to
+     *                         them.
+     */
+    private MemberModel generateMemberModel(MemberShape member,
+                                            Shape parentShape,
+                                            Map<String, HttpBinding> bindings,
+                                            boolean containerElement) {
+        String memberName = member.getMemberName();
+        Shape targetShape = model.expectShape(member.getTarget());
+
+        ShapeInfo parentCtx = ShapeInfo.ofSmithy(parentShape, model);
+        ShapeInfo shapeCtx = ShapeInfo.ofSmithy(targetShape, model);
+
+        String variableName = namingStrategy.getVariableName(memberName, parentCtx);
+        String variableType = typeUtils.getJavaDataType(model, targetShape);
+
+        String documentation = member.getTrait(DocumentationTrait.class)
+                                     .map(DocumentationTrait::getValue)
+                                     .orElse(null);
+
+        MemberModel memberModel = new MemberModel();
+        memberModel.withC2jName(memberName)
+                   .withC2jShape(targetShape.getId().getName())
+                   .withName(capitalize(memberName))
+                   .withVariable(new VariableModel(variableName, variableType, variableType)
+                                     .withDocumentation(documentation))
+                   .withSetterModel(new VariableModel(variableName, variableType, variableType))
+                   .withGetterModel(new ReturnTypeModel(variableType))
+                   .withTimestampFormat(resolveTimestampFormat(member, targetShape));
+
+        memberModel.setDocumentation(documentation);
+
+        memberModel.withFluentGetterMethodName(
+                       namingStrategy.getFluentGetterMethodName(memberName, parentCtx, shapeCtx))
+                   .withFluentEnumGetterMethodName(
+                       namingStrategy.getFluentEnumGetterMethodName(memberName, parentCtx, shapeCtx))
+                   .withFluentSetterMethodName(
+                       namingStrategy.getFluentSetterMethodName(memberName, parentCtx, shapeCtx))
+                   .withFluentEnumSetterMethodName(
+                       namingStrategy.getFluentEnumSetterMethodName(memberName, parentCtx, shapeCtx))
+                   .withExistenceCheckMethodName(
+                       namingStrategy.getExistenceCheckMethodName(memberName, parentCtx))
+                   .withBeanStyleGetterMethodName(
+                       namingStrategy.getBeanStyleGetterMethodName(memberName, parentCtx, shapeCtx))
+                   .withBeanStyleSetterMethodName(
+                       namingStrategy.getBeanStyleSetterMethodName(memberName, parentCtx, shapeCtx));
+        memberModel.setUnionEnumTypeName(namingStrategy.getUnionEnumTypeName(memberModel));
+
+        member.getTrait(DeprecatedTrait.class).ifPresent(dep -> {
+            memberModel.setDeprecated(true);
+            dep.getMessage().ifPresent(memberModel::setDeprecatedMessage);
+        });
+
+        // C2J's member `required` flag is membership in the shape's `required` list, which the
+        // C2J -> Smithy conversion expresses as the @required trait. Match that exactly rather than
+        // Smithy's richer nullability (NullableIndex), which folds in @default / @clientOptional and
+        // diverges from the C2J value the templates expect.
+        memberModel.setRequired(member.hasTrait(RequiredTrait.class));
+
+        memberModel.setSensitive(isSensitive(member, targetShape));
+
+        if (member.hasTrait(IdempotencyTokenTrait.class)) {
+            if (!variableType.equals(String.class.getSimpleName())) {
+                throw new IllegalArgumentException(memberName
+                    + " is idempotent. Its shape should be string type but it is of "
+                    + variableType + " type.");
+            }
+            memberModel.setIdempotencyToken(true);
+        }
+
+        memberModel.setEventPayload(member.hasTrait(EventPayloadTrait.class));
+        memberModel.setEventHeader(member.hasTrait(EventHeaderTrait.class));
+
+        memberModel.setXmlAttribute(member.hasTrait(XmlAttributeTrait.class));
+
+        member.getTrait(XmlNamespaceTrait.class)
+              .ifPresent(ns -> memberModel.setXmlNameSpaceUri(ns.getUri()));
+
+        member.getTrait(ContextParamTrait.class).ifPresent(cp -> {
+            ContextParam contextParam = new ContextParam();
+            contextParam.setName(cp.getName());
+            memberModel.setContextParam(contextParam);
+        });
+
+        memberModel.setEndpointDiscoveryId(member.hasTrait(ClientEndpointDiscoveryIdTrait.class));
+
+        // Only string enums map to a Java enum. C2J has no int-enum concept: an intEnum is written
+        // as a plain integer shape, so a member targeting one is a plain Integer with no enumType.
+        if (targetShape.isEnumShape()) {
+            memberModel.withEnumType(namingStrategy.getShapeClassName(targetShape.getId().getName()));
+        }
+
+        if (targetShape.isListShape()) {
+            memberModel.setListModel(buildListModel(targetShape.asListShape().get()));
+        } else if (targetShape.isMapShape()) {
+            memberModel.setMapModel(buildMapModel(targetShape.asMapShape().get()));
+        }
+
+        memberModel.setHttp(buildHttpMapping(member, targetShape, bindings, containerElement));
+
+        return memberModel;
+    }
+
+    /**
+     * Reports whether a member is sensitive. True when the member itself or
+     * its target is marked {@link SensitiveTrait}, or, for a list or map
+     * target, when the element, key, or value shape is marked sensitive.
+     */
+    private boolean isSensitive(MemberShape member, Shape targetShape) {
+        if (member.hasTrait(SensitiveTrait.class) || targetShape.hasTrait(SensitiveTrait.class)) {
+            return true;
+        }
+        if (targetShape.isListShape()) {
+            Shape listMember = model.expectShape(
+                targetShape.asListShape().get().getMember().getTarget());
+            return listMember.hasTrait(SensitiveTrait.class);
+        }
+        if (targetShape.isMapShape()) {
+            MapShape map = targetShape.asMapShape().get();
+            Shape key = model.expectShape(map.getKey().getTarget());
+            Shape value = model.expectShape(map.getValue().getTarget());
+            return key.hasTrait(SensitiveTrait.class) || value.hasTrait(SensitiveTrait.class);
+        }
+        return false;
+    }
+
+    /**
+     * Resolves the timestamp format for a member. The member's own trait takes
+     * precedence, followed by the trait on the target shape. The Smithy format
+     * name is converted to the name the intermediate model uses downstream.
+     */
+    private static String resolveTimestampFormat(MemberShape member, Shape targetShape) {
+        if (member.hasTrait(TimestampFormatTrait.class)) {
+            return smithyToSdkTimestampFormat(
+                member.expectTrait(TimestampFormatTrait.class).getValue());
+        }
+        if (targetShape.hasTrait(TimestampFormatTrait.class)) {
+            return smithyToSdkTimestampFormat(
+                targetShape.expectTrait(TimestampFormatTrait.class).getValue());
+        }
+        return null;
+    }
+
+    private static String smithyToSdkTimestampFormat(String smithyFormat) {
+        switch (smithyFormat) {
+            case TimestampFormatTrait.DATE_TIME:
+                return "iso8601";
+            case TimestampFormatTrait.EPOCH_SECONDS:
+                return "unixTimestamp";
+            case TimestampFormatTrait.HTTP_DATE:
+                return "rfc822";
+            default:
+                return smithyFormat;
+        }
+    }
+
+    private ListModel buildListModel(ListShape listShape) {
+        MemberShape listMember = listShape.getMember();
+        Shape targetShape = model.expectShape(listMember.getTarget());
+
+        // Nested container members carry no HTTP binding, so pass null bindings.
+        MemberModel elementMember = generateMemberModel(listMember, listShape, null, true);
+
+        String elementType = typeUtils.getJavaDataType(model, targetShape);
+        String listImpl = TypeUtils.getDataTypeMapping(TypeUtils.TypeKey.LIST_DEFAULT_IMPL);
+        String listIface = TypeUtils.getDataTypeMapping(TypeUtils.TypeKey.LIST_INTERFACE);
+
+        String memberLocationName = listMember.getTrait(XmlNameTrait.class)
+                                              .map(XmlNameTrait::getValue)
+                                              .orElse(null);
+
+        return new ListModel(elementType, memberLocationName, listImpl, listIface, elementMember);
+    }
+
+    private MapModel buildMapModel(MapShape mapShape) {
+        MemberShape keyMember = mapShape.getKey();
+        MemberShape valueMember = mapShape.getValue();
+
+        MemberModel keyModel = generateMemberModel(keyMember, mapShape, null, true);
+        MemberModel valueModel = generateMemberModel(valueMember, mapShape, null, true);
+
+        String mapImpl = TypeUtils.getDataTypeMapping(TypeUtils.TypeKey.MAP_DEFAULT_IMPL);
+        String mapIface = TypeUtils.getDataTypeMapping(TypeUtils.TypeKey.MAP_INTERFACE);
+
+        String keyLocation = keyMember.getTrait(XmlNameTrait.class)
+                                      .map(XmlNameTrait::getValue)
+                                      .orElse("key");
+        String valueLocation = valueMember.getTrait(XmlNameTrait.class)
+                                          .map(XmlNameTrait::getValue)
+                                          .orElse("value");
+
+        return new MapModel(mapImpl, mapIface, keyLocation, keyModel, valueLocation, valueModel);
+    }
+
+    /**
+     * Builds the HTTP mapping for a member from the resolved
+     * {@link HttpBindingIndex} bindings. When {@code bindings} is null, the
+     * member belongs to a nested container and no HTTP location applies,
+     * which is consistent with the Smithy rule that binding traits are
+     * honored only on top-level operation shapes.
+     */
+    private ParameterHttpMapping buildHttpMapping(MemberShape member,
+                                                  Shape targetShape,
+                                                  Map<String, HttpBinding> bindings,
+                                                  boolean containerElement) {
+        ParameterHttpMapping mapping = new ParameterHttpMapping();
+        String memberName = member.getMemberName();
+
+        HttpBinding binding = bindings != null ? bindings.get(memberName) : null;
+
+        Location location = null;
+        String bindingLocationName = null;
+        boolean isPayload = false;
+
+        if (binding != null) {
+            switch (binding.getLocation()) {
+                case HEADER:
+                    location = Location.HEADER;
+                    bindingLocationName = binding.getLocationName();
+                    break;
+                case QUERY:
+                    location = Location.QUERY_STRING;
+                    bindingLocationName = binding.getLocationName();
+                    break;
+                case LABEL:
+                    location = Location.URI;
+                    bindingLocationName = binding.getLocationName();
+                    break;
+                case PAYLOAD:
+                    isPayload = true;
+                    break;
+                case PREFIX_HEADERS:
+                    location = Location.HEADERS;
+                    bindingLocationName = binding.getLocationName();
+                    break;
+                case RESPONSE_CODE:
+                    location = Location.STATUS_CODE;
+                    break;
+                default:
+                    // No explicit location: serialized in the body (DOCUMENT) or a binding not
+                    // mapped in the first-batch scope (e.g. QUERY_PARAMS).
+                    break;
+            }
+        }
+
+        String marshallLocationName =
+            SmithyWireNames.marshallLocationName(protocol, member, memberName, bindingLocationName, containerElement);
+        String unmarshallLocationName =
+            SmithyWireNames.unmarshallLocationName(protocol, member, memberName, bindingLocationName);
+
+        boolean streaming = targetShape.hasTrait(StreamingTrait.class);
+        boolean requiresLength = targetShape.hasTrait(RequiresLengthTrait.class)
+                                 || member.hasTrait(RequiresLengthTrait.class);
+        boolean flattened = member.hasTrait(XmlFlattenedTrait.class)
+                            || targetShape.hasTrait(XmlFlattenedTrait.class);
+
+        // TODO(smithy-migration): isGreedy is left false. It applies only to @httpLabel members
+        // bound to a greedy URI segment ({member+}) and requires threading the operation's request
+        // URI into this per-member builder. Zero first-batch impact; needed for the S3 family.
+        mapping.withLocation(location)
+               .withPayload(isPayload)
+               .withStreaming(streaming)
+               .withRequiresLength(requiresLength)
+               .withFlattened(flattened)
+               .withUnmarshallLocationName(unmarshallLocationName)
+               .withMarshallLocationName(marshallLocationName);
+
+        return mapping;
+    }
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/smithy/SmithyWireNames.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/smithy/SmithyWireNames.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.codegen.smithy;
+
+import software.amazon.awssdk.codegen.model.intermediate.Protocol;
+import software.amazon.awssdk.utils.StringUtils;
+import software.amazon.smithy.aws.traits.protocols.Ec2QueryNameTrait;
+import software.amazon.smithy.model.shapes.MemberShape;
+import software.amazon.smithy.model.traits.JsonNameTrait;
+import software.amazon.smithy.model.traits.XmlNameTrait;
+
+/**
+ * Resolves a member's per-protocol wire names ({@code marshallLocationName} /
+ * {@code unmarshallLocationName}). Smithy counterpart to C2J's {@code AddShapes} {@code derive*LocationName}
+ * methods.
+ */
+final class SmithyWireNames {
+
+    private SmithyWireNames() {
+    }
+
+    /**
+     * Wire name used when writing a member. EC2 has its own rule (see {@link #deriveEc2MarshallName});
+     * other protocols use the name-override trait, then the HTTP binding location name, then the
+     * member name.
+     */
+    static String marshallLocationName(String protocol,
+                                       MemberShape member,
+                                       String memberName,
+                                       String bindingLocationName,
+                                       boolean containerElement) {
+        if (Protocol.EC2.getValue().equalsIgnoreCase(protocol)) {
+            return deriveEc2MarshallName(member, memberName, containerElement);
+        }
+        return traitOrBindingName(protocol, member, bindingLocationName, memberName);
+    }
+
+    /**
+     * Wire name used when reading a member: name-override trait, then HTTP binding location name,
+     * then the member name.
+     */
+    static String unmarshallLocationName(String protocol,
+                                         MemberShape member,
+                                         String memberName,
+                                         String bindingLocationName) {
+        return traitOrBindingName(protocol, member, bindingLocationName, memberName);
+    }
+
+    private static String traitOrBindingName(String protocol,
+                                             MemberShape member,
+                                             String bindingLocationName,
+                                             String memberName) {
+        String traitName = memberNameOverride(protocol, member);
+        if (StringUtils.isNotBlank(traitName)) {
+            return traitName;
+        }
+        if (StringUtils.isNotBlank(bindingLocationName)) {
+            return bindingLocationName;
+        }
+        return memberName;
+    }
+
+    /**
+     * Protocol-appropriate wire-name override, or {@code null} if none. XML protocols (rest-xml, ec2)
+     * use {@code @xmlName}; JSON protocols use {@code @jsonName}. {@code query} is omitted for now: it
+     * also needs C2J's {@code queryName} precedence, which has no Smithy trait wired yet.
+     */
+    private static String memberNameOverride(String protocol, MemberShape member) {
+        if (Protocol.REST_XML.getValue().equalsIgnoreCase(protocol)
+            || Protocol.EC2.getValue().equalsIgnoreCase(protocol)) {
+            return member.getTrait(XmlNameTrait.class).map(XmlNameTrait::getValue).orElse(null);
+        }
+        if (Protocol.REST_JSON.getValue().equalsIgnoreCase(protocol)
+            || Protocol.AWS_JSON.getValue().equalsIgnoreCase(protocol)) {
+            return member.getTrait(JsonNameTrait.class).map(JsonNameTrait::getValue).orElse(null);
+        }
+        return null;
+    }
+
+    /**
+     * EC2 marshall wire name: {@code @ec2QueryName} verbatim, else {@code @xmlName} or the member
+     * name with its first character upper-cased (mirrors C2J's {@code deriveLocationNameForEc2}).
+     * A synthetic list element / map key / value ({@code containerElement}) keeps its literal
+     * lower-case name, matching C2J.
+     */
+    private static String deriveEc2MarshallName(MemberShape member, String memberName, boolean containerElement) {
+        String ec2QueryName = member.getTrait(Ec2QueryNameTrait.class)
+                                    .map(Ec2QueryNameTrait::getValue)
+                                    .orElse(null);
+        if (StringUtils.isNotBlank(ec2QueryName)) {
+            return ec2QueryName;
+        }
+        String xmlName = member.getTrait(XmlNameTrait.class)
+                               .map(XmlNameTrait::getValue)
+                               .orElse(null);
+        if (StringUtils.isNotBlank(xmlName)) {
+            return upperCaseFirst(xmlName);
+        }
+        if (containerElement) {
+            return memberName;
+        }
+        return upperCaseFirst(memberName);
+    }
+
+    private static String upperCaseFirst(String value) {
+        return Character.toUpperCase(value.charAt(0)) + value.substring(1);
+    }
+}

--- a/codegen/src/test/java/software/amazon/awssdk/codegen/smithy/AddSmithyShapesMemberModelTest.java
+++ b/codegen/src/test/java/software/amazon/awssdk/codegen/smithy/AddSmithyShapesMemberModelTest.java
@@ -1,0 +1,633 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.codegen.smithy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.codegen.internal.TypeUtils;
+import software.amazon.awssdk.codegen.model.config.customization.CustomizationConfig;
+import software.amazon.awssdk.codegen.model.intermediate.MemberModel;
+import software.amazon.awssdk.codegen.model.service.Location;
+import software.amazon.awssdk.codegen.naming.DefaultSmithyNamingStrategy;
+import software.amazon.awssdk.codegen.naming.NamingStrategy;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.knowledge.HttpBinding;
+import software.amazon.smithy.model.knowledge.HttpBindingIndex;
+import software.amazon.smithy.model.shapes.MemberShape;
+import software.amazon.smithy.model.shapes.OperationShape;
+import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.shapes.StructureShape;
+
+/**
+ * Unit tests for {@code AddSmithyShapes.generateMemberModel}.
+ *
+ * <p>Each test constructs a tiny Smithy model containing a service and the
+ * shape(s) under test, invokes the translator via a package-private probe
+ * subclass, and asserts specific {@link MemberModel} fields. Nothing runs
+ * through the full IntermediateModel builder — that first end-to-end
+ * signal is PR 5's job.
+ */
+class AddSmithyShapesMemberModelTest {
+
+    private static final String USES =
+        "use aws.api#service\n"
+        + "use aws.auth#sigv4\n"
+        + "use aws.protocols#restJson1\n"
+        + "use aws.protocols#ec2QueryName\n"
+        + "\n";
+
+    private static final String SERVICE_HEADER =
+        "@service(sdkId: \"Demo\", arnNamespace: \"demo\")\n"
+        + "@restJson1\n"
+        + "@sigv4(name: \"demo\")\n"
+        + "service DemoService { version: \"2024-01-01\" }\n\n";
+
+    private static final String SERVICE_HEADER_WITH_OP =
+        "@service(sdkId: \"Demo\", arnNamespace: \"demo\")\n"
+        + "@restJson1\n"
+        + "@sigv4(name: \"demo\")\n"
+        + "service DemoService { version: \"2024-01-01\", operations: [Op] }\n\n";
+
+    /**
+     * Concrete probe subclass — {@code AddSmithyShapes} is abstract so tests
+     * need a way to invoke the protected translator without a real processor.
+     */
+    private static final class Probe extends AddSmithyShapes {
+        Probe(Model model, ServiceShape service, String protocol) {
+            super(model,
+                  service,
+                  new DefaultSmithyNamingStrategy(model, service, CustomizationConfig.create()),
+                  CustomizationConfig.create(),
+                  protocol,
+                  new TypeUtils(namingStrategyFor(model, service)));
+        }
+
+        MemberModel translate(MemberShape member,
+                              Shape parentShape,
+                              Map<String, HttpBinding> bindings) {
+            return generateMemberModel(member, parentShape, bindings);
+        }
+
+        private static NamingStrategy namingStrategyFor(Model model, ServiceShape service) {
+            return new DefaultSmithyNamingStrategy(model, service, CustomizationConfig.create());
+        }
+    }
+
+    /**
+     * Builds a Smithy model wrapping {@code body} in a demo service.
+     */
+    private static Model modelOf(String body) {
+        return modelOf(SERVICE_HEADER, body);
+    }
+
+    private static Model modelWithOp(String body) {
+        return modelOf(SERVICE_HEADER_WITH_OP, body);
+    }
+
+    private static Model modelOf(String header, String body) {
+        return Model.assembler()
+                    .discoverModels(Model.class.getClassLoader())
+                    .addUnparsedModel("test.smithy",
+                                      "$version: \"2.0\"\nnamespace demo\n\n" + USES + header + body)
+                    .assemble()
+                    .unwrap();
+    }
+
+    private static Probe probe(Model model, String protocol) {
+        return new Probe(model, model.getServiceShapes().iterator().next(), protocol);
+    }
+
+    private static StructureShape struct(Model model, String name) {
+        return model.expectShape(ShapeId.from("demo#" + name), StructureShape.class);
+    }
+
+    private static Map<String, HttpBinding> requestBindings(Model model, String opName) {
+        return HttpBindingIndex.of(model).getRequestBindings(
+            model.expectShape(ShapeId.from("demo#" + opName), OperationShape.class).getId());
+    }
+
+    // ---- Naming, scalars, documentation -----------------------------------
+
+    @Test
+    void scalarMember_populatesNamesAndVariableModel() {
+        Model model = modelOf(
+            "structure Parent {\n"
+            + "    /// A friendly description.\n"
+            + "    tableName: String\n"
+            + "}\n");
+        Probe probe = probe(model, "rest-json");
+
+        StructureShape parent = struct(model, "Parent");
+        MemberShape member = parent.getMember("tableName").get();
+
+        MemberModel mm = probe.translate(member, parent, null);
+
+        assertThat(mm.getC2jName()).isEqualTo("tableName");
+        assertThat(mm.getC2jShape()).isEqualTo("String");
+        assertThat(mm.getName()).isEqualTo("TableName");
+        assertThat(mm.getVariable().getVariableName()).isEqualTo("tableName");
+        assertThat(mm.getVariable().getVariableType()).isEqualTo("String");
+        assertThat(mm.getDocumentation()).isEqualTo("A friendly description.");
+    }
+
+    // ---- Required / nullable ----------------------------------------------
+
+    @Test
+    void requiredMember_setRequiredTrue() {
+        Model model = modelOf(
+            "structure Parent {\n"
+            + "    @required\n"
+            + "    id: String\n"
+            + "}\n");
+        MemberModel mm = probe(model, "rest-json").translate(
+            struct(model, "Parent").getMember("id").get(), struct(model, "Parent"), null);
+        assertThat(mm.isRequired()).isTrue();
+    }
+
+    @Test
+    void optionalMember_setRequiredFalse() {
+        Model model = modelOf(
+            "structure Parent { id: String }\n");
+        MemberModel mm = probe(model, "rest-json").translate(
+            struct(model, "Parent").getMember("id").get(), struct(model, "Parent"), null);
+        assertThat(mm.isRequired()).isFalse();
+    }
+
+    // ---- Deprecated -------------------------------------------------------
+
+    @Test
+    void deprecatedMember_carriesFlagAndMessage() {
+        Model model = modelOf(
+            "structure Parent {\n"
+            + "    @deprecated(message: \"use newerField\")\n"
+            + "    oldField: String\n"
+            + "}\n");
+        MemberModel mm = probe(model, "rest-json").translate(
+            struct(model, "Parent").getMember("oldField").get(), struct(model, "Parent"), null);
+        assertThat(mm.isDeprecated()).isTrue();
+        assertThat(mm.getDeprecatedMessage()).isEqualTo("use newerField");
+    }
+
+    // ---- Sensitive --------------------------------------------------------
+
+    // Smithy's @sensitive trait applies to shapes only (not members). The
+    // translator's isSensitive helper checks the member for parity with C2J
+    // (where sensitive could appear on either), but real Smithy models
+    // express sensitivity on the target shape only.
+    @Test
+    void sensitiveOnTarget_carriesFlag() {
+        Model model = modelOf(
+            "@sensitive string SecretString\n"
+            + "structure Parent { secret: SecretString }\n");
+        MemberModel mm = probe(model, "rest-json").translate(
+            struct(model, "Parent").getMember("secret").get(), struct(model, "Parent"), null);
+        assertThat(mm.isSensitive()).isTrue();
+    }
+
+    @Test
+    void sensitiveOnListElementTarget_carriesFlag() {
+        Model model = modelOf(
+            "@sensitive string SecretString\n"
+            + "list SecretList { member: SecretString }\n"
+            + "structure Parent { secrets: SecretList }\n");
+        MemberModel mm = probe(model, "rest-json").translate(
+            struct(model, "Parent").getMember("secrets").get(), struct(model, "Parent"), null);
+        assertThat(mm.isSensitive()).isTrue();
+    }
+
+    // ---- Idempotency token ------------------------------------------------
+
+    @Test
+    void idempotencyToken_onStringMember_isMarked() {
+        Model model = modelOf(
+            "structure Parent {\n"
+            + "    @idempotencyToken\n"
+            + "    token: String\n"
+            + "}\n");
+        MemberModel mm = probe(model, "rest-json").translate(
+            struct(model, "Parent").getMember("token").get(), struct(model, "Parent"), null);
+        assertThat(mm.isIdempotencyToken()).isTrue();
+    }
+
+    // Note: Smithy's own IdempotencyTokenTrait selector already rejects
+    // non-string targets at model-assembly time, so the runtime check inside
+    // generateMemberModel is a defense-in-depth guard rather than a
+    // reachable failure path. No unit test needed here.
+
+    // ---- Timestamp format translation -------------------------------------
+
+    @Test
+    void timestampFormat_smithyNamesTranslateToC2jNames() {
+        Model model = modelOf(
+            "structure Parent {\n"
+            + "    @timestampFormat(\"date-time\")   iso: Timestamp\n"
+            + "    @timestampFormat(\"epoch-seconds\") epoch: Timestamp\n"
+            + "    @timestampFormat(\"http-date\")   http: Timestamp\n"
+            + "}\n");
+        Probe p = probe(model, "rest-json");
+        StructureShape parent = struct(model, "Parent");
+
+        assertThat(p.translate(parent.getMember("iso").get(), parent, null).getTimestampFormat())
+            .isEqualTo("iso8601");
+        assertThat(p.translate(parent.getMember("epoch").get(), parent, null).getTimestampFormat())
+            .isEqualTo("unixTimestamp");
+        assertThat(p.translate(parent.getMember("http").get(), parent, null).getTimestampFormat())
+            .isEqualTo("rfc822");
+    }
+
+    // ---- Enum type reference ----------------------------------------------
+
+    @Test
+    void enumTarget_setsEnumTypeAndKeepsVariableTypeAsString() {
+        Model model = modelOf(
+            "enum Status { A, B }\n"
+            + "structure Parent { status: Status }\n");
+        MemberModel mm = probe(model, "rest-json").translate(
+            struct(model, "Parent").getMember("status").get(), struct(model, "Parent"), null);
+
+        assertThat(mm.getEnumType()).isEqualTo("Status");
+        assertThat(mm.getVariable().getVariableType()).isEqualTo("String");
+    }
+
+    @Test
+    void intEnumTarget_treatedAsPlainInteger_noEnumType() {
+        // C2J has no int-enum concept: an intEnum target is a plain integer. The member must be a
+        // plain Integer with no enumType, matching what C2J produces for the same field.
+        Model model = modelOf(
+            "intEnum Priority {\n"
+            + "    LOW = 1\n"
+            + "    HIGH = 2\n"
+            + "}\n"
+            + "structure Parent { priority: Priority }\n");
+        MemberModel mm = probe(model, "rest-json").translate(
+            struct(model, "Parent").getMember("priority").get(), struct(model, "Parent"), null);
+
+        assertThat(mm.getEnumType()).isNull();
+        assertThat(mm.getVariable().getVariableType()).isEqualTo("Integer");
+    }
+
+    // ---- List / map -------------------------------------------------------
+
+    @Test
+    void listTarget_populatesListModelWithElementMember() {
+        Model model = modelOf(
+            "list StringList { member: String }\n"
+            + "structure Parent { items: StringList }\n");
+        MemberModel mm = probe(model, "rest-json").translate(
+            struct(model, "Parent").getMember("items").get(), struct(model, "Parent"), null);
+
+        assertThat(mm.getListModel()).isNotNull();
+        assertThat(mm.getListModel().getMemberType()).isEqualTo("String");
+        assertThat(mm.getListModel().getListMemberModel().getC2jName()).isEqualTo("member");
+    }
+
+    @Test
+    void mapTarget_populatesMapModelWithKeyAndValueMembers() {
+        Model model = modelOf(
+            "map StringMap { key: String, value: String }\n"
+            + "structure Parent { entries: StringMap }\n");
+        MemberModel mm = probe(model, "rest-json").translate(
+            struct(model, "Parent").getMember("entries").get(), struct(model, "Parent"), null);
+
+        assertThat(mm.getMapModel()).isNotNull();
+        assertThat(mm.getMapModel().getKeyModel().getC2jName()).isEqualTo("key");
+        assertThat(mm.getMapModel().getValueModel().getC2jName()).isEqualTo("value");
+    }
+
+    // ---- HTTP bindings ----------------------------------------------------
+
+    @Test
+    void httpHeader_locationAndName_populated() {
+        Model model = modelWithOp(
+            "@http(method: \"GET\", uri: \"/things\")\n"
+            + "operation Op { input: In, output: Out }\n"
+            + "structure In {\n"
+            + "    @httpHeader(\"X-Trace-Id\")\n"
+            + "    trace: String\n"
+            + "}\n"
+            + "structure Out {}\n");
+        MemberModel mm = probe(model, "rest-json").translate(
+            struct(model, "In").getMember("trace").get(),
+            struct(model, "In"),
+            requestBindings(model, "Op"));
+
+        assertThat(mm.getHttp().getLocation()).isEqualTo(Location.HEADER);
+        assertThat(mm.getHttp().getMarshallLocationName()).isEqualTo("X-Trace-Id");
+        assertThat(mm.getHttp().getUnmarshallLocationName()).isEqualTo("X-Trace-Id");
+    }
+
+    @Test
+    void httpLabel_mapsToUriLocation() {
+        Model model = modelWithOp(
+            "@http(method: \"GET\", uri: \"/things/{id}\")\n"
+            + "operation Op { input: In, output: Out }\n"
+            + "structure In {\n"
+            + "    @required @httpLabel\n"
+            + "    id: String\n"
+            + "}\n"
+            + "structure Out {}\n");
+        MemberModel mm = probe(model, "rest-json").translate(
+            struct(model, "In").getMember("id").get(),
+            struct(model, "In"),
+            requestBindings(model, "Op"));
+
+        assertThat(mm.getHttp().getLocation()).isEqualTo(Location.URI);
+    }
+
+    @Test
+    void httpPayload_setsPayloadFlagAndClearsLocation() {
+        Model model = modelWithOp(
+            "@http(method: \"PUT\", uri: \"/things\")\n"
+            + "operation Op { input: In, output: Out }\n"
+            + "structure In {\n"
+            + "    @httpPayload\n"
+            + "    body: String\n"
+            + "}\n"
+            + "structure Out {}\n");
+        MemberModel mm = probe(model, "rest-json").translate(
+            struct(model, "In").getMember("body").get(),
+            struct(model, "In"),
+            requestBindings(model, "Op"));
+
+        assertThat(mm.getHttp().getIsPayload()).isTrue();
+        assertThat(mm.getHttp().getLocation()).isNull();
+    }
+
+    @Test
+    void nestedMember_noBindings_hasNoLocation() {
+        Model model = modelOf(
+            "structure Parent { child: String }\n");
+        MemberModel mm = probe(model, "rest-json").translate(
+            struct(model, "Parent").getMember("child").get(), struct(model, "Parent"), null);
+
+        assertThat(mm.getHttp().getLocation()).isNull();
+        assertThat(mm.getHttp().getIsPayload()).isFalse();
+        assertThat(mm.getHttp().getMarshallLocationName()).isEqualTo("child");
+    }
+
+    // ---- Streaming / flatten / requiresLength -----------------------------
+
+    @Test
+    void streamingBlobTarget_setsStreamingFlag() {
+        Model model = modelOf(
+            "@streaming blob StreamBlob\n"
+            + "structure Parent {\n"
+            + "    @required\n"
+            + "    body: StreamBlob\n"
+            + "}\n");
+        MemberModel mm = probe(model, "rest-json").translate(
+            struct(model, "Parent").getMember("body").get(), struct(model, "Parent"), null);
+
+        assertThat(mm.getHttp().getIsStreaming()).isTrue();
+    }
+
+    @Test
+    void xmlFlattenedTrait_setsFlattenedFlag() {
+        Model model = modelOf(
+            "list StringList { member: String }\n"
+            + "structure Parent {\n"
+            + "    @xmlFlattened\n"
+            + "    items: StringList\n"
+            + "}\n");
+        MemberModel mm = probe(model, "rest-xml").translate(
+            struct(model, "Parent").getMember("items").get(), struct(model, "Parent"), null);
+
+        assertThat(mm.getHttp().isFlattened()).isTrue();
+    }
+
+    // ---- Wire-name overrides ----------------------------------------------
+
+    @Test
+    void jsonName_overridesMarshallAndUnmarshallLocationName_forRestJson() {
+        Model model = modelOf(
+            "structure Parent {\n"
+            + "    @jsonName(\"my_field\")\n"
+            + "    myField: String\n"
+            + "}\n");
+        MemberModel mm = probe(model, "rest-json").translate(
+            struct(model, "Parent").getMember("myField").get(), struct(model, "Parent"), null);
+
+        assertThat(mm.getHttp().getMarshallLocationName()).isEqualTo("my_field");
+        assertThat(mm.getHttp().getUnmarshallLocationName()).isEqualTo("my_field");
+    }
+
+    @Test
+    void xmlName_overridesLocationName_forRestXml() {
+        Model model = modelOf(
+            "structure Parent {\n"
+            + "    @xmlName(\"MyField\")\n"
+            + "    myField: String\n"
+            + "}\n");
+        MemberModel mm = probe(model, "rest-xml").translate(
+            struct(model, "Parent").getMember("myField").get(), struct(model, "Parent"), null);
+
+        assertThat(mm.getHttp().getMarshallLocationName()).isEqualTo("MyField");
+    }
+
+    // ---- EC2 uppercase-first-char convention ------------------------------
+
+    @Test
+    void ec2Protocol_uppercasesFirstCharOfMemberName() {
+        Model model = modelOf(
+            "structure Parent { instanceId: String }\n");
+        MemberModel mm = probe(model, "ec2").translate(
+            struct(model, "Parent").getMember("instanceId").get(), struct(model, "Parent"), null);
+
+        assertThat(mm.getHttp().getMarshallLocationName()).isEqualTo("InstanceId");
+    }
+
+    @Test
+    void ec2Protocol_prefersEc2QueryNameTrait() {
+        Model model = modelOf(
+            "structure Parent {\n"
+            + "    @ec2QueryName(\"OverrideName\")\n"
+            + "    instanceId: String\n"
+            + "}\n");
+        MemberModel mm = probe(model, "ec2").translate(
+            struct(model, "Parent").getMember("instanceId").get(), struct(model, "Parent"), null);
+
+        assertThat(mm.getHttp().getMarshallLocationName()).isEqualTo("OverrideName");
+    }
+
+    @Test
+    void ec2Protocol_marshallUppercasesXmlNameStem_whenNoEc2QueryName() {
+        // Member name and @xmlName stems differ (plural vs singular). C2J upper-cases the
+        // locationName (@xmlName), not the member name: TagSpecification, not TagSpecifications.
+        Model model = modelOf(
+            "list TagSpecificationList { member: String }\n"
+            + "structure Parent {\n"
+            + "    @xmlName(\"TagSpecification\")\n"
+            + "    tagSpecifications: TagSpecificationList\n"
+            + "}\n");
+        MemberModel mm = probe(model, "ec2").translate(
+            struct(model, "Parent").getMember("tagSpecifications").get(), struct(model, "Parent"), null);
+
+        assertThat(mm.getHttp().getMarshallLocationName()).isEqualTo("TagSpecification");
+    }
+
+    @Test
+    void ec2Protocol_unmarshallUsesXmlNameVerbatim() {
+        // EC2 response element names come from @xmlName (C2J locationName), lower-cased on the wire.
+        Model model = modelOf(
+            "structure Parent {\n"
+            + "    @xmlName(\"min\")\n"
+            + "    min: Integer\n"
+            + "}\n");
+        MemberModel mm = probe(model, "ec2").translate(
+            struct(model, "Parent").getMember("min").get(), struct(model, "Parent"), null);
+
+        assertThat(mm.getHttp().getUnmarshallLocationName()).isEqualTo("min");
+        // Marshall still upper-cases the xmlName stem.
+        assertThat(mm.getHttp().getMarshallLocationName()).isEqualTo("Min");
+    }
+
+    // ---- Event stream member traits ---------------------------------------
+
+    @Test
+    void eventPayloadAndEventHeader_traitsSurfaceOnMemberModel() {
+        Model model = modelOf(
+            "structure Event {\n"
+            + "    @eventHeader header: String\n"
+            + "    @eventPayload payload: String\n"
+            + "}\n");
+        Probe p = probe(model, "rest-json");
+        StructureShape parent = struct(model, "Event");
+
+        assertThat(p.translate(parent.getMember("header").get(), parent, null).isEventHeader())
+            .isTrue();
+        assertThat(p.translate(parent.getMember("payload").get(), parent, null).isEventPayload())
+            .isTrue();
+    }
+
+    // ---- XML attribute / namespace ----------------------------------------
+
+    @Test
+    void xmlAttributeTrait_carriesFlag() {
+        Model model = modelOf(
+            "structure Parent {\n"
+            + "    @xmlAttribute\n"
+            + "    id: String\n"
+            + "}\n");
+        MemberModel mm = probe(model, "rest-xml").translate(
+            struct(model, "Parent").getMember("id").get(), struct(model, "Parent"), null);
+
+        assertThat(mm.isXmlAttribute()).isTrue();
+    }
+
+    @Test
+    void xmlNamespaceOnMember_setsUri() {
+        Model model = modelOf(
+            "structure Parent {\n"
+            + "    @xmlNamespace(uri: \"https://example.com/ns\")\n"
+            + "    inner: String\n"
+            + "}\n");
+        MemberModel mm = probe(model, "rest-xml").translate(
+            struct(model, "Parent").getMember("inner").get(), struct(model, "Parent"), null);
+
+        assertThat(mm.getXmlNameSpaceUri()).isEqualTo("https://example.com/ns");
+    }
+
+    // ---- Endpoint rules contextParam (member level, added in PR 4) --------
+
+    @Test
+    void contextParam_setsNameFromTrait() {
+        Model model = modelWithOp(
+            "@http(method: \"POST\", uri: \"/op\")\n"
+            + "operation Op { input: In, output: Out }\n"
+            + "structure In {\n"
+            + "    @smithy.rules#contextParam(name: \"TableName\")\n"
+            + "    table: String\n"
+            + "}\n"
+            + "structure Out {}\n");
+        MemberModel mm = probe(model, "rest-json").translate(
+            struct(model, "In").getMember("table").get(), struct(model, "In"),
+            requestBindings(model, "Op"));
+
+        assertThat(mm.getContextParam()).isNotNull();
+        assertThat(mm.getContextParam().getName()).isEqualTo("TableName");
+    }
+
+    @Test
+    void noContextParam_leavesFieldNull() {
+        Model model = modelOf(
+            "structure Parent { id: String }\n");
+        MemberModel mm = probe(model, "rest-json").translate(
+            struct(model, "Parent").getMember("id").get(), struct(model, "Parent"), null);
+
+        assertThat(mm.getContextParam()).isNull();
+    }
+
+    // ---- Endpoint discovery id (member level, added in PR 4) --------------
+
+    @Test
+    void endpointDiscoveryId_markedFromTrait() {
+        // A full endpoint-discovery setup is required for the model to validate:
+        // the service declares @clientEndpointDiscovery, the operation is
+        // @clientDiscoveredEndpoint, and the input member carries the id trait.
+        Model model = Model.assembler()
+            .discoverModels(Model.class.getClassLoader())
+            .addUnparsedModel("test.smithy",
+                "$version: \"2.0\"\nnamespace demo\n\n"
+                + "use aws.api#service\n"
+                + "use aws.auth#sigv4\n"
+                + "use aws.protocols#restJson1\n"
+                + "use aws.api#clientEndpointDiscovery\n"
+                + "use aws.api#clientDiscoveredEndpoint\n"
+                + "use aws.api#clientEndpointDiscoveryId\n\n"
+                + "@service(sdkId: \"Demo\", arnNamespace: \"demo\")\n"
+                + "@restJson1\n"
+                + "@sigv4(name: \"demo\")\n"
+                + "@clientEndpointDiscovery(operation: DescribeEndpoints, error: BadRequestException)\n"
+                + "service DemoService { version: \"2024-01-01\", operations: [DescribeEndpoints, GetItem] }\n\n"
+                + "@http(method: \"POST\", uri: \"/endpoints\")\n"
+                + "operation DescribeEndpoints {\n"
+                + "    input: DescribeEndpointsIn,\n"
+                + "    output: DescribeEndpointsOut,\n"
+                + "    errors: [BadRequestException]\n"
+                + "}\n"
+                + "structure DescribeEndpointsIn {}\n"
+                + "structure DescribeEndpointsOut { @required Endpoints: Endpoints }\n"
+                + "list Endpoints { member: Endpoint }\n"
+                + "structure Endpoint {\n"
+                + "    @required Address: String\n"
+                + "    @required CachePeriodInMinutes: Long\n"
+                + "}\n\n"
+                + "@clientDiscoveredEndpoint(required: true)\n"
+                + "@http(method: \"POST\", uri: \"/get\")\n"
+                + "operation GetItem { input: GetItemIn, output: GetItemOut, errors: [BadRequestException] }\n"
+                + "structure GetItemIn {\n"
+                + "    @required\n"
+                + "    @clientEndpointDiscoveryId\n"
+                + "    key: String\n"
+                + "}\n"
+                + "structure GetItemOut {}\n\n"
+                + "@error(\"client\")\n"
+                + "structure BadRequestException { message: String }\n")
+            .assemble()
+            .unwrap();
+
+        StructureShape getItemIn = struct(model, "GetItemIn");
+        MemberModel mm = probe(model, "rest-json").translate(
+            getItemIn.getMember("key").get(), getItemIn,
+            HttpBindingIndex.of(model).getRequestBindings(ShapeId.from("demo#GetItem")));
+
+        assertThat(mm.isEndpointDiscoveryId()).isTrue();
+    }
+}

--- a/codegen/src/test/java/software/amazon/awssdk/codegen/smithy/AddSmithyShapesShapeModelTest.java
+++ b/codegen/src/test/java/software/amazon/awssdk/codegen/smithy/AddSmithyShapesShapeModelTest.java
@@ -1,0 +1,312 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.codegen.smithy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.codegen.internal.TypeUtils;
+import software.amazon.awssdk.codegen.model.config.customization.CustomizationConfig;
+import software.amazon.awssdk.codegen.model.intermediate.EnumModel;
+import software.amazon.awssdk.codegen.model.intermediate.ShapeModel;
+import software.amazon.awssdk.codegen.naming.DefaultSmithyNamingStrategy;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.knowledge.HttpBinding;
+import software.amazon.smithy.model.knowledge.HttpBindingIndex;
+import software.amazon.smithy.model.shapes.OperationShape;
+import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.ShapeId;
+
+/**
+ * Unit tests for {@code AddSmithyShapes.generateShapeModel}.
+ *
+ * <p>Focuses on shape-level fields ({@link ShapeModel} attributes) —
+ * per-member translations are covered by
+ * {@code AddSmithyShapesMemberModelTest}.
+ */
+class AddSmithyShapesShapeModelTest {
+
+    private static final String USES =
+        "use aws.api#service\n"
+        + "use aws.auth#sigv4\n"
+        + "use aws.protocols#restJson1\n"
+        + "\n";
+
+    private static final String SERVICE_HEADER =
+        "@service(sdkId: \"Demo\", arnNamespace: \"demo\")\n"
+        + "@restJson1\n"
+        + "@sigv4(name: \"demo\")\n"
+        + "service DemoService { version: \"2024-01-01\" }\n\n";
+
+    private static final String SERVICE_HEADER_WITH_OP =
+        "@service(sdkId: \"Demo\", arnNamespace: \"demo\")\n"
+        + "@restJson1\n"
+        + "@sigv4(name: \"demo\")\n"
+        + "service DemoService { version: \"2024-01-01\", operations: [Op] }\n\n";
+
+    private static final class Probe extends AddSmithyShapes {
+        Probe(Model model, ServiceShape service, String protocol) {
+            super(model,
+                  service,
+                  new DefaultSmithyNamingStrategy(model, service, CustomizationConfig.create()),
+                  CustomizationConfig.create(),
+                  protocol,
+                  new TypeUtils(new DefaultSmithyNamingStrategy(model, service, CustomizationConfig.create())));
+        }
+
+        ShapeModel translate(String javaClassName, Shape shape, Map<String, HttpBinding> bindings) {
+            return generateShapeModel(javaClassName, shape, bindings);
+        }
+    }
+
+    private static Model modelOf(String header, String body) {
+        return Model.assembler()
+                    .discoverModels(Model.class.getClassLoader())
+                    .addUnparsedModel("test.smithy",
+                                      "$version: \"2.0\"\nnamespace demo\n\n" + USES + header + body)
+                    .assemble()
+                    .unwrap();
+    }
+
+    private static Model modelOf(String body) {
+        return modelOf(SERVICE_HEADER, body);
+    }
+
+    private static Model modelWithOp(String body) {
+        return modelOf(SERVICE_HEADER_WITH_OP, body);
+    }
+
+    private static Probe probe(Model model, String protocol) {
+        return new Probe(model, model.getServiceShapes().iterator().next(), protocol);
+    }
+
+    private static Shape shape(Model model, String name) {
+        return model.expectShape(ShapeId.from("demo#" + name));
+    }
+
+    // ---- Basic structure --------------------------------------------------
+
+    @Test
+    void structure_populatesNamesAndDocumentation() {
+        Model model = modelOf(
+            "/// A widget structure.\n"
+            + "structure Widget {\n"
+            + "    id: String\n"
+            + "    name: String\n"
+            + "}\n");
+        ShapeModel sm = probe(model, "rest-json").translate("Widget", shape(model, "Widget"), null);
+
+        assertThat(sm.getC2jName()).isEqualTo("Widget");
+        assertThat(sm.getShapeName()).isEqualTo("Widget");
+        assertThat(sm.getDocumentation()).isEqualTo("A widget structure.");
+        assertThat(sm.getMembers()).extracting("c2jName")
+                                   .containsExactlyInAnyOrder("id", "name");
+    }
+
+    @Test
+    void nullDocumentation_normalizedToEmptyStringByModel() {
+        // ShapeModel.setDocumentation normalizes null → "" via the codegen's
+        // escape/normalize pass. This matches C2J behavior — every call site
+        // passes through setDocumentation regardless of whether the source
+        // model has a docstring.
+        Model model = modelOf(
+            "structure Widget { id: String }\n");
+        ShapeModel sm = probe(model, "rest-json").translate("Widget", shape(model, "Widget"), null);
+
+        assertThat(sm.getDocumentation()).isEqualTo("");
+    }
+
+    // ---- Required list ---------------------------------------------------
+
+    @Test
+    void requiredList_collectsMemberNamesInModelOrder() {
+        Model model = modelOf(
+            "structure Widget {\n"
+            + "    @required id: String\n"
+            + "    name: String\n"
+            + "    @required kind: String\n"
+            + "}\n");
+        ShapeModel sm = probe(model, "rest-json").translate("Widget", shape(model, "Widget"), null);
+
+        assertThat(sm.getRequired()).containsExactlyInAnyOrder("id", "kind");
+    }
+
+    @Test
+    void requiredList_isNullWhenNoRequiredMembers() {
+        Model model = modelOf(
+            "structure Widget { id: String }\n");
+        ShapeModel sm = probe(model, "rest-json").translate("Widget", shape(model, "Widget"), null);
+
+        assertThat(sm.getRequired()).isNull();
+    }
+
+    // ---- Deprecation ------------------------------------------------------
+
+    @Test
+    void deprecatedShape_setsFlagAndMessage() {
+        Model model = modelOf(
+            "@deprecated(message: \"use NewWidget\")\n"
+            + "structure Widget { id: String }\n");
+        ShapeModel sm = probe(model, "rest-json").translate("Widget", shape(model, "Widget"), null);
+
+        assertThat(sm.isDeprecated()).isTrue();
+        assertThat(sm.getDeprecatedMessage()).isEqualTo("use NewWidget");
+    }
+
+    // ---- Union ------------------------------------------------------------
+
+    @Test
+    void union_setsUnionFlag() {
+        Model model = modelOf(
+            "union Payload {\n"
+            + "    text: String\n"
+            + "    number: Integer\n"
+            + "}\n");
+        ShapeModel sm = probe(model, "rest-json").translate("Payload", shape(model, "Payload"), null);
+
+        assertThat(sm.isUnion()).isTrue();
+    }
+
+    // ---- Event stream detection -------------------------------------------
+
+    @Test
+    void streamingUnion_isEventStream_and_membersAreEvents() {
+        Model model = modelWithOp(
+            "@http(method: \"POST\", uri: \"/subscribe\")\n"
+            + "operation Op { input: In, output: Out }\n"
+            + "structure In {}\n"
+            + "structure Out {\n"
+            + "    @httpPayload events: EventStream\n"
+            + "}\n"
+            + "\n"
+            + "@streaming\n"
+            + "union EventStream {\n"
+            + "    tick: TickEvent\n"
+            + "    tock: TockEvent\n"
+            + "}\n"
+            + "structure TickEvent { seq: Integer }\n"
+            + "structure TockEvent { seq: Integer }\n");
+
+        Probe p = probe(model, "rest-json");
+        ShapeModel unionModel = p.translate("EventStream", shape(model, "EventStream"), null);
+        ShapeModel tickModel = p.translate("TickEvent", shape(model, "TickEvent"), null);
+        ShapeModel plainModel = p.translate("In", shape(model, "In"), null);
+
+        assertThat(unionModel.isEventStream()).isTrue();
+        assertThat(tickModel.isEvent()).isTrue();
+        assertThat(plainModel.isEvent()).isFalse();
+        assertThat(plainModel.isEventStream()).isFalse();
+    }
+
+    // ---- Exception fields -------------------------------------------------
+
+    @Test
+    void exceptionShape_setsFaultAndRetryable() {
+        Model model = modelOf(
+            "@error(\"server\") @retryable(throttling: true)\n"
+            + "structure Boom { message: String }\n");
+        ShapeModel sm = probe(model, "rest-json").translate("BoomException", shape(model, "Boom"), null);
+
+        assertThat(sm.isFault()).isTrue();      // @error("server") → fault
+        assertThat(sm.isRetryable()).isTrue();
+        assertThat(sm.isThrottling()).isTrue();
+    }
+
+    @Test
+    void clientErrorShape_faultIsFalse() {
+        Model model = modelOf(
+            "@error(\"client\")\n"
+            + "structure BadRequest { message: String }\n");
+        ShapeModel sm = probe(model, "rest-json").translate("BadRequestException",
+                                                            shape(model, "BadRequest"), null);
+
+        assertThat(sm.isFault()).isFalse();
+    }
+
+    // ---- XML namespace ----------------------------------------------------
+
+    @Test
+    void xmlNamespaceOnShape_isTranslated() {
+        Model model = modelOf(
+            "@xmlNamespace(uri: \"https://example.com/ns\", prefix: \"ex\")\n"
+            + "structure Widget { id: String }\n");
+        ShapeModel sm = probe(model, "rest-xml").translate("Widget", shape(model, "Widget"), null);
+
+        assertThat(sm.getXmlNamespace()).isNotNull();
+        assertThat(sm.getXmlNamespace().getUri()).isEqualTo("https://example.com/ns");
+        assertThat(sm.getXmlNamespace().getPrefix()).isEqualTo("ex");
+    }
+
+    // ---- Enum shapes ------------------------------------------------------
+
+    @Test
+    void enumShape_populatesEnumModelList() {
+        Model model = modelOf(
+            "enum Status { A, B }\n");
+        ShapeModel sm = probe(model, "rest-json").translate("Status", shape(model, "Status"), null);
+
+        assertThat(sm.getEnums()).extracting(EnumModel::getValue)
+                                 .containsExactlyInAnyOrder("A", "B");
+    }
+
+    @Test
+    void intEnumShape_isNotTranslatedAsEnum() {
+        // C2J has no int-enum concept: an intEnum is written as a plain integer shape with no enum
+        // values. To preserve parity we do not emit an EnumModel list for it.
+        Model model = modelOf(
+            "intEnum Priority {\n"
+            + "    LOW = 1\n"
+            + "    HIGH = 2\n"
+            + "}\n");
+        ShapeModel sm = probe(model, "rest-json").translate("Priority", shape(model, "Priority"), null);
+
+        assertThat(sm.getEnums()).isNullOrEmpty();
+    }
+
+    // ---- Aggregate flags --------------------------------------------------
+
+    @Test
+    void aggregateFlags_computedFromMembers() {
+        Model model = modelWithOp(
+            "@http(method: \"POST\", uri: \"/things\")\n"
+            + "operation Op { input: In, output: Out }\n"
+            + "structure In {\n"
+            + "    @httpHeader(\"X-Meta\") meta: String\n"
+            + "    @httpPayload body: String\n"
+            + "}\n"
+            + "structure Out {\n"
+            + "    @httpResponseCode status: Integer\n"
+            + "    @httpHeader(\"X-Trace\") trace: String\n"
+            + "}\n");
+
+        Map<String, HttpBinding> inputBindings = HttpBindingIndex.of(model).getRequestBindings(
+            model.expectShape(ShapeId.from("demo#Op"), OperationShape.class).getId());
+        Map<String, HttpBinding> outputBindings = HttpBindingIndex.of(model).getResponseBindings(
+            model.expectShape(ShapeId.from("demo#Op"), OperationShape.class).getId());
+
+        Probe p = probe(model, "rest-json");
+        ShapeModel inSm = p.translate("In", shape(model, "In"), inputBindings);
+        ShapeModel outSm = p.translate("Out", shape(model, "Out"), outputBindings);
+
+        assertThat(inSm.isHasHeaderMember()).isTrue();
+        assertThat(inSm.isHasPayloadMember()).isTrue();
+
+        assertThat(outSm.isHasHeaderMember()).isTrue();
+        assertThat(outSm.isHasStatusCodeMember()).isTrue();
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

This is part of the incremental migration of the code generator from the C2J model to Smithy as the source of truth for the intermediate model. The existing C2J path builds `ShapeModel`/`MemberModel` objects from C2J shapes;
the Smithy path needs an equivalent that produces the *same* IM from a Smitht`Model`.

This PR adds the shared, protocol-aware base class that does that shape/member translation. It is the foundation the concrete shape processors (input, output, exception, and model shapes) will extend in a follow-up PR. The goal
throughout is C2J parity: given the same API, the Smithy-derived IM should match what the C2J path produces today.

## Modifications
<!--- Describe your changes in detail -->

- **`AddSmithyShapes` (new, abstract):** shared base for the Smithy shape processors. Two entry points:
  - `generateShapeModel(...)` builds a `ShapeModel` and all of its members, setting shape-level metadata from traits (documentation, deprecation, XML namespace, error/fault, retryable/throttling) and from shape kind (union, event stream, string-enum values).
  - `generateMemberModel(...)` builds a single `MemberModel` (names via the naming strategy, type via `TypeUtils`, timestamp format, sensitivity, idempotency token, event header/payload, context param, list/map models, and HTTP mapping).
  - Delegates to the Smithy libraries where they already compute a fact rather than re-deriving it: `HttpBindingIndex` for HTTP bindings, `TopDownIndex` for reachable operations, and `@required` membership for the `required` list/flag (matching C2J semantics rather than Smithy's richer nullability).
  - Handles a few known C2J-vs-Smithy differences explicitly, with comments. 
- **`SmithyWireNames` (new):** resolves per-protocol `marshallLocationName` / `unmarshallLocationName` for a member — the Smithy counterpart to C2J's`derive*LocationName`. Applies the name-override trait (`@xmlName` / `@jsonName`), then the HTTP binding location name, then the member name; EC2 has its own rule (`@ec2QueryName`, else first-character upper-casing), and synthetic list/map elements keep their literal lower-case names.
- **`codegen/pom.xml`:** add the `smithy-rules-engine` dependency, needed for`ContextParamTrait`.

Scope note: the base class is not yet invoked by production code generation. it is exercised only by the unit tests below. The concrete subclasses and their registration into the processor chain come in a follow-up PR, so there is no change to any generated SDK output in this change.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- `AddSmithyShapesShapeModelTest` (13 tests): shape-level translation. 
- `AddSmithyShapesMemberModelTest` (30 tests): member-level translation.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
