### PR TITLE
Increase timeout on flaky HandlerPublisherVerificationTest

### DIFF
--- a/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/nrs/HandlerPublisherVerificationTest.java
+++ b/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/nrs/HandlerPublisherVerificationTest.java
@@ -57,7 +57,7 @@ public class HandlerPublisherVerificationTest extends PublisherVerification<Long
 
     @Factory(dataProvider = "data")
     public HandlerPublisherVerificationTest(int batchSize, int publishInitial, boolean scheduled) {
-        super(new TestEnvironment(200));
+        super(new TestEnvironment(2000, 200, 200));
         this.batchSize = batchSize;
         this.publishInitial = publishInitial;
         this.scheduled = scheduled;


### PR DESCRIPTION
Increase timeout on flaky HandlerPublisherVerificationTest

## Motivation and Context
We've had multiple incidents of this test failing during releases (and succeeding upon retry).  A true fix is complex so just raising the timeout here to reduce liklihood.


## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
