### PR TITLE
Correctly support endpoint expressions with multiple chained assigns

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-eb8289e.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-eb8289e.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "AWS SDK for Java v2",
+    "contributor": "",
+    "description": "Correctly support endpoint expressions with multiple chained assigns."
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/rules2/AssignTypesVisitor.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/rules2/AssignTypesVisitor.java
@@ -117,16 +117,21 @@ public final class AssignTypesVisitor extends RewriteRuleExpressionVisitor {
 
     @Override
     public RuleExpression visitLetExpression(LetExpression e) {
-        LetExpression expr = (LetExpression) super.visitLetExpression(e);
-        expr.bindings().forEach((k, v) -> {
-            RuleType type = v.type();
+        // Process bindings sequentially so that each binding's type is registered before subsequent bindings are
+        // visited. This allows later bindings to reference variables assigned by earlier bindings within the same
+        // let expression (e.g., `isoArn = aws.parseArn(...)` followed by `isoArnType = getAttr(isoArn, ...)`).
+        LetExpression.Builder builder = LetExpression.builder();
+        e.bindings().forEach((k, v) -> {
+            RuleExpression visited = v.accept(this);
+            RuleType type = visited.type();
             if (type == null) {
-                addError("Cannot find type for variable `%s`, expression: `%s`", k, v);
+                addError("Cannot find type for variable `%s`, expression: `%s`", k, visited);
             } else {
                 putLocal(k, type);
             }
+            builder.putBinding(k, visited);
         });
-        return expr;
+        return builder.build();
     }
 
     @Override

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/query/endpoint-rule-set.json
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/query/endpoint-rule-set.json
@@ -416,10 +416,20 @@
                 }
               ],
               "assign": "ParsedArn"
+            },
+            {
+              "fn": "getAttr",
+              "argv": [
+                {
+                  "ref": "ParsedArn"
+                },
+                "resourceId[0]"
+              ],
+              "assign": "ArnResourceId"
             }
           ],
           "endpoint": {
-            "url": "https://{endpointId}.query.{partitionResult#dualStackDnsSuffix}",
+            "url": "https://{ArnResourceId}.{endpointId}.query.{partitionResult#dualStackDnsSuffix}",
             "properties": {
               "authSchemes": [
                 {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-provider-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-provider-class.java
@@ -374,10 +374,16 @@ public final class DefaultQueryEndpointProvider implements QueryEndpointProvider
                                 .builder()
                                 .fn(FnNode.builder().fn("aws.parseArn").argv(Arrays.asList(Expr.ref(Identifier.of("FirstArn"))))
                                         .build().validate()).result("ParsedArn").build())
+                .addCondition(
+                        Condition
+                                .builder()
+                                .fn(FnNode.builder().fn("getAttr")
+                                        .argv(Arrays.asList(Expr.ref(Identifier.of("ParsedArn")), Expr.of("resourceId[0]")))
+                                        .build().validate()).result("ArnResourceId").build())
                 .endpoint(
                         EndpointResult
                                 .builder()
-                                .url(Expr.of("https://{endpointId}.query.{partitionResult#dualStackDnsSuffix}"))
+                                .url(Expr.of("https://{ArnResourceId}.{endpointId}.query.{partitionResult#dualStackDnsSuffix}"))
                                 .addProperty(
                                         Identifier.of("authSchemes"),
                                         Literal.fromTuple(Arrays.asList(Literal.fromRecord(MapUtils.of(Identifier.of("name"),

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-provider-know-prop-override-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules/endpoint-provider-know-prop-override-class.java
@@ -369,10 +369,16 @@ public final class DefaultQueryEndpointProvider implements QueryEndpointProvider
                                 .builder()
                                 .fn(FnNode.builder().fn("aws.parseArn").argv(Arrays.asList(Expr.ref(Identifier.of("FirstArn"))))
                                         .build().validate()).result("ParsedArn").build())
+                .addCondition(
+                        Condition
+                                .builder()
+                                .fn(FnNode.builder().fn("getAttr")
+                                        .argv(Arrays.asList(Expr.ref(Identifier.of("ParsedArn")), Expr.of("resourceId[0]")))
+                                        .build().validate()).result("ArnResourceId").build())
                 .endpoint(
                         EndpointResult
                                 .builder()
-                                .url(Expr.of("https://{endpointId}.query.{partitionResult#dualStackDnsSuffix}"))
+                                .url(Expr.of("https://{ArnResourceId}.{endpointId}.query.{partitionResult#dualStackDnsSuffix}"))
                                 .addProperty(
                                         Identifier.of("authSchemes"),
                                         Literal.fromTuple(Arrays.asList(Literal.fromRecord(MapUtils.of(Identifier.of("name"),

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules2/endpoint-provider-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules2/endpoint-provider-class.java
@@ -64,15 +64,18 @@ public final class DefaultQueryEndpointProvider implements QueryEndpointProvider
                 if (firstArn != null) {
                     RuleArn parsedArn = RulesFunctions.awsParseArn(firstArn);
                     if (parsedArn != null) {
-                        return RuleResult.endpoint(Endpoint
-                                .builder()
-                                .endpointUrl(
-                                        EndpointUrl.fromComponents("https",
-                                                params.endpointId() + ".query." + partitionResult.dualStackDnsSuffix(), -1, ""))
-                                .putAttribute(
-                                        AwsEndpointAttribute.AUTH_SCHEMES,
-                                        Arrays.asList(SigV4aAuthScheme.builder().signingName("query")
-                                                .signingRegionSet(Arrays.asList("*")).build())).build());
+                        String arnResourceId = RulesFunctions.listAccess(parsedArn.resourceId(), 0);
+                        if (arnResourceId != null) {
+                            return RuleResult.endpoint(Endpoint
+                                    .builder()
+                                    .endpointUrl(
+                                            EndpointUrl.fromComponents("https", arnResourceId + "." + params.endpointId()
+                                                    + ".query." + partitionResult.dualStackDnsSuffix(), -1, ""))
+                                    .putAttribute(
+                                            AwsEndpointAttribute.AUTH_SCHEMES,
+                                            Arrays.asList(SigV4aAuthScheme.builder().signingName("query")
+                                                    .signingRegionSet(Arrays.asList("*")).build())).build());
+                        }
                     }
                 }
             }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules2/endpoint-provider-know-prop-override-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules2/endpoint-provider-know-prop-override-class.java
@@ -64,15 +64,18 @@ public final class DefaultQueryEndpointProvider implements QueryEndpointProvider
                 if (firstArn != null) {
                     RuleArn parsedArn = RulesFunctions.awsParseArn(firstArn);
                     if (parsedArn != null) {
-                        return RuleResult.endpoint(Endpoint
-                                .builder()
-                                .endpointUrl(
-                                        EndpointUrl.fromComponents("https",
-                                                params.endpointId() + ".query." + partitionResult.dualStackDnsSuffix(), -1, ""))
-                                .putAttribute(
-                                        AwsEndpointAttribute.AUTH_SCHEMES,
-                                        Arrays.asList(SigV4aAuthScheme.builder().signingName("query")
-                                                .signingRegionSet(Arrays.asList("*")).build())).build());
+                        String arnResourceId = RulesFunctions.listAccess(parsedArn.resourceId(), 0);
+                        if (arnResourceId != null) {
+                            return RuleResult.endpoint(Endpoint
+                                    .builder()
+                                    .endpointUrl(
+                                            EndpointUrl.fromComponents("https", arnResourceId + "." + params.endpointId()
+                                                    + ".query." + partitionResult.dualStackDnsSuffix(), -1, ""))
+                                    .putAttribute(
+                                            AwsEndpointAttribute.AUTH_SCHEMES,
+                                            Arrays.asList(SigV4aAuthScheme.builder().signingName("query")
+                                                    .signingRegionSet(Arrays.asList("*")).build())).build());
+                        }
                     }
                 }
             }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules2/endpoint-provider-uri-cache-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/rules2/endpoint-provider-uri-cache-class.java
@@ -64,15 +64,18 @@ public final class DefaultQueryEndpointProvider implements QueryEndpointProvider
                 if (firstArn != null) {
                     RuleArn parsedArn = RulesFunctions.awsParseArn(firstArn);
                     if (parsedArn != null) {
-                        return RuleResult.endpoint(Endpoint
-                                .builder()
-                                .endpointUrl(
-                                        EndpointUrl.fromComponents("https",
-                                                params.endpointId() + ".query." + partitionResult.dualStackDnsSuffix(), -1, ""))
-                                .putAttribute(
-                                        AwsEndpointAttribute.AUTH_SCHEMES,
-                                        Arrays.asList(SigV4aAuthScheme.builder().signingName("query")
-                                                .signingRegionSet(Arrays.asList("*")).build())).build());
+                        String arnResourceId = RulesFunctions.listAccess(parsedArn.resourceId(), 0);
+                        if (arnResourceId != null) {
+                            return RuleResult.endpoint(Endpoint
+                                    .builder()
+                                    .endpointUrl(
+                                            EndpointUrl.fromComponents("https", arnResourceId + "." + params.endpointId()
+                                                    + ".query." + partitionResult.dualStackDnsSuffix(), -1, ""))
+                                    .putAttribute(
+                                            AwsEndpointAttribute.AUTH_SCHEMES,
+                                            Arrays.asList(SigV4aAuthScheme.builder().signingName("query")
+                                                    .signingRegionSet(Arrays.asList("*")).build())).build());
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Correctly support endpoint expressions with multiple chained assigns.

## Motivation and Context
Codegen for endpoint rules with expressions with multiple chained assigns were failing because we our codegen would visit each assign and collect them and then after all were visited only then generate the lets, but since the generating the lets is what updates the symbol table we were not able to find the result of earlier assigns.  Basically an endpoint rule like:

```
isoArn = aws.parseArn(ResourceARN) && isoArnType = isoArn.resourceId[0] 
```

In the above expression the isoArnType assign needs to use the resul tof the first assing to isoArn, which currently fails with:

```
  Cannot find a member with name `resourceId` for type `Void`,  
  Cannot find type for expression `(get-member isoArn resourceId)`,  
  Cannot find type for variable `isoArnType`,
```


## Modifications
When visiting letExpressions we need to visit *and* process them sequentially - that is, we need to process the bindings AND register the types.

## Testing
Added codegen test with previously failing example ruleset.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
