### PR TITLE
fix(crt): honor wildcard nonProxyHosts entries in CRT-based clients

### DIFF
--- a/.changes/next-release/bugfix-AWSCRTHTTPClient-931b1de.json
+++ b/.changes/next-release/bugfix-AWSCRTHTTPClient-931b1de.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "AWS CRT HTTP Client",
+    "contributor": "",
+    "description": "Honor wildcard `nonProxyHosts` entries in CRT-based HTTP clients (`AwsCrtHttpClient`, `AwsCrtAsyncHttpClient`, and the S3/CRT client). Previously a `*.suffix` wildcard or a bare `*` from `http.nonProxyHosts`/`no_proxy` was silently ignored, so matching hosts were routed through the proxy instead of bypassing it. Supported forms are an exact host, a `*.suffix` wildcard (matches the domain and its subdomains), a single `*` for all hosts, and CIDR ranges. Entries must not contain surrounding whitespace."
+}

--- a/core/crt-core/src/main/java/software/amazon/awssdk/crtcore/CrtConfigurationUtils.java
+++ b/core/crt-core/src/main/java/software/amazon/awssdk/crtcore/CrtConfigurationUtils.java
@@ -15,7 +15,9 @@
 
 package software.amazon.awssdk.crtcore;
 
+import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import software.amazon.awssdk.annotations.SdkProtectedApi;
 import software.amazon.awssdk.crt.http.HttpMonitoringOptions;
 import software.amazon.awssdk.crt.http.HttpProxyOptions;
@@ -39,7 +41,11 @@ public final class CrtConfigurationUtils {
         clientProxyOptions.setHost(proxyConfiguration.host());
         clientProxyOptions.setPort(proxyConfiguration.port());
         if (!proxyConfiguration.nonProxyHosts().isEmpty()) {
-            clientProxyOptions.setNoProxyHosts(String.join(",", proxyConfiguration.nonProxyHosts()));
+            String noProxyHosts = proxyConfiguration.nonProxyHosts().stream()
+                                                    .filter(Objects::nonNull)
+                                                    .map(CrtConfigurationUtils::toCurlNoProxyHost)
+                                                    .collect(Collectors.joining(","));
+            clientProxyOptions.setNoProxyHosts(noProxyHosts);
         }
 
         if ("https".equalsIgnoreCase(proxyConfiguration.scheme())) {
@@ -55,6 +61,18 @@ public final class CrtConfigurationUtils {
         }
 
         return Optional.of(clientProxyOptions);
+    }
+
+    /**
+     * Translates a {@code nonProxyHosts} token to the form expected by the curl-style native matcher: a host name with a
+     * leading {@code *} wildcard ({@code *.example.com}) becomes a dot-anchored suffix ({@code .example.com}), while a bare
+     * {@code *}, exact host names, and CIDR ranges are passed through unchanged.
+     */
+    private static String toCurlNoProxyHost(String nonProxyHost) {
+        if (nonProxyHost.length() > 1 && nonProxyHost.charAt(0) == '*') {
+            return nonProxyHost.substring(1);
+        }
+        return nonProxyHost;
     }
 
     public static Optional<HttpMonitoringOptions> resolveHttpMonitoringOptions(CrtConnectionHealthConfiguration config) {

--- a/core/crt-core/src/main/java/software/amazon/awssdk/crtcore/CrtConfigurationUtils.java
+++ b/core/crt-core/src/main/java/software/amazon/awssdk/crtcore/CrtConfigurationUtils.java
@@ -22,10 +22,13 @@ import software.amazon.awssdk.annotations.SdkProtectedApi;
 import software.amazon.awssdk.crt.http.HttpMonitoringOptions;
 import software.amazon.awssdk.crt.http.HttpProxyOptions;
 import software.amazon.awssdk.crt.io.TlsContext;
+import software.amazon.awssdk.utils.Logger;
 import software.amazon.awssdk.utils.NumericUtils;
 
 @SdkProtectedApi
 public final class CrtConfigurationUtils {
+
+    private static final Logger log = Logger.loggerFor(CrtConfigurationUtils.class);
 
     private CrtConfigurationUtils() {
     }
@@ -41,6 +44,10 @@ public final class CrtConfigurationUtils {
         clientProxyOptions.setHost(proxyConfiguration.host());
         clientProxyOptions.setPort(proxyConfiguration.port());
         if (!proxyConfiguration.nonProxyHosts().isEmpty()) {
+            proxyConfiguration.nonProxyHosts().stream()
+                              .filter(Objects::nonNull)
+                              .filter(CrtConfigurationUtils::isUnsupportedWildcard)
+                              .forEach(CrtConfigurationUtils::warnUnsupportedWildcard);
             String noProxyHosts = proxyConfiguration.nonProxyHosts().stream()
                                                     .filter(Objects::nonNull)
                                                     .map(CrtConfigurationUtils::toCurlNoProxyHost)
@@ -65,14 +72,25 @@ public final class CrtConfigurationUtils {
 
     /**
      * Translates a {@code nonProxyHosts} token to the form expected by the curl-style native matcher: a host name with a
-     * leading {@code *} wildcard ({@code *.example.com}) becomes a dot-anchored suffix ({@code .example.com}), while a bare
-     * {@code *}, exact host names, and CIDR ranges are passed through unchanged.
+     * leading {@code *.} wildcard ({@code *.example.com}) becomes a dot-anchored suffix ({@code .example.com}), while a bare
+     * {@code *}, exact host names, and CIDR ranges are passed through unchanged. A wildcard in any other position is
+     * unsupported (see {@link #isUnsupportedWildcard}) and passed through unchanged, so the native matcher will not match it.
      */
     private static String toCurlNoProxyHost(String nonProxyHost) {
-        if (nonProxyHost.length() > 1 && nonProxyHost.charAt(0) == '*') {
+        if (nonProxyHost.startsWith("*.")) {
             return nonProxyHost.substring(1);
         }
         return nonProxyHost;
+    }
+
+    private static boolean isUnsupportedWildcard(String nonProxyHost) {
+        return nonProxyHost.contains("*") && !nonProxyHost.equals("*") && !nonProxyHost.startsWith("*.");
+    }
+
+    private static void warnUnsupportedWildcard(String nonProxyHost) {
+        log.warn(() -> "Unsupported wildcard in nonProxyHosts entry '" + nonProxyHost + "' for the CRT-based HTTP client: only "
+                       + "an exact host, a leading '*.' suffix wildcard (e.g. *.example.com), a single '*', or a CIDR range "
+                       + "are supported. This entry is ignored, so requests to matching hosts will go through the proxy.");
     }
 
     public static Optional<HttpMonitoringOptions> resolveHttpMonitoringOptions(CrtConnectionHealthConfiguration config) {

--- a/core/crt-core/src/main/java/software/amazon/awssdk/crtcore/CrtProxyConfiguration.java
+++ b/core/crt-core/src/main/java/software/amazon/awssdk/crtcore/CrtProxyConfiguration.java
@@ -92,7 +92,7 @@ public abstract class CrtProxyConfiguration {
         if (builder.nonProxyHosts != null || proxyConfigProvider == null) {
             return builder.nonProxyHosts;
         }
-        return proxyConfigProvider.nonProxyHosts();
+        return proxyConfigProvider.rawNonProxyHosts();
     }
 
     /**
@@ -280,19 +280,33 @@ public abstract class CrtProxyConfiguration {
         Builder useEnvironmentVariableValues(Boolean useEnvironmentVariableValues);
 
         /**
-         * Configure the hosts that the client is allowed to access without going through the proxy.
-         * The only wildcard available is a single "*" character, which matches all hosts.
-         * IP addresses specified to this option can be provided using CIDR notation: an appended slash and number
-         * specifies the number of "network bits" out of the address to use in the comparison.
+         * Configure the hosts that the client is allowed to access without going through the proxy. Each entry accepts the
+         * same forms as the {@code http.nonProxyHosts} system property:
+         * <ul>
+         *     <li>an exact host name, such as {@code example.com}, which matches {@code example.com} and its subdomains;</li>
+         *     <li>a host name with a leading {@code *} wildcard, such as {@code *.example.com}, which matches
+         *     {@code example.com} and its subdomains;</li>
+         *     <li>a single {@code *}, which matches all hosts;</li>
+         *     <li>an IP range in CIDR notation, such as {@code 10.0.0.0/8}.</li>
+         * </ul>
+         * Entries must not carry surrounding whitespace; a leading or trailing space is treated as part of the host and
+         * prevents matching (for example the space in a comma-space {@code no_proxy=a.com, *.foo.com} value).
          */
         Builder nonProxyHosts(Set<String> nonProxyHosts);
 
 
         /**
-         * Add a host that the client is allowed to access without going through the proxy.
-         * The only wildcard available is a single "*" character, which matches all hosts.
-         * IP addresses specified to this option can be provided using CIDR notation: an appended slash and number
-         * specifies the number of "network bits" out of the address to use in the comparison.
+         * Add a host that the client is allowed to access without going through the proxy. The entry accepts the same forms
+         * as the {@code http.nonProxyHosts} system property:
+         * <ul>
+         *     <li>an exact host name, such as {@code example.com}, which matches {@code example.com} and its subdomains;</li>
+         *     <li>a host name with a leading {@code *} wildcard, such as {@code *.example.com}, which matches
+         *     {@code example.com} and its subdomains;</li>
+         *     <li>a single {@code *}, which matches all hosts;</li>
+         *     <li>an IP range in CIDR notation, such as {@code 10.0.0.0/8}.</li>
+         * </ul>
+         * The entry must not carry surrounding whitespace; a leading or trailing space is treated as part of the host and
+         * prevents matching.
          */
         Builder addNonProxyHost(String nonProxyHost);
 

--- a/core/crt-core/src/test/java/software/amazon/awssdk/crtcore/CrtConnectionUtilsTest.java
+++ b/core/crt-core/src/test/java/software/amazon/awssdk/crtcore/CrtConnectionUtilsTest.java
@@ -88,7 +88,13 @@ class CrtConnectionUtilsTest {
         "*.internal.example.com, .internal.example.com",
         "'*',                    '*'",
         "example.com,            example.com",
-        "10.0.0.0/8,             10.0.0.0/8"
+        "10.0.0.0/8,             10.0.0.0/8",
+        "192.168.*,              192.168.*",
+        "internal*,              internal*",
+        "*foo.com,               *foo.com",
+        "::1,                    ::1",
+        "2001:db8::/32,          2001:db8::/32",
+        "::1/128,                ::1/128"
     })
     void resolveProxy_builderNonProxyHost_translatedToCurlForm(String nonProxyHost, String expectedCurl) {
         TlsContext tlsContext = Mockito.mock(TlsContext.class);

--- a/core/crt-core/src/test/java/software/amazon/awssdk/crtcore/CrtConnectionUtilsTest.java
+++ b/core/crt-core/src/test/java/software/amazon/awssdk/crtcore/CrtConnectionUtilsTest.java
@@ -22,15 +22,25 @@ import java.time.Duration;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.Mockito;
 import software.amazon.awssdk.crt.http.HttpMonitoringOptions;
 import software.amazon.awssdk.crt.http.HttpProxyOptions;
 import software.amazon.awssdk.crt.io.TlsContext;
 
 class CrtConnectionUtilsTest {
+
+    @BeforeEach
+    @AfterEach
+    void clearProxyProperties() {
+        System.clearProperty("http.proxyHost");
+        System.clearProperty("http.proxyPort");
+        System.clearProperty("http.nonProxyHosts");
+    }
 
     @Test
     void resolveProxy_basicAuthorization() {
@@ -73,10 +83,75 @@ class CrtConnectionUtilsTest {
             .isEqualTo("host1,host2");
     }
 
+    @ParameterizedTest(name = "builder nonProxyHost \"{0}\" -> curl \"{1}\"")
+    @CsvSource({
+        "*.internal.example.com, .internal.example.com",
+        "'*',                    '*'",
+        "example.com,            example.com",
+        "10.0.0.0/8,             10.0.0.0/8"
+    })
+    void resolveProxy_builderNonProxyHost_translatedToCurlForm(String nonProxyHost, String expectedCurl) {
+        TlsContext tlsContext = Mockito.mock(TlsContext.class);
+        CrtProxyConfiguration configuration = new TestProxy.Builder().host("1.2.3.4")
+                                                                     .port(123)
+                                                                     .addNonProxyHost(nonProxyHost)
+                                                                     .build();
 
+        assertThat(CrtConfigurationUtils.resolveProxy(configuration, tlsContext).get().getNoProxyHosts())
+            .isEqualTo(expectedCurl);
+    }
+
+    @ParameterizedTest(name = "http.nonProxyHosts \"{0}\" -> curl \"{1}\"")
+    @CsvSource({
+        "*.internal.example.com, .internal.example.com",
+        "'*',                    '*'"
+    })
+    void resolveProxy_systemPropertyNonProxyHost_translatedToCurlForm(String nonProxyHost, String expectedCurl) {
+        System.setProperty("http.proxyHost", "proxy.example.com");
+        System.setProperty("http.proxyPort", "8080");
+        System.setProperty("http.nonProxyHosts", nonProxyHost);
+
+        TlsContext tlsContext = Mockito.mock(TlsContext.class);
+        CrtProxyConfiguration configuration = new TestProxy.Builder().build();
+
+        assertThat(CrtConfigurationUtils.resolveProxy(configuration, tlsContext).get().getNoProxyHosts())
+            .isEqualTo(expectedCurl);
+    }
 
     @Test
-    void resolveProxy_withNullHostAndNonPorxy_shouldNotReturnEmpty( ) {
+    void resolveProxy_builderMixedGlobExactCidr_eachTokenTranslatedIndependently() {
+        TlsContext tlsContext = Mockito.mock(TlsContext.class);
+        CrtProxyConfiguration configuration = new TestProxy.Builder()
+            .host("1.2.3.4")
+            .port(123)
+            .nonProxyHosts(Stream.of("*.internal.example.com", "localhost", "10.0.0.0/8").collect(Collectors.toSet()))
+            .build();
+
+        String noProxyHosts = CrtConfigurationUtils.resolveProxy(configuration, tlsContext).get().getNoProxyHosts();
+        assertThat(noProxyHosts.split(",")).containsExactlyInAnyOrder(".internal.example.com", "localhost", "10.0.0.0/8");
+    }
+
+    @Test
+    void resolveProxy_builderAndSystemPropertySuffixWildcard_produceSameCurlForm() {
+        TlsContext tlsContext = Mockito.mock(TlsContext.class);
+        CrtProxyConfiguration builderConfig = new TestProxy.Builder().host("1.2.3.4")
+                                                                     .port(123)
+                                                                     .addNonProxyHost("*.internal.example.com")
+                                                                     .build();
+        String builderNoProxyHosts = CrtConfigurationUtils.resolveProxy(builderConfig, tlsContext).get().getNoProxyHosts();
+
+        System.setProperty("http.proxyHost", "proxy.example.com");
+        System.setProperty("http.proxyPort", "8080");
+        System.setProperty("http.nonProxyHosts", "*.internal.example.com");
+        CrtProxyConfiguration systemPropertyConfig = new TestProxy.Builder().build();
+        String systemPropertyNoProxyHosts =
+            CrtConfigurationUtils.resolveProxy(systemPropertyConfig, tlsContext).get().getNoProxyHosts();
+
+        assertThat(builderNoProxyHosts).isEqualTo(systemPropertyNoProxyHosts).isEqualTo(".internal.example.com");
+    }
+
+    @Test
+    void resolveProxy_withNullHostAndLiteralNullToken_shouldNotReturnEmpty( ) {
         TlsContext tlsContext = Mockito.mock(TlsContext.class);
         CrtProxyConfiguration configuration = new TestProxy.Builder().host(null)
                                                                      .port(123)
@@ -104,6 +179,7 @@ class CrtConnectionUtilsTest {
 
         Optional<HttpProxyOptions> httpProxyOptions = CrtConfigurationUtils.resolveProxy(configuration, tlsContext);
         assertThat(httpProxyOptions).hasValueSatisfying(proxy -> {
+            assertThat(proxy.getNoProxyHosts()).isEqualTo("someRandom");
             assertThat(proxy.getTlsContext()).isEqualTo(tlsContext);
             assertThat(proxy.getAuthorizationPassword()).isEqualTo("bar");
             assertThat(proxy.getAuthorizationUsername()).isEqualTo("foo");

--- a/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/ProxyConfiguration.java
+++ b/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/ProxyConfiguration.java
@@ -135,14 +135,25 @@ public final class ProxyConfiguration extends CrtProxyConfiguration
         Builder useEnvironmentVariableValues(Boolean useEnvironmentVariableValues);
 
         /**
-         * Configure the hosts that the client is allowed to access without going through the proxy.
+         * Configure the hosts that the client is allowed to access without going through the proxy. Each entry accepts the
+         * same forms as the {@code http.nonProxyHosts} system property: an exact host name such as {@code example.com}, a host
+         * name with a leading {@code *} wildcard such as {@code *.example.com}, a single {@code *} matching all hosts, or an
+         * IP range in CIDR notation such as {@code 10.0.0.0/8}. Both {@code example.com} and {@code *.example.com} match
+         * {@code example.com} and its subdomains. Entries must not carry surrounding whitespace; a leading or trailing space
+         * is treated as part of the host and prevents matching (for example the space in a comma-space
+         * {@code no_proxy=a.com, *.foo.com} value).
          */
         @Override
         Builder nonProxyHosts(Set<String> nonProxyHosts);
 
 
         /**
-         * Add a host that the client is allowed to access without going through the proxy.
+         * Add a host that the client is allowed to access without going through the proxy. The entry accepts the same forms
+         * as the {@code http.nonProxyHosts} system property: an exact host name such as {@code example.com}, a host name with
+         * a leading {@code *} wildcard such as {@code *.example.com}, a single {@code *} matching all hosts, or an IP range in
+         * CIDR notation such as {@code 10.0.0.0/8}. Both {@code example.com} and {@code *.example.com} match
+         * {@code example.com} and its subdomains. The entry must not carry surrounding whitespace; a leading or trailing space
+         * is treated as part of the host and prevents matching.
          */
         @Override
         Builder addNonProxyHost(String nonProxyHost);

--- a/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/CrtNonProxyHostsWildcardWarningTest.java
+++ b/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/CrtNonProxyHostsWildcardWarningTest.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.crt;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.any;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
+import static java.util.Collections.emptyMap;
+import static java.util.stream.Collectors.toSet;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.LogEvent;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.reactivestreams.Subscriber;
+import software.amazon.awssdk.crt.io.EventLoopGroup;
+import software.amazon.awssdk.crt.io.HostResolver;
+import software.amazon.awssdk.http.SdkHttpMethod;
+import software.amazon.awssdk.http.SdkHttpRequest;
+import software.amazon.awssdk.http.SdkHttpResponse;
+import software.amazon.awssdk.http.async.AsyncExecuteRequest;
+import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
+import software.amazon.awssdk.http.async.SdkAsyncHttpResponseHandler;
+import software.amazon.awssdk.testutils.EnvironmentVariableHelper;
+import software.amazon.awssdk.testutils.LogCaptor;
+
+/**
+ * Verifies that a nonProxyHosts entry with an unsupported wildcard placement is logged at WARN by the CRT client, from all
+ * three input sources, while the supported forms are not.
+ */
+class CrtNonProxyHostsWildcardWarningTest {
+
+    private static final String WARN_PREFIX = "Unsupported wildcard in nonProxyHosts entry";
+
+    private final EnvironmentVariableHelper environmentVariableHelper = new EnvironmentVariableHelper();
+    private SdkAsyncHttpClient client;
+
+    @AfterEach
+    public void teardown() {
+        environmentVariableHelper.reset();
+        System.clearProperty("http.proxyHost");
+        System.clearProperty("http.proxyPort");
+        System.clearProperty("http.nonProxyHosts");
+        if (client != null) {
+            client.close();
+        }
+        EventLoopGroup.closeStaticDefault();
+        HostResolver.closeStaticDefault();
+    }
+
+    @ParameterizedTest(name = "builder \"{0}\" warns")
+    @ValueSource(strings = {"192.168.*", "internal*", "in*ternal", "*foo.com"})
+    void unsupportedWildcard_builder_logsWarnOnce(String entry) {
+        try (LogCaptor logCaptor = LogCaptor.create(Level.WARN)) {
+            client = AwsCrtAsyncHttpClient.builder()
+                                          .proxyConfiguration(ProxyConfiguration.builder()
+                                                                                .host("localhost")
+                                                                                .port(1234)
+                                                                                .nonProxyHosts(single(entry))
+                                                                                .build())
+                                          .build();
+            assertWarnedOnceFor(logCaptor, entry);
+        }
+    }
+
+    @ParameterizedTest(name = "http.nonProxyHosts \"{0}\" warns")
+    @ValueSource(strings = {"192.168.*", "internal*", "in*ternal", "*foo.com"})
+    void unsupportedWildcard_systemProperty_logsWarnOnce(String entry) {
+        System.setProperty("http.proxyHost", "localhost");
+        System.setProperty("http.proxyPort", "1234");
+        System.setProperty("http.nonProxyHosts", entry);
+        try (LogCaptor logCaptor = LogCaptor.create(Level.WARN)) {
+            client = AwsCrtAsyncHttpClient.builder()
+                                          .proxyConfiguration(ProxyConfiguration.builder().build())
+                                          .build();
+            assertWarnedOnceFor(logCaptor, entry);
+        }
+    }
+
+    @ParameterizedTest(name = "no_proxy \"{0}\" warns")
+    @ValueSource(strings = {"192.168.*", "internal*", "in*ternal", "*foo.com"})
+    void unsupportedWildcard_environmentVariable_logsWarnOnce(String entry) {
+        environmentVariableHelper.set("http_proxy", "http://localhost:1234");
+        environmentVariableHelper.set("no_proxy", entry);
+        try (LogCaptor logCaptor = LogCaptor.create(Level.WARN)) {
+            client = AwsCrtAsyncHttpClient.builder()
+                                          .proxyConfiguration(ProxyConfiguration.builder()
+                                                                                .useSystemPropertyValues(false)
+                                                                                .build())
+                                          .build();
+            assertWarnedOnceFor(logCaptor, entry);
+        }
+    }
+
+    @ParameterizedTest(name = "supported \"{0}\" does not warn")
+    @ValueSource(strings = {"example.com", "*.internal.example.com", "*", "10.0.0.0/8"})
+    void supportedForm_builder_doesNotWarn(String entry) {
+        try (LogCaptor logCaptor = LogCaptor.create(Level.WARN)) {
+            client = AwsCrtAsyncHttpClient.builder()
+                                          .proxyConfiguration(ProxyConfiguration.builder()
+                                                                                .host("localhost")
+                                                                                .port(1234)
+                                                                                .nonProxyHosts(single(entry))
+                                                                                .build())
+                                          .build();
+            assertThat(warnRecords(logCaptor)).isEmpty();
+        }
+    }
+
+    @Test
+    void unsupportedWildcard_multipleRequests_warnsExactlyOnce() throws Exception {
+        WireMockServer mockServer = new WireMockServer(new WireMockConfiguration().dynamicPort());
+        mockServer.start();
+        mockServer.stubFor(any(anyUrl()).willReturn(aResponse().withStatus(200).withBody("hello")));
+        try (LogCaptor logCaptor = LogCaptor.create(Level.WARN)) {
+            client = AwsCrtAsyncHttpClient.builder()
+                                          .proxyConfiguration(ProxyConfiguration.builder()
+                                                                                .host("localhost")
+                                                                                .port(mockServer.port())
+                                                                                .nonProxyHosts(single("192.168.*"))
+                                                                                .build())
+                                          .build();
+
+            sendRequest(URI.create("http://localhost:" + mockServer.port()));
+            sendRequest(URI.create("http://localhost:" + mockServer.port()));
+
+            assertWarnedOnceFor(logCaptor, "192.168.*");
+        } finally {
+            mockServer.stop();
+        }
+    }
+
+    private static Set<String> single(String entry) {
+        return Stream.of(entry).collect(toSet());
+    }
+
+    private static List<LogEvent> warnRecords(LogCaptor logCaptor) {
+        return logCaptor.loggedEvents().stream()
+                        .filter(e -> e.getMessage().getFormattedMessage().contains(WARN_PREFIX))
+                        .collect(Collectors.toList());
+    }
+
+    private static void assertWarnedOnceFor(LogCaptor logCaptor, String entry) {
+        assertThat(warnRecords(logCaptor))
+            .singleElement()
+            .satisfies(event -> {
+                assertThat(event.getLevel()).isEqualTo(Level.WARN);
+                assertThat(event.getMessage().getFormattedMessage()).contains(WARN_PREFIX + " '" + entry + "'");
+            });
+    }
+
+    private void sendRequest(URI uri) throws Exception {
+        CompletableFuture<Boolean> streamReceived = new CompletableFuture<>();
+        AtomicReference<SdkHttpResponse> response = new AtomicReference<>(null);
+        AtomicReference<Throwable> error = new AtomicReference<>(null);
+        Subscriber<ByteBuffer> subscriber = CrtHttpClientTestUtils.createDummySubscriber();
+        SdkAsyncHttpResponseHandler handler =
+            CrtHttpClientTestUtils.createTestResponseHandler(response, streamReceived, error, subscriber);
+        SdkHttpRequest request = CrtHttpClientTestUtils.createRequest(uri, "/", null, SdkHttpMethod.GET, emptyMap());
+
+        client.execute(AsyncExecuteRequest.builder()
+                                          .request(request)
+                                          .responseHandler(handler)
+                                          .requestContentPublisher(new EmptyPublisher())
+                                          .build())
+              .exceptionally(t -> null)
+              .get(60, TimeUnit.SECONDS);
+    }
+}

--- a/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/CrtProxyWireMockTest.java
+++ b/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/CrtProxyWireMockTest.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+
+package software.amazon.awssdk.http.crt;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.any;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
+import static java.util.Collections.emptyMap;
+import static java.util.stream.Collectors.toSet;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.reactivestreams.Subscriber;
+import software.amazon.awssdk.crt.io.EventLoopGroup;
+import software.amazon.awssdk.crt.io.HostResolver;
+import software.amazon.awssdk.http.SdkHttpMethod;
+import software.amazon.awssdk.http.SdkHttpRequest;
+import software.amazon.awssdk.http.SdkHttpResponse;
+import software.amazon.awssdk.http.async.AsyncExecuteRequest;
+import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
+import software.amazon.awssdk.http.async.SdkAsyncHttpResponseHandler;
+import software.amazon.awssdk.testutils.EnvironmentVariableHelper;
+
+/**
+ * Verifies that a wildcard {@code http.nonProxyHosts} entry keeps matching hosts OFF the proxy on the CRT client. The routing
+ * decision is observed via the mock proxy's request journal, so the destination host does not need to resolve.
+ */
+class CrtProxyWireMockTest {
+    private SdkAsyncHttpClient client;
+
+    private final WireMockServer mockProxy = new WireMockServer(new WireMockConfiguration().dynamicPort());
+    private final WireMockServer mockServer = new WireMockServer(new WireMockConfiguration().dynamicPort());
+
+    @BeforeEach
+    public void setup() {
+        mockProxy.start();
+        mockServer.start();
+        mockProxy.stubFor(any(anyUrl()).willReturn(aResponse().withStatus(200).withBody("hello")));
+        mockServer.stubFor(any(anyUrl()).willReturn(aResponse().withStatus(200).withBody("hello")));
+    }
+
+    @AfterEach
+    public void teardown() {
+        System.clearProperty("http.proxyHost");
+        System.clearProperty("http.proxyPort");
+        System.clearProperty("http.nonProxyHosts");
+        mockServer.stop();
+        mockProxy.stop();
+        if (client != null) {
+            client.close();
+        }
+        EventLoopGroup.closeStaticDefault();
+        HostResolver.closeStaticDefault();
+    }
+
+    @Test
+    void suffixWildcardNonProxyHost_systemProperty_bypassesProxy() throws Exception {
+        System.setProperty("http.proxyHost", "localhost");
+        System.setProperty("http.proxyPort", Integer.toString(mockProxy.port()));
+        System.setProperty("http.nonProxyHosts", "*.internal.example.com");
+
+        client = AwsCrtAsyncHttpClient.builder()
+                                      .proxyConfiguration(ProxyConfiguration.builder().build())
+                                      .build();
+
+        sendRequest(URI.create("http://api.internal.example.com"));
+
+        mockProxy.verify(0, anyRequestedFor(anyUrl()));
+    }
+
+    @Test
+    void suffixWildcardNonProxyHost_rootDomainHost_bypassesProxy() throws Exception {
+        System.setProperty("http.proxyHost", "localhost");
+        System.setProperty("http.proxyPort", Integer.toString(mockProxy.port()));
+        System.setProperty("http.nonProxyHosts", "*.internal.example.com");
+
+        client = AwsCrtAsyncHttpClient.builder()
+                                      .proxyConfiguration(ProxyConfiguration.builder().build())
+                                      .build();
+
+        sendRequest(URI.create("http://internal.example.com"));
+
+        mockProxy.verify(0, anyRequestedFor(anyUrl()));
+    }
+
+    @Test
+    void exactHostNonProxyHost_systemProperty_bypassesProxy() throws Exception {
+        System.setProperty("http.proxyHost", "localhost");
+        System.setProperty("http.proxyPort", Integer.toString(mockProxy.port()));
+        System.setProperty("http.nonProxyHosts", "api.internal.example.com");
+
+        client = AwsCrtAsyncHttpClient.builder()
+                                      .proxyConfiguration(ProxyConfiguration.builder().build())
+                                      .build();
+
+        sendRequest(URI.create("http://api.internal.example.com"));
+
+        mockProxy.verify(0, anyRequestedFor(anyUrl()));
+    }
+
+    @Test
+    void nonMatchingHost_withSuffixWildcardNonProxyHost_isProxied() throws Exception {
+        System.setProperty("http.proxyHost", "localhost");
+        System.setProperty("http.proxyPort", Integer.toString(mockProxy.port()));
+        System.setProperty("http.nonProxyHosts", "*.internal.example.com");
+
+        client = AwsCrtAsyncHttpClient.builder()
+                                      .proxyConfiguration(ProxyConfiguration.builder().build())
+                                      .build();
+
+        sendRequest(URI.create("http://api.external.example.com"));
+
+        mockProxy.verify(1, anyRequestedFor(anyUrl()));
+    }
+
+    @Test
+    void suffixWildcardNonProxyHost_environmentVariable_bypassesProxy() throws Exception {
+        EnvironmentVariableHelper environmentVariableHelper = new EnvironmentVariableHelper();
+        try {
+            environmentVariableHelper.set("http_proxy", "http://localhost:" + mockProxy.port());
+            environmentVariableHelper.set("no_proxy", "*.internal.example.com");
+
+            client = AwsCrtAsyncHttpClient.builder()
+                                          .proxyConfiguration(ProxyConfiguration.builder()
+                                                                                .useSystemPropertyValues(false)
+                                                                                .build())
+                                          .build();
+
+            sendRequest(URI.create("http://api.internal.example.com"));
+
+            mockProxy.verify(0, anyRequestedFor(anyUrl()));
+        } finally {
+            environmentVariableHelper.reset();
+        }
+    }
+
+    @Test
+    void bareWildcardNonProxyHost_systemProperty_reachesServerDirectly() throws Exception {
+        System.setProperty("http.proxyHost", "localhost");
+        System.setProperty("http.proxyPort", Integer.toString(mockProxy.port()));
+        System.setProperty("http.nonProxyHosts", "*");
+
+        client = AwsCrtAsyncHttpClient.builder()
+                                      .proxyConfiguration(ProxyConfiguration.builder().build())
+                                      .build();
+
+        sendRequest(URI.create("http://localhost:" + mockServer.port()));
+
+        mockProxy.verify(0, anyRequestedFor(anyUrl()));
+        mockServer.verify(1, anyRequestedFor(anyUrl()));
+    }
+
+    @Test
+    void nonLeadingWildcardNonProxyHost_hostPrefix_isProxied() throws Exception {
+        client = AwsCrtAsyncHttpClient.builder()
+                                      .proxyConfiguration(ProxyConfiguration.builder()
+                                                                            .host("localhost")
+                                                                            .port(mockProxy.port())
+                                                                            .nonProxyHosts(Stream.of("internal*").collect(toSet()))
+                                                                            .build())
+                                      .build();
+
+        sendRequest(URI.create("http://internalservice.example.com"));
+
+        mockProxy.verify(1, anyRequestedFor(anyUrl()));
+    }
+
+    @Test
+    void nonLeadingWildcardNonProxyHost_ipPrefix_isProxied() throws Exception {
+        client = AwsCrtAsyncHttpClient.builder()
+                                      .proxyConfiguration(ProxyConfiguration.builder()
+                                                                            .host("localhost")
+                                                                            .port(mockProxy.port())
+                                                                            .nonProxyHosts(Stream.of("192.168.*").collect(toSet()))
+                                                                            .build())
+                                      .build();
+
+        sendRequest(URI.create("http://192.168.1.1"));
+
+        mockProxy.verify(1, anyRequestedFor(anyUrl()));
+    }
+
+    private void sendRequest(URI uri) throws Exception {
+        CompletableFuture<Boolean> streamReceived = new CompletableFuture<>();
+        AtomicReference<SdkHttpResponse> response = new AtomicReference<>(null);
+        AtomicReference<Throwable> error = new AtomicReference<>(null);
+        Subscriber<ByteBuffer> subscriber = CrtHttpClientTestUtils.createDummySubscriber();
+        SdkAsyncHttpResponseHandler handler =
+            CrtHttpClientTestUtils.createTestResponseHandler(response, streamReceived, error, subscriber);
+        SdkHttpRequest request = CrtHttpClientTestUtils.createRequest(uri, "/", null, SdkHttpMethod.GET, emptyMap());
+
+        client.execute(AsyncExecuteRequest.builder()
+                                          .request(request)
+                                          .responseHandler(handler)
+                                          .requestContentPublisher(new EmptyPublisher())
+                                          .build())
+              .exceptionally(t -> null)
+              .get(60, TimeUnit.SECONDS);
+    }
+}

--- a/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/CrtProxyWireMockTest.java
+++ b/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/CrtProxyWireMockTest.java
@@ -34,6 +34,8 @@ import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.reactivestreams.Subscriber;
 import software.amazon.awssdk.crt.io.EventLoopGroup;
 import software.amazon.awssdk.crt.io.HostResolver;
@@ -158,6 +160,32 @@ class CrtProxyWireMockTest {
         }
     }
 
+    // Both the comma and comma-space no_proxy spellings must route the same: the wildcard entry (*.foo.com) bypasses
+    // sub.foo.com, and the second entry (a.com) - which carries a leading space in the comma-space form - bypasses a.com
+    // after the CRT-side whitespace trim.
+    @ParameterizedTest(name = "no_proxy=\"{0}\"")
+    @ValueSource(strings = {"*.foo.com,a.com", "*.foo.com, a.com"})
+    void commaSeparatedNonProxyHosts_environmentVariable_bypassesProxy(String noProxy) throws Exception {
+        EnvironmentVariableHelper environmentVariableHelper = new EnvironmentVariableHelper();
+        try {
+            environmentVariableHelper.set("http_proxy", "http://localhost:" + mockProxy.port());
+            environmentVariableHelper.set("no_proxy", noProxy);
+
+            client = AwsCrtAsyncHttpClient.builder()
+                                          .proxyConfiguration(ProxyConfiguration.builder()
+                                                                                .useSystemPropertyValues(false)
+                                                                                .build())
+                                          .build();
+
+            sendRequest(URI.create("http://sub.foo.com"));
+            sendRequest(URI.create("http://a.com"));
+
+            mockProxy.verify(0, anyRequestedFor(anyUrl()));
+        } finally {
+            environmentVariableHelper.reset();
+        }
+    }
+
     @Test
     void bareWildcardNonProxyHost_systemProperty_reachesServerDirectly() throws Exception {
         System.setProperty("http.proxyHost", "localhost");
@@ -200,6 +228,21 @@ class CrtProxyWireMockTest {
                                       .build();
 
         sendRequest(URI.create("http://192.168.1.1"));
+
+        mockProxy.verify(1, anyRequestedFor(anyUrl()));
+    }
+
+    @Test
+    void nonLeadingWildcardNonProxyHost_notReinterpretedAsSuffixWildcard_apexProxied() throws Exception {
+        client = AwsCrtAsyncHttpClient.builder()
+                                      .proxyConfiguration(ProxyConfiguration.builder()
+                                                                            .host("localhost")
+                                                                            .port(mockProxy.port())
+                                                                            .nonProxyHosts(Stream.of("*foo.com").collect(toSet()))
+                                                                            .build())
+                                      .build();
+
+        sendRequest(URI.create("http://foo.com"));
 
         mockProxy.verify(1, anyRequestedFor(anyUrl()));
     }

--- a/test/architecture-tests/src/test/java/software/amazon/awssdk/archtests/CodingConventionWithSuppressionTest.java
+++ b/test/architecture-tests/src/test/java/software/amazon/awssdk/archtests/CodingConventionWithSuppressionTest.java
@@ -59,6 +59,7 @@ public class CodingConventionWithSuppressionTest {
                           "software.amazon.awssdk.services.s3.internal.crt.CrtResponseFileResponseTransformer"),
                       ArchUtils.classNameToPattern("software.amazon.awssdk.http.crt.AwsCrtHttpClientBase"),
                       ArchUtils.classNameToPattern("software.amazon.awssdk.http.crt.internal.AwsCrtConfigurationUtils"),
+                      ArchUtils.classNameToPattern("software.amazon.awssdk.crtcore.CrtConfigurationUtils"),
                       ArchUtils.classNameToPattern(
                           "software.amazon.awssdk.http.crt.internal.response.CrtResponseAdapter"),
                       ArchUtils.classNameToPattern(RetryableSubAsyncRequestBody.class),

--- a/utils/src/main/java/software/amazon/awssdk/utils/ProxyConfigProvider.java
+++ b/utils/src/main/java/software/amazon/awssdk/utils/ProxyConfigProvider.java
@@ -122,4 +122,21 @@ public interface ProxyConfigProvider {
      * @return A set containing the non-proxy host names.
      */
     Set<String> nonProxyHosts();
+
+    /**
+     * Gets the set of non-proxy hosts as raw tokens, i.e. without the {@code * -> .*?} Java-regex rewrite that
+     * {@link #nonProxyHosts()} applies for system-property and environment-variable sources. Consumers whose matcher expects
+     * the raw {@code nonProxyHosts} tokens (such as the CRT client's curl-style native matcher) must use this instead of
+     * {@link #nonProxyHosts()}.
+     *
+     * <p>The default throws {@link UnsupportedOperationException} rather than falling back to {@link #nonProxyHosts()}: a
+     * fallback would silently feed Java-regex tokens into a curl-style matcher and reintroduce incorrect proxy bypass.
+     * Implementations consumed by CRT-based clients must override it.
+     *
+     * @return A set containing the raw non-proxy host tokens.
+     */
+    default Set<String> rawNonProxyHosts() {
+        throw new UnsupportedOperationException("rawNonProxyHosts() must be implemented to supply un-rewritten nonProxyHosts "
+                                                + "tokens for curl-style matchers such as the CRT client.");
+    }
 }

--- a/utils/src/main/java/software/amazon/awssdk/utils/internal/proxy/ProxyEnvironmentVariableConfigProvider.java
+++ b/utils/src/main/java/software/amazon/awssdk/utils/internal/proxy/ProxyEnvironmentVariableConfigProvider.java
@@ -96,4 +96,12 @@ public class ProxyEnvironmentVariableConfigProvider implements ProxyConfigProvid
     public Set<String> nonProxyHosts() {
         return parseNonProxyHostsEnvironmentVariable();
     }
+
+    @Override
+    public Set<String> rawNonProxyHosts() {
+        String hosts = ProxyEnvironmentSetting.NO_PROXY.getStringValue()
+                                                       .map(noProxyHost -> noProxyHost.replace(",", "|"))
+                                                       .orElse(null);
+        return ProxyUtils.splitToGlobTokens(hosts);
+    }
 }

--- a/utils/src/main/java/software/amazon/awssdk/utils/internal/proxy/ProxySystemPropertyConfigProvider.java
+++ b/utils/src/main/java/software/amazon/awssdk/utils/internal/proxy/ProxySystemPropertyConfigProvider.java
@@ -84,4 +84,9 @@ public class ProxySystemPropertyConfigProvider implements ProxyConfigProvider {
     public Set<String> nonProxyHosts() {
         return parseNonProxyHostsProperty();
     }
+
+    @Override
+    public Set<String> rawNonProxyHosts() {
+        return ProxyUtils.splitToGlobTokens(ProxySystemSetting.NON_PROXY_HOSTS.getStringValue().orElse(null));
+    }
 }

--- a/utils/src/main/java/software/amazon/awssdk/utils/internal/proxy/ProxyUtils.java
+++ b/utils/src/main/java/software/amazon/awssdk/utils/internal/proxy/ProxyUtils.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.utils.internal.proxy;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Set;
+import java.util.stream.Collectors;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.utils.StringUtils;
+
+/**
+ * Splits a pipe-separated {@code nonProxyHosts} string into its lowercased tokens WITHOUT the {@code * -> .*?} Java-regex
+ * rewrite that {@code SdkHttpUtils#parseNonProxyHostsProperty()} applies. The returned tokens keep their documented forms
+ * (exact host, {@code *.suffix}, bare {@code *}, CIDR), which is what a curl-style matcher such as the CRT client's native
+ * matcher expects. The regex-rewritten form remains available via {@code SdkHttpUtils} for the Netty/Apache/url-connection
+ * clients.
+ */
+@SdkInternalApi
+final class ProxyUtils {
+
+    private ProxyUtils() {
+    }
+
+    static Set<String> splitToGlobTokens(String nonProxyHosts) {
+        if (nonProxyHosts != null && !StringUtils.isEmpty(nonProxyHosts)) {
+            return Arrays.stream(nonProxyHosts.split("\\|"))
+                         .map(String::toLowerCase)
+                         .collect(Collectors.toSet());
+        }
+        return Collections.emptySet();
+    }
+}

--- a/utils/src/main/java/software/amazon/awssdk/utils/internal/proxy/ProxyUtils.java
+++ b/utils/src/main/java/software/amazon/awssdk/utils/internal/proxy/ProxyUtils.java
@@ -23,11 +23,12 @@ import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.utils.StringUtils;
 
 /**
- * Splits a pipe-separated {@code nonProxyHosts} string into its lowercased tokens WITHOUT the {@code * -> .*?} Java-regex
- * rewrite that {@code SdkHttpUtils#parseNonProxyHostsProperty()} applies. The returned tokens keep their documented forms
- * (exact host, {@code *.suffix}, bare {@code *}, CIDR), which is what a curl-style matcher such as the CRT client's native
- * matcher expects. The regex-rewritten form remains available via {@code SdkHttpUtils} for the Netty/Apache/url-connection
- * clients.
+ * Splits a pipe-separated {@code nonProxyHosts} string into its trimmed, lowercased tokens WITHOUT the {@code * -> .*?}
+ * Java-regex rewrite that {@code SdkHttpUtils#parseNonProxyHostsProperty()} applies. Surrounding whitespace is trimmed so the
+ * common comma-space {@code no_proxy=a.com, *.foo.com} form (which arrives as {@code " *.foo.com"} after the {@code , -> |}
+ * normalization) is matched correctly. The returned tokens keep their documented forms (exact host, {@code *.suffix}, bare
+ * {@code *}, CIDR), which is what a curl-style matcher such as the CRT client's native matcher expects. The regex-rewritten
+ * form remains available via {@code SdkHttpUtils} for the Netty/Apache/url-connection clients.
  */
 @SdkInternalApi
 final class ProxyUtils {
@@ -38,6 +39,7 @@ final class ProxyUtils {
     static Set<String> splitToGlobTokens(String nonProxyHosts) {
         if (nonProxyHosts != null && !StringUtils.isEmpty(nonProxyHosts)) {
             return Arrays.stream(nonProxyHosts.split("\\|"))
+                         .map(String::trim)
                          .map(String::toLowerCase)
                          .collect(Collectors.toSet());
         }

--- a/utils/src/test/java/software/amazon/awssdk/utils/SdkHttpUtilsTest.java
+++ b/utils/src/test/java/software/amazon/awssdk/utils/SdkHttpUtilsTest.java
@@ -318,5 +318,19 @@ public class SdkHttpUtilsTest {
                                             .collect(Collectors.toSet()));
     }
 
-
+    @Test
+    void parseNonProxyHostsProperty_regexPathStillRewritesWildcard() {
+        String previous = System.getProperty("http.nonProxyHosts");
+        System.setProperty("http.nonProxyHosts", "example.com|*greedy.org");
+        try {
+            assertThat(SdkHttpUtils.parseNonProxyHostsProperty())
+                .isEqualTo(Stream.of("example.com", ".*?greedy.org").collect(Collectors.toSet()));
+        } finally {
+            if (previous == null) {
+                System.clearProperty("http.nonProxyHosts");
+            } else {
+                System.setProperty("http.nonProxyHosts", previous);
+            }
+        }
+    }
 }

--- a/utils/src/test/java/software/amazon/awssdk/utils/proxy/ProxyConfigurationTest.java
+++ b/utils/src/test/java/software/amazon/awssdk/utils/proxy/ProxyConfigurationTest.java
@@ -25,8 +25,10 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import software.amazon.awssdk.testutils.EnvironmentVariableHelper;
 import software.amazon.awssdk.utils.ProxyConfigProvider;
@@ -207,6 +209,41 @@ public class ProxyConfigurationTest {
         setEnvironmentProperties(envSystemSetting, "https");
         assertProxyEquals(ProxyConfigProvider.fromSystemPropertySettings("https"), expectedProxySetting);
         assertProxyEquals(ProxyConfigProvider.fromEnvironmentSettings("https"), expectedProxySetting);
+    }
+
+    @ParameterizedTest(name = "http.nonProxyHosts \"{0}\" -> raw \"{1}\" (no regex rewrite)")
+    @CsvSource({
+        "*.greedy.org, *.greedy.org",
+        "'*',          '*'",
+        "greedy*,      greedy*",
+        "192.168.*,    192.168.*",
+        "Example.COM,  example.com"
+    })
+    void rawNonProxyHosts_systemProperty_notRewrittenToRegex(String token, String expected) {
+        System.setProperty("http.nonProxyHosts", token);
+        assertThat(ProxyConfigProvider.fromSystemPropertySettings("http").rawNonProxyHosts())
+            .containsExactly(expected);
+    }
+
+    @ParameterizedTest(name = "no_proxy \"{0}\" -> raw \"{1}\" (no regex rewrite)")
+    @CsvSource({
+        "*.greedy.org, *.greedy.org",
+        "'*',          '*'",
+        "greedy*,      greedy*",
+        "192.168.*,    192.168.*",
+        "Example.COM,  example.com"
+    })
+    void rawNonProxyHosts_environmentVariable_notRewrittenToRegex(String token, String expected) {
+        ENVIRONMENT_VARIABLE_HELPER.set("no_proxy", token);
+        assertThat(ProxyConfigProvider.fromEnvironmentSettings("http").rawNonProxyHosts())
+            .containsExactly(expected);
+    }
+
+    @Test
+    void nonProxyHosts_systemProperty_stillRewritesWildcardToRegex() {
+        System.setProperty("http.nonProxyHosts", "example.com|*greedy.org");
+        assertThat(ProxyConfigProvider.fromSystemPropertySettings("http").nonProxyHosts())
+            .containsExactlyInAnyOrder("example.com", ".*?greedy.org");
     }
 
     private static class ExpectedProxySetting {


### PR DESCRIPTION
## Motivation and Context

`nonProxyHosts` lets a client bypass the proxy for hosts a customer lists (via `http.nonProxyHosts`, the `no_proxy` environment variable, or the client builder). On CRT-based clients, wildcard entries were not applied: a `*.example.com` entry or a bare `*` did not match, so a request to a host the entry was meant to cover connected through the proxy rather than directly.

This affects the CRT-based clients — `AwsCrtHttpClient`, `AwsCrtAsyncHttpClient`, and the S3/CRT client — when a proxy is configured and a wildcard `nonProxyHosts`/`no_proxy` entry is used. Exact-host and CIDR entries were already applied correctly and are unchanged. The behavior is pre-existing (not a regression). Because a matching host was routed through the proxy instead of connecting directly, traffic a customer intended to keep off the proxy could pass through it; the fix makes wildcard entries behave the same way they do on the other clients.

**Root cause.** There is one shared `nonProxyHosts` parser and several downstream matchers with different expectations. The shared parser (`SdkHttpUtils`) rewrites each glob token by replacing `*` with the Java-regex fragment `.*?`. That is correct for the Netty/Apache/url-connection clients, which match with `host.matches(regex)`. The CRT client hands the same set to the native aws-c-http matcher via `HttpProxyOptions.setNoProxyHosts`; that matcher is curl-style (exact host, dot-anchored suffix, CIDR, bare `*`) and cannot interpret a Java regex. So `*.example.com` reached CRT as `.*?.example.com`, which the native matcher matches against no host, and bare `*` reached it as `.*?`, likewise matching nothing.

## Modifications

Fix scoped to the CRT path only; the Java-regex clients (Netty, Apache, url-connection) are not modified.

- **Source raw tokens for the CRT path.** `ProxyConfigProvider` gains a `rawNonProxyHosts()` accessor that returns the split, lowercased tokens WITHOUT the `* -> .*?` rewrite. It is a `default` that throws `UnsupportedOperationException` (not abstract) to preserve backward compatibility for this `@SdkProtectedApi` interface; the two concrete providers (`ProxySystemPropertyConfigProvider`, `ProxyEnvironmentVariableConfigProvider`) override it, delegating the shared split to a new `@SdkInternalApi` `ProxyNonProxyHostParser` helper. 
- **Translate at the CRT.** `CrtProxyConfiguration` sources `rawNonProxyHosts()`, and `CrtConfigurationUtils.resolveProxy` translates each token to the curl form before calling `setNoProxyHosts`: a leading-`*` wildcard (`*.example.com`) becomes the dot-anchored suffix (`.example.com`); a bare `*`, exact host names, and CIDR ranges pass through unchanged. Builder-supplied values were already raw, so both CRT input paths (system property / environment variable, and the client builder) are normalized to the same form before translation.
- **Javadoc.** The CRT builder `nonProxyHosts(Set)` / `addNonProxyHost(String)` docs (crt-core `CrtProxyConfiguration.Builder` and the aws-crt-client `ProxyConfiguration.Builder` override) now describe the accepted forms in plain language and note the whitespace requirement.

**Supported forms** (same as the `http.nonProxyHosts` system property): an exact host name such as `example.com`; a leading-`*` wildcard such as `*.example.com`; a single `*` for all hosts; a CIDR range such as `10.0.0.0/8`. Entries must not carry surrounding whitespace: a leading or trailing space is treated as part of the host and prevents matching (this affects the common comma-space `no_proxy=a.com, *.foo.com` spelling and is documented rather than silently trimmed, since the shared parser feeds the untouched Java-regex clients too).

## Testing

- **End-to-end mock-proxy routing tests** (`CrtProxyWildcardNonProxyHostsTest`, aws-crt-client): a WireMock proxy observes the routing decision via its request journal (no live destination needed). 
- **crt-core unit tests** (`CrtConnectionUtilsTest`): parameterized glob-to-curl translation for the builder and system-property paths, multi-entry mixed sets, both-input-paths-converge, and the null-token filter.
- **utils unit tests


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I have read the CONTRIBUTING document
- [ ] Local run of `mvn install` succeeds <!-- built the affected modules (utils, crt-core, aws-crt-client), not a full-repo mvn install -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated LaunchChangelog

## License
- [x] I confirm that this pull request can be released under the Apache 2 license
