### PR TITLE
Stop hardcoding the API version in Route 53 QueryParamBindingTest

### DIFF
--- a/services/route53/src/test/java/software/amazon/awssdk/services/route53/QueryParamBindingTest.java
+++ b/services/route53/src/test/java/software/amazon/awssdk/services/route53/QueryParamBindingTest.java
@@ -15,11 +15,14 @@
 
 package software.amazon.awssdk.services.route53;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.core.ClientEndpointProvider;
 import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
@@ -32,6 +35,8 @@ import software.amazon.awssdk.services.route53.transform.GetHealthCheckLastFailu
 import software.amazon.awssdk.services.route53.transform.ListHealthChecksRequestMarshaller;
 
 public class QueryParamBindingTest {
+
+    private static final Pattern API_VERSION_PREFIX = Pattern.compile("^/\\d{4}-\\d{2}-\\d{2}(?=/)");
 
     protected static final AwsXmlProtocolFactory PROTOCOL_FACTORY = AwsXmlProtocolFactory
         .builder()
@@ -58,7 +63,7 @@ public class QueryParamBindingTest {
                 .build();
 
         SdkHttpFullRequest httpReq_List = new ListHealthChecksRequestMarshaller(PROTOCOL_FACTORY).marshall(listReq);
-        assertEquals("/2013-04-01/healthcheck", httpReq_List.encodedPath());
+        assertEquals("/healthcheck", pathAfterApiVersion(httpReq_List.encodedPath()));
 
         Map<String, List<String>> queryParams = httpReq_List.rawQueryParameters();
         assertEquals(2, queryParams.size());
@@ -74,10 +79,18 @@ public class QueryParamBindingTest {
         System.out.println(httpReq_GetFailure);
         // parameter value should be URL encoded
         assertEquals(
-                "/2013-04-01/healthcheck/%3Fcharlie/lastfailurereason",
-                httpReq_GetFailure.encodedPath());
+                "/healthcheck/%3Fcharlie/lastfailurereason",
+                pathAfterApiVersion(httpReq_GetFailure.encodedPath()));
 
         queryParams = httpReq_GetFailure.rawQueryParameters();
         assertEquals(0, queryParams.size());
+    }
+
+    private static String pathAfterApiVersion(String encodedPath) {
+        Matcher matcher = API_VERSION_PREFIX.matcher(encodedPath);
+        assertThat(matcher.lookingAt())
+            .withFailMessage("Expected path to start with an API version segment, but was: %s", encodedPath)
+            .isTrue();
+        return encodedPath.substring(matcher.end());
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

`QueryParamBindingTest.testReservedCharInParamValue` hardcoded the API version in its expected paths, e.g. `/2013-04-01/healthcheck`. That segment comes from the model, so any model update that changes the API version breaks the test even though marshalling is unchanged.

The test checks that reserved characters in `@UriLabel` values and query parameters get encoded. The version prefix has nothing to do with that.

## Modifications
<!--- Describe your changes in detail -->
Strip the version segment, then compare the rest against a literal.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

mvn clean test -pl :route53 — module suite and checkstyle pass.

Bumped the API version in a local copy of the model and regenerated. Confirmed the marshaller picked up the new path, and the test passed.



## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
