### PR TITLE
Fix flakey TCK test

### DIFF
--- a/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/nrs/HandlerPublisherVerificationTest.java
+++ b/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/nrs/HandlerPublisherVerificationTest.java
@@ -23,6 +23,7 @@ import io.netty.channel.DefaultEventLoopGroup;
 import io.netty.channel.local.LocalChannel;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.tck.PublisherVerification;
 import org.reactivestreams.tck.TestEnvironment;
@@ -57,7 +58,7 @@ public class HandlerPublisherVerificationTest extends PublisherVerification<Long
 
     @Factory(dataProvider = "data")
     public HandlerPublisherVerificationTest(int batchSize, int publishInitial, boolean scheduled) {
-        super(new TestEnvironment(200));
+        super(new TestEnvironment(1000, 200));
         this.batchSize = batchSize;
         this.publishInitial = publishInitial;
         this.scheduled = scheduled;
@@ -82,12 +83,12 @@ public class HandlerPublisherVerificationTest extends PublisherVerification<Long
     // doesn't happen if you create 32 publishers in a single test.
     @BeforeMethod
     public void startEventLoop() {
-        eventLoop = new DefaultEventLoopGroup();
+        eventLoop = new DefaultEventLoopGroup(1);
     }
 
     @AfterMethod
     public void stopEventLoop() {
-        eventLoop.shutdownGracefully();
+        eventLoop.shutdownGracefully(0, 0, TimeUnit.MILLISECONDS).syncUninterruptibly();
         eventLoop = null;
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
TCK test fails intermittently in CI with: `produced less than 3 elements within 200 ms`

The test uses a 200ms deadline for element delivery. On loaded CI hosts, thread scheduling delays can exceed 200ms, causing the test to time out. 

## Modifications
<!--- Describe your changes in detail -->
- **Raise the TCK deadline selectively:** `TestEnvironment(200)` → `TestEnvironment(1000, 200)`. The first value (1000ms) is how long the test waits for expected elements. The second (200ms) is how long it waits to confirm no *extra* signals arrive.
- **Reduce thread churn:** `DefaultEventLoopGroup()` → `DefaultEventLoopGroup(1)`. Only one thread is needed for this unit test. The no-arg constructor defaults to `2 * availableProcessors()` threads; only one is needed for this unit test.
- **Await shutdown:** `shutdownGracefully()` → `shutdownGracefully(0, 0, MILLISECONDS).syncUninterruptibly()`. The no-arg form returns immediately with a 2s quiet period and 15s timeout, allowing old threads to linger into the next test. The explicit form shuts down immediately and blocks until complete, ensuring threads are fully terminated before the next test starts.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Verified that setting the timeout to 1ms reproduces the exact CI failure locally, confirming the timeout is the sole failure mechanism.
- Ran test on loop successfully.

