### PR TITLE
Make bytebuffer retryable on mpu

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-inmemorysplit.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-inmemorysplit.json
@@ -2,5 +2,5 @@
     "type": "bugfix",
     "category": "AWS SDK for Java v2",
     "contributor": "",
-    "description": "Make individual parts retryable when an in-memory `AsyncRequestBody` (for example one created with `AsyncRequestBody.fromBytes`, `fromByteBuffer`, or `fromString`) is split, such as during an S3 multipart upload The body in these cases is entirely in memory already so no data is copied and callers no longer need to wrap the body in `BufferedSplittableAsyncRequestBody` to get retries."
+    "description": "Make individual parts retryable when an in-memory `AsyncRequestBody` (for example one created with `AsyncRequestBody.fromBytes`, `fromByteBuffer`, or `fromString`) is split, such as during an S3 multipart upload. The body in these cases is entirely in memory already so no data is copied and callers no longer need to wrap the body in `BufferedSplittableAsyncRequestBody` to get retries."
 }

--- a/.changes/next-release/bugfix-AWSSDKforJavav2-inmemorysplit.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-inmemorysplit.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "AWS SDK for Java v2",
+    "contributor": "",
+    "description": "Make individual parts retryable when an in-memory `AsyncRequestBody` (for example one created with `AsyncRequestBody.fromBytes`, `fromByteBuffer`, or `fromString`) is split, such as during an S3 multipart upload The body in these cases is entirely in memory already so no data is copied and callers no longer need to wrap the body in `BufferedSplittableAsyncRequestBody` to get retries."
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/ByteBuffersAsyncRequestBody.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/ByteBuffersAsyncRequestBody.java
@@ -31,12 +31,15 @@ import org.reactivestreams.Subscription;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.annotations.SdkTestInternalApi;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
+import software.amazon.awssdk.core.async.AsyncRequestBodySplitConfiguration;
+import software.amazon.awssdk.core.async.CloseableAsyncRequestBody;
+import software.amazon.awssdk.core.async.SdkPublisher;
 import software.amazon.awssdk.core.exception.NonRetryableException;
 import software.amazon.awssdk.core.internal.util.Mimetype;
 import software.amazon.awssdk.core.internal.util.NoopSubscription;
 import software.amazon.awssdk.utils.Logger;
-import software.amazon.awssdk.utils.SdkAutoCloseable;
 import software.amazon.awssdk.utils.Validate;
+import software.amazon.awssdk.utils.async.SimplePublisher;
 
 /**
  * An implementation of {@link AsyncRequestBody} for providing data from the supplied {@link ByteBuffer} array. This is created
@@ -57,6 +60,12 @@ import software.amazon.awssdk.utils.Validate;
  *   <li>Send error notifications to all active subscribers</li>
  *   <li>Prevent new subscriptions</li>
  * </ul>
+ *
+ * <h3>Splitting:</h3>
+ * Because all data is already in memory, this implementation splits into independent
+ * {@code ByteBuffersAsyncRequestBody} parts backed by read-only slices of the same data rather than using
+ * {@link SplittingPublisher} making each part replayable.
+ *
  * @see AsyncRequestBody#fromBytes(byte[])
  * @see AsyncRequestBody#fromBytesUnsafe(byte[])
  * @see AsyncRequestBody#fromByteBuffer(ByteBuffer)
@@ -66,7 +75,7 @@ import software.amazon.awssdk.utils.Validate;
  * @see AsyncRequestBody#fromString(String)
  */
 @SdkInternalApi
-public final class ByteBuffersAsyncRequestBody implements AsyncRequestBody, SdkAutoCloseable {
+public final class ByteBuffersAsyncRequestBody implements CloseableAsyncRequestBody {
     private static final Logger log = Logger.loggerFor(ByteBuffersAsyncRequestBody.class);
 
     private final String mimetype;
@@ -121,6 +130,105 @@ public final class ByteBuffersAsyncRequestBody implements AsyncRequestBody, SdkA
     @Override
     public String body() {
         return BodyType.BYTES.getName();
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>Behaves the same as {@link #splitCloseable(AsyncRequestBodySplitConfiguration)}; the emitted parts are
+     * closeable, even though they are exposed here as plain {@link AsyncRequestBody}s.
+     */
+    @Override
+    public SdkPublisher<AsyncRequestBody> split(AsyncRequestBodySplitConfiguration splitConfiguration) {
+        // The identity mapping only widens the element type. SdkPublisher is invariant, so the publisher returned by
+        // splitCloseable cannot be returned directly.
+        return splitCloseable(splitConfiguration).map(body -> body);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>Each part is an independent, replayable {@code ByteBuffersAsyncRequestBody} backed by read-only slices of this
+     * body's data, so no data is copied and each part may be subscribed to more than once (i.e. it supports retries).
+     * Closing a part releases only that part's slices; it does not affect this body or any sibling part.
+     *
+     * <p>{@link AsyncRequestBodySplitConfiguration#bufferSizeInBytes()} is not applicable here and is ignored, since all
+     * of the data is already buffered in memory.
+     */
+    @Override
+    public SdkPublisher<CloseableAsyncRequestBody> splitCloseable(AsyncRequestBodySplitConfiguration splitConfiguration) {
+        Validate.notNull(splitConfiguration, "splitConfiguration");
+        long chunkSizeInBytes = splitConfiguration.chunkSizeInBytes() == null
+                                ? AsyncRequestBodySplitConfiguration.defaultConfiguration().chunkSizeInBytes()
+                                : splitConfiguration.chunkSizeInBytes();
+
+        SimplePublisher<CloseableAsyncRequestBody> publisher = new SimplePublisher<>();
+
+        // Reading closed and snapshotting buffers must be atomic, otherwise a concurrent close() could
+        // split an already-emptied buffer list. Nothing is published while the lock is held.
+        List<ByteBuffer> dataToSplit = null;
+        boolean alreadyClosed;
+        synchronized (lock) {
+            alreadyClosed = closed;
+            if (!alreadyClosed) {
+                dataToSplit = new ArrayList<>(buffers);
+            }
+        }
+
+        if (alreadyClosed) {
+            publisher.error(NonRetryableException.create("AsyncRequestBody has been closed"));
+            return SdkPublisher.adapt(publisher);
+        }
+
+        try {
+            sendParts(publisher, dataToSplit, chunkSizeInBytes);
+            publisher.complete();
+        } catch (Throwable t) {
+            log.debug(() -> "Failed to split the in-memory request body", t);
+            publisher.error(t);
+        }
+        return SdkPublisher.adapt(publisher);
+    }
+
+    /**
+     * Slices {@code dataToSplit} at {@code chunkSizeInBytes} boundaries and sends one part per chunk. The slices are
+     * read-only views over the existing data, so this does not copy the payload. A single empty part is sent if there is
+     * no data, mirroring the behavior of {@link SplittingPublisher} for an empty body.
+     */
+    private void sendParts(SimplePublisher<CloseableAsyncRequestBody> publisher,
+                           List<ByteBuffer> dataToSplit,
+                           long chunkSizeInBytes) {
+        List<ByteBuffer> currentPart = new ArrayList<>();
+        long currentPartLength = 0;
+        boolean anyPartSent = false;
+
+        for (ByteBuffer data : dataToSplit) {
+            // A read-only view (no underlying copy)
+            ByteBuffer remainingData = data.asReadOnlyBuffer();
+
+            while (remainingData.hasRemaining()) {
+                int lengthToRead = Math.toIntExact(Math.min(chunkSizeInBytes - currentPartLength,
+                                                            remainingData.remaining()));
+                // No underlying copy, just a view on top of the already read-only buffer.
+                ByteBuffer slice = remainingData.duplicate();
+                slice.limit(slice.position() + lengthToRead);
+                remainingData.position(remainingData.position() + lengthToRead);
+
+                currentPart.add(slice);
+                currentPartLength += lengthToRead;
+
+                if (currentPartLength == chunkSizeInBytes) {
+                    publisher.send(new ByteBuffersAsyncRequestBody(mimetype, currentPartLength, currentPart));
+                    anyPartSent = true;
+                    currentPart = new ArrayList<>();
+                    currentPartLength = 0;
+                }
+            }
+        }
+
+        if (currentPartLength > 0 || !anyPartSent) {
+            publisher.send(new ByteBuffersAsyncRequestBody(mimetype, currentPartLength, currentPart));
+        }
     }
 
     public static ByteBuffersAsyncRequestBody of(List<ByteBuffer> buffers, long length) {

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/async/ByteBuffersAsyncRequestBodySplitTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/async/ByteBuffersAsyncRequestBodySplitTest.java
@@ -1,0 +1,373 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.internal.async;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.nio.ByteBuffer;
+import java.nio.ReadOnlyBufferException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import software.amazon.awssdk.core.async.AsyncRequestBody;
+import software.amazon.awssdk.core.async.AsyncRequestBodySplitConfiguration;
+import software.amazon.awssdk.core.async.CloseableAsyncRequestBody;
+import software.amazon.awssdk.core.async.SdkPublisher;
+import software.amazon.awssdk.core.exception.NonRetryableException;
+import software.amazon.awssdk.core.internal.util.Mimetype;
+
+/**
+ * Tests for {@link ByteBuffersAsyncRequestBody#split(AsyncRequestBodySplitConfiguration)} and
+ * {@link ByteBuffersAsyncRequestBody#splitCloseable(AsyncRequestBodySplitConfiguration)}.
+ *
+ * <p>Because all of the data is already resident in memory, each split part must be independently replayable so that a
+ * failed part upload can be retried.
+ */
+class ByteBuffersAsyncRequestBodySplitTest {
+
+    private static Stream<Arguments> splitTestCases() {
+        byte[] content = bytesOfLength(100);
+        return Stream.of(
+            Arguments.of("chunk size divides content evenly", buffers(content), 10L, 10),
+            Arguments.of("chunk size does not divide content evenly", buffers(content), 30L, 4),
+            Arguments.of("chunk size equal to content length", buffers(content), 100L, 1),
+            Arguments.of("chunk size larger than content length", buffers(content), 1000L, 1),
+            Arguments.of("chunk size of one byte", buffers(bytesOfLength(5)), 1L, 5),
+            // Each source buffer holds a distinct range of the content so that data assembled out of order is detected.
+            Arguments.of("multiple source buffers, chunk spans buffers",
+                         Arrays.asList(ByteBuffer.wrap(Arrays.copyOfRange(content, 0, 10)),
+                                       ByteBuffer.wrap(Arrays.copyOfRange(content, 10, 20)),
+                                       ByteBuffer.wrap(Arrays.copyOfRange(content, 20, 30))),
+                         7L, 5),
+            Arguments.of("multiple source buffers, chunk smaller than each buffer",
+                         Arrays.asList(ByteBuffer.wrap(Arrays.copyOfRange(content, 0, 10)),
+                                       ByteBuffer.wrap(Arrays.copyOfRange(content, 10, 20))),
+                         4L, 5),
+            Arguments.of("source buffers include an empty buffer",
+                         Arrays.asList(ByteBuffer.wrap(Arrays.copyOfRange(content, 0, 5)),
+                                       ByteBuffer.wrap(new byte[0]),
+                                       ByteBuffer.wrap(Arrays.copyOfRange(content, 5, 10))),
+                         5L, 2)
+        );
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("splitTestCases")
+    void splitCloseable_splitsAtChunkBoundariesPreservingContent(String description,
+                                                                 List<ByteBuffer> sourceBuffers,
+                                                                 long chunkSize,
+                                                                 int expectedNumParts) throws Exception {
+        byte[] expectedContent = concat(sourceBuffers);
+        ByteBuffersAsyncRequestBody body = ByteBuffersAsyncRequestBody.of(sourceBuffers, expectedContent.length);
+
+        List<CloseableAsyncRequestBody> parts = collectParts(body.splitCloseable(c -> c.chunkSizeInBytes(chunkSize)));
+
+        assertThat(parts).hasSize(expectedNumParts);
+        for (int i = 0; i < parts.size(); i++) {
+            long expectedPartLength = i == parts.size() - 1
+                                      ? expectedContent.length - (i * chunkSize)
+                                      : chunkSize;
+            assertThat(parts.get(i).contentLength()).hasValue(expectedPartLength);
+        }
+
+        assertThat(concatDrained(parts)).isEqualTo(expectedContent);
+    }
+
+    @ParameterizedTest(name = "chunk size {0}")
+    @ValueSource(longs = {1L, 7L, 10L, 100L, 1000L})
+    void splitCloseable_eachPartIsReplayable(long chunkSize) throws Exception {
+        byte[] content = bytesOfLength(100);
+        List<CloseableAsyncRequestBody> parts =
+            collectParts(AsyncRequestBody.fromBytes(content).splitCloseable(c -> c.chunkSizeInBytes(chunkSize)));
+
+        // Drain every part three times; each pass must reproduce the full content. The second and subsequent passes are
+        // what a retry of an individual part upload does.
+        for (int pass = 0; pass < 3; pass++) {
+            assertThat(concatDrained(parts)).as("pass %d", pass).isEqualTo(content);
+        }
+    }
+
+    @Test
+    void splitCloseable_closingPart_doesNotAffectSiblingsOrSource() throws Exception {
+        byte[] content = bytesOfLength(30);
+        ByteBuffersAsyncRequestBody body = ByteBuffersAsyncRequestBody.from(content);
+
+        List<CloseableAsyncRequestBody> parts = collectParts(body.splitCloseable(c -> c.chunkSizeInBytes(10L)));
+        assertThat(parts).hasSize(3);
+
+        parts.get(1).close();
+
+        assertThat(drain(parts.get(0))).isEqualTo(Arrays.copyOfRange(content, 0, 10));
+        assertThat(drain(parts.get(2))).isEqualTo(Arrays.copyOfRange(content, 20, 30));
+        assertThat(drain(body)).isEqualTo(content);
+
+        assertThatThrownBy(() -> drain(parts.get(1)))
+            .hasCauseInstanceOf(NonRetryableException.class)
+            .hasMessageContaining("AsyncRequestBody has been closed");
+    }
+
+    @Test
+    void splitCloseable_closingSource_doesNotAffectParts() throws Exception {
+        byte[] content = bytesOfLength(30);
+        ByteBuffersAsyncRequestBody body = ByteBuffersAsyncRequestBody.from(content);
+
+        List<CloseableAsyncRequestBody> parts = collectParts(body.splitCloseable(c -> c.chunkSizeInBytes(10L)));
+        body.close();
+
+        assertThat(concatDrained(parts)).isEqualTo(content);
+    }
+
+    @Test
+    void splitCloseable_whenSourceIsClosed_shouldError() {
+        ByteBuffersAsyncRequestBody body = ByteBuffersAsyncRequestBody.from(bytesOfLength(30));
+        body.close();
+
+        assertThatThrownBy(() -> collectParts(body.splitCloseable(c -> c.chunkSizeInBytes(10L))))
+            .hasCauseInstanceOf(NonRetryableException.class)
+            .hasMessageContaining("AsyncRequestBody has been closed");
+    }
+
+    @Test
+    void splitCloseable_doesNotMutateSourceBuffers() throws Exception {
+        ByteBuffer first = ByteBuffer.wrap(bytesOfLength(20));
+        ByteBuffer second = ByteBuffer.wrap(bytesOfLength(20));
+        second.position(5);
+        int firstPosition = first.position();
+        int secondPosition = second.position();
+
+        ByteBuffersAsyncRequestBody body = ByteBuffersAsyncRequestBody.of(first, second);
+        collectParts(body.splitCloseable(c -> c.chunkSizeInBytes(7L)));
+
+        assertThat(first.position()).isEqualTo(firstPosition);
+        assertThat(second.position()).isEqualTo(secondPosition);
+    }
+
+    /**
+     * The parts view the source data rather than copying it, so a part must not be usable to mutate that data. Asserts
+     * on the slices the parts actually hold: asserting on the buffers delivered to a subscriber would prove nothing,
+     * since {@code ByteBuffersAsyncRequestBody} makes every published buffer read-only on the way out regardless.
+     */
+    @Test
+    void splitCloseable_partSlicesAreReadOnly_soPartsCannotMutateSourceData() throws Exception {
+        // fromBytesUnsafe does not copy, so the parts slice the caller's array directly.
+        byte[] callerOwnedArray = bytesOfLength(20);
+        List<CloseableAsyncRequestBody> parts = collectParts(
+            AsyncRequestBody.fromBytesUnsafe(callerOwnedArray).splitCloseable(c -> c.chunkSizeInBytes(10L)));
+
+        assertThat(parts).hasSize(2);
+        for (CloseableAsyncRequestBody part : parts) {
+            List<ByteBuffer> slices = ((ByteBuffersAsyncRequestBody) part).bufferedData();
+            assertThat(slices).isNotEmpty().allMatch(ByteBuffer::isReadOnly);
+            for (ByteBuffer slice : slices) {
+                assertThatThrownBy(() -> slice.put(0, (byte) 99)).isInstanceOf(ReadOnlyBufferException.class);
+            }
+        }
+
+        assertThat(callerOwnedArray).isEqualTo(bytesOfLength(20));
+    }
+
+    @Test
+    void splitCloseable_emptyBody_shouldEmitSingleEmptyPart() throws Exception {
+        List<CloseableAsyncRequestBody> parts =
+            collectParts(AsyncRequestBody.empty().splitCloseable(c -> c.chunkSizeInBytes(10L)));
+
+        assertThat(parts).hasSize(1);
+        assertThat(parts.get(0).contentLength()).hasValue(0L);
+        assertThat(drain(parts.get(0))).isEmpty();
+    }
+
+    @Test
+    void splitCloseable_propagatesContentType() throws Exception {
+        AsyncRequestBody body = AsyncRequestBody.fromString("hello world");
+        assertThat(body.contentType()).isNotEqualTo(Mimetype.MIMETYPE_OCTET_STREAM);
+
+        List<CloseableAsyncRequestBody> parts = collectParts(body.splitCloseable(c -> c.chunkSizeInBytes(4L)));
+
+        assertThat(parts).isNotEmpty().allSatisfy(p -> assertThat(p.contentType()).isEqualTo(body.contentType()));
+    }
+
+    @Test
+    void splitCloseable_propagatesBodyType() throws Exception {
+        List<CloseableAsyncRequestBody> parts =
+            collectParts(AsyncRequestBody.fromBytes(bytesOfLength(20)).splitCloseable(c -> c.chunkSizeInBytes(10L)));
+
+        assertThat(parts).allSatisfy(p -> assertThat(p.body()).isEqualTo(AsyncRequestBody.BodyType.BYTES.getName()));
+    }
+
+    @Test
+    void splitCloseable_nullConfiguration_shouldThrow() {
+        AsyncRequestBodySplitConfiguration configuration = null;
+        assertThatThrownBy(() -> AsyncRequestBody.fromBytes(bytesOfLength(10)).splitCloseable(configuration))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("splitConfiguration");
+    }
+
+    @Test
+    void splitCloseable_noChunkSizeConfigured_shouldUseDefaultChunkSize() throws Exception {
+        long defaultChunkSize = AsyncRequestBodySplitConfiguration.defaultConfiguration().chunkSizeInBytes();
+        byte[] content = bytesOfLength(Math.toIntExact(defaultChunkSize + 1));
+
+        List<CloseableAsyncRequestBody> parts = collectParts(
+            AsyncRequestBody.fromBytes(content).splitCloseable(AsyncRequestBodySplitConfiguration.builder().build()));
+
+        assertThat(parts).hasSize(2);
+        assertThat(parts.get(0).contentLength()).hasValue(defaultChunkSize);
+        assertThat(parts.get(1).contentLength()).hasValue(1L);
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    void legacySplit_producesReplayableParts() throws Exception {
+        byte[] content = bytesOfLength(30);
+        SdkPublisher<AsyncRequestBody> publisher =
+            AsyncRequestBody.fromBytes(content).split(c -> c.chunkSizeInBytes(10L));
+
+        List<AsyncRequestBody> parts = new ArrayList<>();
+        subscribeAndCollect(publisher, parts);
+
+        assertThat(parts).hasSize(3);
+        assertThat(concatDrained(parts)).isEqualTo(content);
+        assertThat(concatDrained(parts)).isEqualTo(content);
+    }
+
+    /**
+     * Content where each byte encodes its own offset, so that content assembled in the wrong order is detected.
+     */
+    private static byte[] bytesOfLength(int length) {
+        byte[] bytes = new byte[length];
+        for (int i = 0; i < length; i++) {
+            bytes[i] = (byte) (i % 256);
+        }
+        return bytes;
+    }
+
+    private static List<ByteBuffer> buffers(byte[] content) {
+        return Arrays.asList(ByteBuffer.wrap(content));
+    }
+
+    private static byte[] concat(List<ByteBuffer> buffers) {
+        return concatBytes(buffers.stream()
+                                  .map(b -> {
+                                      ByteBuffer duplicate = b.duplicate();
+                                      byte[] bytes = new byte[duplicate.remaining()];
+                                      duplicate.get(bytes);
+                                      return bytes;
+                                  })
+                                  .collect(Collectors.toList()));
+    }
+
+    private static byte[] concatBytes(List<byte[]> chunks) {
+        int total = chunks.stream().mapToInt(c -> c.length).sum();
+        byte[] result = new byte[total];
+        int offset = 0;
+        for (byte[] chunk : chunks) {
+            System.arraycopy(chunk, 0, result, offset, chunk.length);
+            offset += chunk.length;
+        }
+        return result;
+    }
+
+    private static byte[] concatDrained(List<? extends AsyncRequestBody> parts) throws Exception {
+        List<byte[]> drained = new ArrayList<>();
+        for (AsyncRequestBody part : parts) {
+            drained.add(drain(part));
+        }
+        return concatBytes(drained);
+    }
+
+    private static List<CloseableAsyncRequestBody> collectParts(SdkPublisher<CloseableAsyncRequestBody> publisher)
+        throws Exception {
+        List<CloseableAsyncRequestBody> parts = new ArrayList<>();
+        subscribeAndCollect(publisher, parts);
+        return parts;
+    }
+
+    private static <T> void subscribeAndCollect(SdkPublisher<T> publisher, List<T> collected) throws Exception {
+        CompletableFuture<Void> completed = new CompletableFuture<>();
+        publisher.subscribe(new Subscriber<T>() {
+            @Override
+            public void onSubscribe(Subscription s) {
+                s.request(Long.MAX_VALUE);
+            }
+
+            @Override
+            public void onNext(T part) {
+                collected.add(part);
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                completed.completeExceptionally(t);
+            }
+
+            @Override
+            public void onComplete() {
+                completed.complete(null);
+            }
+        });
+        completed.get(5, TimeUnit.SECONDS);
+    }
+
+    private static byte[] drain(AsyncRequestBody body) throws Exception {
+        return concatBytes(drainToBuffers(body).stream()
+                                               .map(b -> {
+                                                   byte[] bytes = new byte[b.remaining()];
+                                                   b.get(bytes);
+                                                   return bytes;
+                                               })
+                                               .collect(Collectors.toList()));
+    }
+
+    private static List<ByteBuffer> drainToBuffers(AsyncRequestBody body) throws Exception {
+        List<ByteBuffer> received = new ArrayList<>();
+        CompletableFuture<Void> completed = new CompletableFuture<>();
+        body.subscribe(new Subscriber<ByteBuffer>() {
+            @Override
+            public void onSubscribe(Subscription s) {
+                s.request(Long.MAX_VALUE);
+            }
+
+            @Override
+            public void onNext(ByteBuffer byteBuffer) {
+                received.add(byteBuffer);
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                completed.completeExceptionally(t);
+            }
+
+            @Override
+            public void onComplete() {
+                completed.complete(null);
+            }
+        });
+        completed.get(5, TimeUnit.SECONDS);
+        return received;
+    }
+}

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/multipart/S3MultipartClientPutObjectWiremockTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/multipart/S3MultipartClientPutObjectWiremockTest.java
@@ -17,6 +17,7 @@ package software.amazon.awssdk.services.s3.internal.multipart;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
+import static com.github.tomakehurst.wiremock.client.WireMock.containing;
 import static com.github.tomakehurst.wiremock.client.WireMock.delete;
 import static com.github.tomakehurst.wiremock.client.WireMock.lessThanOrExactly;
 import static com.github.tomakehurst.wiremock.client.WireMock.matching;
@@ -39,6 +40,7 @@ import io.reactivex.rxjava3.core.Flowable;
 import java.io.InputStream;
 import java.net.URI;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -46,6 +48,7 @@ import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
 import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -212,6 +215,44 @@ public class S3MultipartClientPutObjectWiremockTest {
         verify(lessThanOrExactly(2), putRequestedFor(anyUrl()).withQueryParam("partNumber", matching(String.valueOf(2))));
     }
 
+    public static Stream<Arguments> inMemoryBodyRetryableErrorTestCase() {
+        return Stream.of(
+            Arguments.of("failOfConnectionReset", aResponse().withFault(Fault.CONNECTION_RESET_BY_PEER)),
+            Arguments.of("failOf500", aResponse().withStatus(500))
+        );
+    }
+
+    /**
+     * An in-memory body holds all of its data, so its parts are retryable without the caller opting into
+     * {@link BufferedSplittableAsyncRequestBody}.
+     */
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("inMemoryBodyRetryableErrorTestCase")
+    void mpuWithInMemoryBody_partsFailOfRetryableError_shouldRetry(String description,
+                                                                  ResponseDefinitionBuilder responseDefinitionBuilder) {
+        stubUploadPartFailsInitialAttemptSucceedsUponRetryCalls(responseDefinitionBuilder);
+        String firstPartContent = StringUtils.repeat('a', 10);
+        String secondPartContent = StringUtils.repeat('b', 10);
+        byte[] payload = (firstPartContent + secondPartContent).getBytes(StandardCharsets.UTF_8);
+
+        s3AsyncClient.putObject(b -> b.bucket(BUCKET).key(KEY), AsyncRequestBody.fromBytes(payload)).join();
+
+        verify(moreThan(1), putRequestedFor(anyUrl()).withQueryParam("partNumber", matching(String.valueOf(1))));
+        verify(lessThanOrExactly(3), putRequestedFor(anyUrl()).withQueryParam("partNumber", matching(String.valueOf(1))));
+        verify(moreThan(1), putRequestedFor(anyUrl()).withQueryParam("partNumber", matching(String.valueOf(2))));
+        verify(lessThanOrExactly(3), putRequestedFor(anyUrl()).withQueryParam("partNumber", matching(String.valueOf(2))));
+
+        // Each part must only ever carry its own slice of the payload, on the initial attempt and on the retry. The
+        // bodies are aws-chunked encoded, so match on the content rather than comparing the payload exactly.
+        verify(moreThan(0), putRequestedFor(anyUrl()).withQueryParam("partNumber", matching(String.valueOf(1)))
+                                                    .withRequestBody(containing(firstPartContent)));
+        verify(0, putRequestedFor(anyUrl()).withQueryParam("partNumber", matching(String.valueOf(1)))
+                                          .withRequestBody(containing(secondPartContent)));
+        verify(moreThan(0), putRequestedFor(anyUrl()).withQueryParam("partNumber", matching(String.valueOf(2)))
+                                                    .withRequestBody(containing(secondPartContent)));
+        verify(0, putRequestedFor(anyUrl()).withQueryParam("partNumber", matching(String.valueOf(2)))
+                                          .withRequestBody(containing(firstPartContent)));
+    }
 
     private void stubUploadPartFailsInitialAttemptSucceedsUponRetryCalls(ResponseDefinitionBuilder responseDefinitionBuilder) {
         stubFor(post(anyUrl()).willReturn(aResponse().withStatus(200).withBody(CREATE_MULTIPART_PAYLOAD)));


### PR DESCRIPTION
Make bytebuffer retryable on mpu.

## Motivation and Context
In-memory `AsyncRequestBody` (for example one created with `AsyncRequestBody.fromBytes`, `fromByteBuffer`, or `fromString`) were previously not retryable in MPU even though all of the data is already fullly in memory and replayable.

## Modifications
Implement `split`/`splitClosable` in  `ByteBuffersAsyncRequestBody`. Gives read-only slices (parts) backed by the existing, in memory body data.

**Comparing to other split implementations**:
Before this PR, the  `ByteBuffersAsyncRequestBody` was using the default interfaces [AsyncRequestBody#splitCloseable](https://github.com/aws/aws-sdk-java-v2/blob/617c8bb288fa1ba776088778f7a03b6c33103af7/core/sdk-core/src/main/java/software/amazon/awssdk/core/async/AsyncRequestBody.java#L585) which uses the [SplittingPublisher](https://github.com/aws/aws-sdk-java-v2/blob/master/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/SplittingPublisher.java) with `retryableSubAsyncRequestBodyEnabled(false)`.  

There is another implementation of split/splitClosable in FileAsyncRequestBody which uses 
[FileAsyncRequestBodySplitHelper](https://github.com/aws/aws-sdk-java-v2/blob/master/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/FileAsyncRequestBodySplitHelper.java)

 
## Testing
New and existing unit tests + manual test.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.


## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
