### PR TITLE
Add SHA256 support to CloudFrontUtilities

### DIFF
--- a/.changes/next-release/feature-AmazonCloudFront-56df8d7.json
+++ b/.changes/next-release/feature-AmazonCloudFront-56df8d7.json
@@ -1,0 +1,6 @@
+{
+    "type": "feature",
+    "category": "Amazon CloudFront",
+    "contributor": "",
+    "description": "Adds SHA256 support to CloudFrontUtilities"
+}

--- a/services/cloudfront/src/main/java/software/amazon/awssdk/services/cloudfront/CloudFrontUtilities.java
+++ b/services/cloudfront/src/main/java/software/amazon/awssdk/services/cloudfront/CloudFrontUtilities.java
@@ -33,7 +33,7 @@ import software.amazon.awssdk.services.cloudfront.internal.url.DefaultSignedUrl;
 import software.amazon.awssdk.services.cloudfront.internal.utils.SigningUtils;
 import software.amazon.awssdk.services.cloudfront.model.CannedSignerRequest;
 import software.amazon.awssdk.services.cloudfront.model.CustomSignerRequest;
-import software.amazon.awssdk.services.cloudfront.model.HashAlgorithm;
+import software.amazon.awssdk.services.cloudfront.utils.SigningHashAlgorithm;
 import software.amazon.awssdk.services.cloudfront.url.SignedUrl;
 
 /**
@@ -381,7 +381,7 @@ public final class CloudFrontUtilities {
                 .keyPairIdHeaderValue(KEY_PAIR_ID_KEY + "=" + request.keyPairId())
                 .signatureHeaderValue(SIGNATURE_KEY + "=" + urlSafeSignature)
                 .expiresHeaderValue(EXPIRES_KEY + "=" + expiry);
-            if (request.hashAlgorithm() != HashAlgorithm.SHA1) {
+            if (request.hashAlgorithm() != SigningHashAlgorithm.SHA1) {
                 builder.hashAlgorithmHeaderValue(HASH_ALGORITHM_KEY + "=" + request.hashAlgorithm().id());
             }
             return builder.build();
@@ -500,7 +500,7 @@ public final class CloudFrontUtilities {
                 .keyPairIdHeaderValue(KEY_PAIR_ID_KEY + "=" + request.keyPairId())
                 .signatureHeaderValue(SIGNATURE_KEY + "=" + urlSafeSignature)
                 .policyHeaderValue(POLICY_KEY + "=" + urlSafePolicy);
-            if (request.hashAlgorithm() != HashAlgorithm.SHA1) {
+            if (request.hashAlgorithm() != SigningHashAlgorithm.SHA1) {
                 builder.hashAlgorithmHeaderValue(HASH_ALGORITHM_KEY + "=" + request.hashAlgorithm().id());
             }
             return builder.build();
@@ -510,11 +510,11 @@ public final class CloudFrontUtilities {
     }
 
     private static byte[] signPolicy(byte[] policyToSign, PrivateKey privateKey,
-                                      HashAlgorithm hashAlgorithm) throws InvalidKeyException {
+                                      SigningHashAlgorithm hashAlgorithm) throws InvalidKeyException {
         return SigningUtils.sign(policyToSign, privateKey, javaSecuritySigningAlgorithm(privateKey, hashAlgorithm));
     }
 
-    private static String javaSecuritySigningAlgorithm(PrivateKey privateKey, HashAlgorithm hashAlgorithm) {
+    private static String javaSecuritySigningAlgorithm(PrivateKey privateKey, SigningHashAlgorithm hashAlgorithm) {
         switch (privateKey.getAlgorithm()) {
             case "RSA":
                 return hashAlgorithm.id() + "withRSA";
@@ -529,8 +529,8 @@ public final class CloudFrontUtilities {
     }
 
     // Returns empty string for SHA-1 to preserve backwards-compatible URL shape (CloudFront defaults to SHA-1 when omitted).
-    private static String hashAlgorithmUrlParam(HashAlgorithm hashAlgorithm) {
-        return hashAlgorithm == HashAlgorithm.SHA1 ? "" : "&Hash-Algorithm=" + hashAlgorithm.id();
+    private static String hashAlgorithmUrlParam(SigningHashAlgorithm hashAlgorithm) {
+        return hashAlgorithm == SigningHashAlgorithm.SHA1 ? "" : "&Hash-Algorithm=" + hashAlgorithm.id();
     }
 
 }

--- a/services/cloudfront/src/main/java/software/amazon/awssdk/services/cloudfront/CloudFrontUtilities.java
+++ b/services/cloudfront/src/main/java/software/amazon/awssdk/services/cloudfront/CloudFrontUtilities.java
@@ -33,6 +33,7 @@ import software.amazon.awssdk.services.cloudfront.internal.url.DefaultSignedUrl;
 import software.amazon.awssdk.services.cloudfront.internal.utils.SigningUtils;
 import software.amazon.awssdk.services.cloudfront.model.CannedSignerRequest;
 import software.amazon.awssdk.services.cloudfront.model.CustomSignerRequest;
+import software.amazon.awssdk.services.cloudfront.model.HashAlgorithm;
 import software.amazon.awssdk.services.cloudfront.url.SignedUrl;
 
 /**
@@ -57,6 +58,7 @@ public final class CloudFrontUtilities {
     private static final String SIGNATURE_KEY = "CloudFront-Signature";
     private static final String EXPIRES_KEY = "CloudFront-Expires";
     private static final String POLICY_KEY = "CloudFront-Policy";
+    private static final String HASH_ALGORITHM_KEY = "CloudFront-Hash-Algorithm";
 
     private CloudFrontUtilities() {
     }
@@ -141,7 +143,7 @@ public final class CloudFrontUtilities {
         try {
             String resourceUrl = request.resourceUrl();
             String cannedPolicy = SigningUtils.buildCannedPolicy(resourceUrl, request.expirationDate());
-            byte[] signatureBytes = signPolicy(cannedPolicy.getBytes(UTF_8), request.privateKey());
+            byte[] signatureBytes = signPolicy(cannedPolicy.getBytes(UTF_8), request.privateKey(), request.hashAlgorithm());
             String urlSafeSignature = SigningUtils.makeBytesUrlSafe(signatureBytes);
             URI uri = URI.create(resourceUrl);
             String protocol = uri.getScheme();
@@ -149,7 +151,8 @@ public final class CloudFrontUtilities {
                                  + (uri.getQuery() != null ? "?" + uri.getRawQuery() + "&" : "?")
                                  + "Expires=" + request.expirationDate().getEpochSecond()
                                  + "&Signature=" + urlSafeSignature
-                                 + "&Key-Pair-Id=" + request.keyPairId();
+                                 + "&Key-Pair-Id=" + request.keyPairId()
+                                 + hashAlgorithmUrlParam(request.hashAlgorithm());
             return DefaultSignedUrl.builder()
                                    .protocol(protocol)
                                    .domain(uri.getHost())
@@ -267,7 +270,7 @@ public final class CloudFrontUtilities {
                                                                        request.expirationDate(),
                                                                        request.ipRange());
 
-            byte[] signatureBytes = signPolicy(policy.getBytes(UTF_8), request.privateKey());
+            byte[] signatureBytes = signPolicy(policy.getBytes(UTF_8), request.privateKey(), request.hashAlgorithm());
             String urlSafePolicy = SigningUtils.makeStringUrlSafe(policy);
             String urlSafeSignature = SigningUtils.makeBytesUrlSafe(signatureBytes);
             URI uri = URI.create(resourceUrl);
@@ -276,7 +279,8 @@ public final class CloudFrontUtilities {
                                  + (uri.getQuery() != null ? "?" + uri.getRawQuery() + "&" : "?")
                                  + "Policy=" + urlSafePolicy
                                  + "&Signature=" + urlSafeSignature
-                                 + "&Key-Pair-Id=" + request.keyPairId();
+                                 + "&Key-Pair-Id=" + request.keyPairId()
+                                 + hashAlgorithmUrlParam(request.hashAlgorithm());
             return DefaultSignedUrl.builder()
                                    .protocol(protocol)
                                    .domain(uri.getHost())
@@ -369,14 +373,18 @@ public final class CloudFrontUtilities {
     public CookiesForCannedPolicy getCookiesForCannedPolicy(CannedSignerRequest request) {
         try {
             String cannedPolicy = SigningUtils.buildCannedPolicy(request.resourceUrl(), request.expirationDate());
-            byte[] signatureBytes = signPolicy(cannedPolicy.getBytes(UTF_8), request.privateKey());
+            byte[] signatureBytes = signPolicy(cannedPolicy.getBytes(UTF_8), request.privateKey(), request.hashAlgorithm());
             String urlSafeSignature = SigningUtils.makeBytesUrlSafe(signatureBytes);
             String expiry = String.valueOf(request.expirationDate().getEpochSecond());
-            return DefaultCookiesForCannedPolicy.builder()
-                                                .resourceUrl(request.resourceUrl())
-                                                .keyPairIdHeaderValue(KEY_PAIR_ID_KEY + "=" + request.keyPairId())
-                                                .signatureHeaderValue(SIGNATURE_KEY + "=" + urlSafeSignature)
-                                                .expiresHeaderValue(EXPIRES_KEY + "=" + expiry).build();
+            DefaultCookiesForCannedPolicy.Builder builder = DefaultCookiesForCannedPolicy.builder()
+                .resourceUrl(request.resourceUrl())
+                .keyPairIdHeaderValue(KEY_PAIR_ID_KEY + "=" + request.keyPairId())
+                .signatureHeaderValue(SIGNATURE_KEY + "=" + urlSafeSignature)
+                .expiresHeaderValue(EXPIRES_KEY + "=" + expiry);
+            if (request.hashAlgorithm() != HashAlgorithm.SHA1) {
+                builder.hashAlgorithmHeaderValue(HASH_ALGORITHM_KEY + "=" + request.hashAlgorithm().id());
+            }
+            return builder.build();
         } catch (InvalidKeyException e) {
             throw SdkClientException.create("Could not sign canned policy cookie", e);
         }
@@ -484,33 +492,45 @@ public final class CloudFrontUtilities {
 
             String policy = SigningUtils.buildCustomPolicy(resourceUrlPattern, request.activeDate(), request.expirationDate(),
                                                            request.ipRange());
-            byte[] signatureBytes = signPolicy(policy.getBytes(UTF_8), request.privateKey());
+            byte[] signatureBytes = signPolicy(policy.getBytes(UTF_8), request.privateKey(), request.hashAlgorithm());
             String urlSafePolicy = SigningUtils.makeStringUrlSafe(policy);
             String urlSafeSignature = SigningUtils.makeBytesUrlSafe(signatureBytes);
-            return DefaultCookiesForCustomPolicy.builder()
-                                                .resourceUrl(request.resourceUrl())
-                                                .keyPairIdHeaderValue(KEY_PAIR_ID_KEY + "=" + request.keyPairId())
-                                                .signatureHeaderValue(SIGNATURE_KEY + "=" + urlSafeSignature)
-                                                .policyHeaderValue(POLICY_KEY + "=" + urlSafePolicy).build();
+            DefaultCookiesForCustomPolicy.Builder builder = DefaultCookiesForCustomPolicy.builder()
+                .resourceUrl(request.resourceUrl())
+                .keyPairIdHeaderValue(KEY_PAIR_ID_KEY + "=" + request.keyPairId())
+                .signatureHeaderValue(SIGNATURE_KEY + "=" + urlSafeSignature)
+                .policyHeaderValue(POLICY_KEY + "=" + urlSafePolicy);
+            if (request.hashAlgorithm() != HashAlgorithm.SHA1) {
+                builder.hashAlgorithmHeaderValue(HASH_ALGORITHM_KEY + "=" + request.hashAlgorithm().id());
+            }
+            return builder.build();
         } catch (InvalidKeyException e) {
             throw SdkClientException.create("Could not sign custom policy cookie", e);
         }
     }
 
-    private static byte[] signPolicy(byte[] policyToSign, PrivateKey privateKey) throws InvalidKeyException {
-        // all CloudFront signed urls currently require the SHA1 and currently only support RSA and EC
+    private static byte[] signPolicy(byte[] policyToSign, PrivateKey privateKey,
+                                      HashAlgorithm hashAlgorithm) throws InvalidKeyException {
+        return SigningUtils.sign(policyToSign, privateKey, javaSecuritySigningAlgorithm(privateKey, hashAlgorithm));
+    }
+
+    private static String javaSecuritySigningAlgorithm(PrivateKey privateKey, HashAlgorithm hashAlgorithm) {
         switch (privateKey.getAlgorithm()) {
             case "RSA":
-                return SigningUtils.signWithSha1Rsa(policyToSign, privateKey);
+                return hashAlgorithm.id() + "withRSA";
             case "EC":
             case "ECDSA":
-                return SigningUtils.signWithSha1ECDSA(policyToSign, privateKey);
+                return hashAlgorithm.id() + "withECDSA";
             default:
-                // do not attempt to use a generic Signer based on the privateKey algorithm:
-                // future supported key types likely require different hash algorithms (eg, SHA256 or higher instead of SHA1)
+                // Only RSA and EC keys are supported by CloudFront for signed URLs/cookies.
                 throw new IllegalArgumentException(
                     "Unsupported key algorithm for CloudFront signed URL: " + privateKey.getAlgorithm());
         }
+    }
+
+    // Returns empty string for SHA-1 to preserve backwards-compatible URL shape (CloudFront defaults to SHA-1 when omitted).
+    private static String hashAlgorithmUrlParam(HashAlgorithm hashAlgorithm) {
+        return hashAlgorithm == HashAlgorithm.SHA1 ? "" : "&Hash-Algorithm=" + hashAlgorithm.id();
     }
 
 }

--- a/services/cloudfront/src/main/java/software/amazon/awssdk/services/cloudfront/CloudFrontUtilities.java
+++ b/services/cloudfront/src/main/java/software/amazon/awssdk/services/cloudfront/CloudFrontUtilities.java
@@ -33,8 +33,8 @@ import software.amazon.awssdk.services.cloudfront.internal.url.DefaultSignedUrl;
 import software.amazon.awssdk.services.cloudfront.internal.utils.SigningUtils;
 import software.amazon.awssdk.services.cloudfront.model.CannedSignerRequest;
 import software.amazon.awssdk.services.cloudfront.model.CustomSignerRequest;
-import software.amazon.awssdk.services.cloudfront.utils.SigningHashAlgorithm;
 import software.amazon.awssdk.services.cloudfront.url.SignedUrl;
+import software.amazon.awssdk.services.cloudfront.utils.SigningHashAlgorithm;
 
 /**
  *

--- a/services/cloudfront/src/main/java/software/amazon/awssdk/services/cloudfront/cookie/CookiesForCannedPolicy.java
+++ b/services/cloudfront/src/main/java/software/amazon/awssdk/services/cloudfront/cookie/CookiesForCannedPolicy.java
@@ -55,6 +55,11 @@ public interface CookiesForCannedPolicy extends SignedCookie,
          * Configure the cookie expires header value
          */
         Builder expiresHeaderValue(String expiresHeaderValue);
+
+        /**
+         * Configure the cookie hash-algorithm header value
+         */
+        Builder hashAlgorithmHeaderValue(String hashAlgorithmHeaderValue);
     }
 
 }

--- a/services/cloudfront/src/main/java/software/amazon/awssdk/services/cloudfront/cookie/CookiesForCustomPolicy.java
+++ b/services/cloudfront/src/main/java/software/amazon/awssdk/services/cloudfront/cookie/CookiesForCustomPolicy.java
@@ -55,6 +55,11 @@ public interface CookiesForCustomPolicy extends SignedCookie,
          * Configure the cookie policy header value
          */
         Builder policyHeaderValue(String policyHeaderValue);
+
+        /**
+         * Configure the cookie hash-algorithm header value
+         */
+        Builder hashAlgorithmHeaderValue(String hashAlgorithmHeaderValue);
     }
 
 }

--- a/services/cloudfront/src/main/java/software/amazon/awssdk/services/cloudfront/cookie/SignedCookie.java
+++ b/services/cloudfront/src/main/java/software/amazon/awssdk/services/cloudfront/cookie/SignedCookie.java
@@ -52,4 +52,12 @@ public interface SignedCookie {
      */
     String keyPairIdHeaderValue();
 
+    /**
+     * Returns the cookie hash-algorithm header value that can be appended to an HTTP GET request,
+     * i.e., "CloudFront-Hash-Algorithm=SHA256", or {@code null} if SHA-1 (the default) is used.
+     */
+    default String hashAlgorithmHeaderValue() {
+        return null;
+    }
+
 }

--- a/services/cloudfront/src/main/java/software/amazon/awssdk/services/cloudfront/internal/cookie/DefaultCookiesForCannedPolicy.java
+++ b/services/cloudfront/src/main/java/software/amazon/awssdk/services/cloudfront/internal/cookie/DefaultCookiesForCannedPolicy.java
@@ -34,12 +34,14 @@ public final class DefaultCookiesForCannedPolicy implements CookiesForCannedPoli
     private final String keyPairIdHeaderValue;
     private final String signatureHeaderValue;
     private final String expiresHeaderValue;
+    private final String hashAlgorithmHeaderValue;
 
     private DefaultCookiesForCannedPolicy(DefaultBuilder builder) {
         this.resourceUrl = builder.resourceUrl;
         this.keyPairIdHeaderValue = builder.keyPairIdHeaderValue;
         this.signatureHeaderValue = builder.signatureHeaderValue;
         this.expiresHeaderValue = builder.expiresHeaderValue;
+        this.hashAlgorithmHeaderValue = builder.hashAlgorithmHeaderValue;
     }
 
     public static Builder builder() {
@@ -58,6 +60,7 @@ public final class DefaultCookiesForCannedPolicy implements CookiesForCannedPoli
                        .add("signatureHeaderValue", signatureHeaderValue)
                        .add("keyPairIdHeaderValue", keyPairIdHeaderValue)
                        .add("expiresHeaderValue", expiresHeaderValue)
+                       .add("hashAlgorithmHeaderValue", hashAlgorithmHeaderValue)
                        .build();
     }
 
@@ -68,13 +71,16 @@ public final class DefaultCookiesForCannedPolicy implements CookiesForCannedPoli
 
     @Override
     public SdkHttpRequest createHttpGetRequest() {
-        return SdkHttpRequest.builder()
-                             .uri(URI.create(resourceUrl))
-                             .appendHeader(COOKIE, signatureHeaderValue())
-                             .appendHeader(COOKIE, keyPairIdHeaderValue())
-                             .appendHeader(COOKIE, expiresHeaderValue())
-                             .method(SdkHttpMethod.GET)
-                             .build();
+        SdkHttpRequest.Builder builder = SdkHttpRequest.builder()
+                                                       .uri(URI.create(resourceUrl))
+                                                       .appendHeader(COOKIE, signatureHeaderValue())
+                                                       .appendHeader(COOKIE, keyPairIdHeaderValue())
+                                                       .appendHeader(COOKIE, expiresHeaderValue())
+                                                       .method(SdkHttpMethod.GET);
+        if (hashAlgorithmHeaderValue != null) {
+            builder.appendHeader(COOKIE, hashAlgorithmHeaderValue);
+        }
+        return builder.build();
     }
 
     @Override
@@ -93,6 +99,11 @@ public final class DefaultCookiesForCannedPolicy implements CookiesForCannedPoli
     }
 
     @Override
+    public String hashAlgorithmHeaderValue() {
+        return hashAlgorithmHeaderValue;
+    }
+
+    @Override
     public boolean equals(Object o) {
         if (this == o) {
             return true;
@@ -105,7 +116,8 @@ public final class DefaultCookiesForCannedPolicy implements CookiesForCannedPoli
         return Objects.equals(keyPairIdHeaderValue, cookie.keyPairIdHeaderValue)
                && Objects.equals(signatureHeaderValue, cookie.signatureHeaderValue)
                && Objects.equals(resourceUrl, cookie.resourceUrl)
-               && Objects.equals(expiresHeaderValue, cookie.expiresHeaderValue);
+               && Objects.equals(expiresHeaderValue, cookie.expiresHeaderValue)
+               && Objects.equals(hashAlgorithmHeaderValue, cookie.hashAlgorithmHeaderValue);
     }
 
     @Override
@@ -114,6 +126,7 @@ public final class DefaultCookiesForCannedPolicy implements CookiesForCannedPoli
         result = 31 * result + (signatureHeaderValue != null ? signatureHeaderValue.hashCode() : 0);
         result = 31 * result + (resourceUrl != null ? resourceUrl.hashCode() : 0);
         result = 31 * result + (expiresHeaderValue != null ? expiresHeaderValue.hashCode() : 0);
+        result = 31 * result + (hashAlgorithmHeaderValue != null ? hashAlgorithmHeaderValue.hashCode() : 0);
         return result;
     }
 
@@ -123,6 +136,7 @@ public final class DefaultCookiesForCannedPolicy implements CookiesForCannedPoli
         private String signatureHeaderValue;
         private String keyPairIdHeaderValue;
         private String expiresHeaderValue;
+        private String hashAlgorithmHeaderValue;
 
         private DefaultBuilder() {
         }
@@ -132,6 +146,7 @@ public final class DefaultCookiesForCannedPolicy implements CookiesForCannedPoli
             this.signatureHeaderValue = cookies.signatureHeaderValue;
             this.keyPairIdHeaderValue = cookies.keyPairIdHeaderValue;
             this.expiresHeaderValue = cookies.expiresHeaderValue;
+            this.hashAlgorithmHeaderValue = cookies.hashAlgorithmHeaderValue;
         }
 
         @Override
@@ -155,6 +170,12 @@ public final class DefaultCookiesForCannedPolicy implements CookiesForCannedPoli
         @Override
         public Builder expiresHeaderValue(String expiresHeaderValue) {
             this.expiresHeaderValue = expiresHeaderValue;
+            return this;
+        }
+
+        @Override
+        public Builder hashAlgorithmHeaderValue(String hashAlgorithmHeaderValue) {
+            this.hashAlgorithmHeaderValue = hashAlgorithmHeaderValue;
             return this;
         }
 

--- a/services/cloudfront/src/main/java/software/amazon/awssdk/services/cloudfront/internal/cookie/DefaultCookiesForCustomPolicy.java
+++ b/services/cloudfront/src/main/java/software/amazon/awssdk/services/cloudfront/internal/cookie/DefaultCookiesForCustomPolicy.java
@@ -34,12 +34,14 @@ public final class DefaultCookiesForCustomPolicy implements CookiesForCustomPoli
     private final String signatureHeaderValue;
     private final String keyPairIdHeaderValue;
     private final String policyHeaderValue;
+    private final String hashAlgorithmHeaderValue;
 
     private DefaultCookiesForCustomPolicy(DefaultBuilder builder) {
         this.resourceUrl = builder.resourceUrl;
         this.signatureHeaderValue = builder.signatureHeaderValue;
         this.keyPairIdHeaderValue = builder.keyPairIdHeaderValue;
         this.policyHeaderValue = builder.policyHeaderValue;
+        this.hashAlgorithmHeaderValue = builder.hashAlgorithmHeaderValue;
     }
 
     public static Builder builder() {
@@ -58,6 +60,7 @@ public final class DefaultCookiesForCustomPolicy implements CookiesForCustomPoli
                        .add("signatureHeaderValue", signatureHeaderValue)
                        .add("keyPairIdHeaderValue", keyPairIdHeaderValue)
                        .add("policyHeaderValue", policyHeaderValue)
+                       .add("hashAlgorithmHeaderValue", hashAlgorithmHeaderValue)
                        .build();
     }
 
@@ -68,13 +71,16 @@ public final class DefaultCookiesForCustomPolicy implements CookiesForCustomPoli
 
     @Override
     public SdkHttpRequest createHttpGetRequest() {
-        return SdkHttpRequest.builder()
-                             .uri(URI.create(resourceUrl))
-                             .appendHeader(COOKIE, policyHeaderValue())
-                             .appendHeader(COOKIE, signatureHeaderValue())
-                             .appendHeader(COOKIE, keyPairIdHeaderValue())
-                             .method(SdkHttpMethod.GET)
-                             .build();
+        SdkHttpRequest.Builder builder = SdkHttpRequest.builder()
+                                                       .uri(URI.create(resourceUrl))
+                                                       .appendHeader(COOKIE, policyHeaderValue())
+                                                       .appendHeader(COOKIE, signatureHeaderValue())
+                                                       .appendHeader(COOKIE, keyPairIdHeaderValue())
+                                                       .method(SdkHttpMethod.GET);
+        if (hashAlgorithmHeaderValue != null) {
+            builder.appendHeader(COOKIE, hashAlgorithmHeaderValue);
+        }
+        return builder.build();
     }
 
     @Override
@@ -93,6 +99,11 @@ public final class DefaultCookiesForCustomPolicy implements CookiesForCustomPoli
     }
 
     @Override
+    public String hashAlgorithmHeaderValue() {
+        return hashAlgorithmHeaderValue;
+    }
+
+    @Override
     public boolean equals(Object o) {
         if (this == o) {
             return true;
@@ -105,7 +116,8 @@ public final class DefaultCookiesForCustomPolicy implements CookiesForCustomPoli
         return Objects.equals(keyPairIdHeaderValue, cookie.keyPairIdHeaderValue)
                && Objects.equals(signatureHeaderValue, cookie.signatureHeaderValue)
                && Objects.equals(resourceUrl, cookie.resourceUrl)
-               && Objects.equals(policyHeaderValue, cookie.policyHeaderValue);
+               && Objects.equals(policyHeaderValue, cookie.policyHeaderValue)
+               && Objects.equals(hashAlgorithmHeaderValue, cookie.hashAlgorithmHeaderValue);
     }
 
     @Override
@@ -114,6 +126,7 @@ public final class DefaultCookiesForCustomPolicy implements CookiesForCustomPoli
         result = 31 * result + (signatureHeaderValue != null ? signatureHeaderValue.hashCode() : 0);
         result = 31 * result + (resourceUrl != null ? resourceUrl.hashCode() : 0);
         result = 31 * result + (policyHeaderValue != null ? policyHeaderValue.hashCode() : 0);
+        result = 31 * result + (hashAlgorithmHeaderValue != null ? hashAlgorithmHeaderValue.hashCode() : 0);
         return result;
     }
 
@@ -122,6 +135,7 @@ public final class DefaultCookiesForCustomPolicy implements CookiesForCustomPoli
         private String signatureHeaderValue;
         private String keyPairIdHeaderValue;
         private String policyHeaderValue;
+        private String hashAlgorithmHeaderValue;
 
         private DefaultBuilder() {
         }
@@ -131,6 +145,7 @@ public final class DefaultCookiesForCustomPolicy implements CookiesForCustomPoli
             this.signatureHeaderValue = cookies.signatureHeaderValue;
             this.keyPairIdHeaderValue = cookies.keyPairIdHeaderValue;
             this.policyHeaderValue = cookies.policyHeaderValue;
+            this.hashAlgorithmHeaderValue = cookies.hashAlgorithmHeaderValue;
         }
 
         @Override
@@ -154,6 +169,12 @@ public final class DefaultCookiesForCustomPolicy implements CookiesForCustomPoli
         @Override
         public Builder policyHeaderValue(String policyHeaderValue) {
             this.policyHeaderValue = policyHeaderValue;
+            return this;
+        }
+
+        @Override
+        public Builder hashAlgorithmHeaderValue(String hashAlgorithmHeaderValue) {
+            this.hashAlgorithmHeaderValue = hashAlgorithmHeaderValue;
             return this;
         }
 

--- a/services/cloudfront/src/main/java/software/amazon/awssdk/services/cloudfront/internal/utils/SigningUtils.java
+++ b/services/cloudfront/src/main/java/software/amazon/awssdk/services/cloudfront/internal/utils/SigningUtils.java
@@ -196,28 +196,11 @@ public final class SigningUtils {
     }
 
     /**
-     * Signs the data given with the private key given, using the SHA1withRSA
-     * algorithm provided by bouncy castle.
+     * Signs the data given with the private key using the specified Java Security signing algorithm.
      */
-    public static byte[] signWithSha1Rsa(byte[] dataToSign, PrivateKey privateKey) throws InvalidKeyException {
+    public static byte[] sign(byte[] dataToSign, PrivateKey privateKey, String algorithm) throws InvalidKeyException {
         try {
-            Signature signature = Signature.getInstance("SHA1withRSA");
-            SecureRandom random = new SecureRandom();
-            signature.initSign(privateKey, random);
-            signature.update(dataToSign);
-            return signature.sign();
-        } catch (NoSuchAlgorithmException | SignatureException e) {
-            throw new IllegalStateException(e);
-        }
-    }
-
-    /**
-     * Signs the data given with the private key given, using the SHA1withECDSA
-     * algorithm provided by bouncy castle.
-     */
-    public static byte[] signWithSha1ECDSA(byte[] dataToSign, PrivateKey privateKey) throws InvalidKeyException  {
-        try {
-            Signature signature = Signature.getInstance("SHA1withECDSA");
+            Signature signature = Signature.getInstance(algorithm);
             SecureRandom random = new SecureRandom();
             signature.initSign(privateKey, random);
             signature.update(dataToSign);

--- a/services/cloudfront/src/main/java/software/amazon/awssdk/services/cloudfront/model/CannedSignerRequest.java
+++ b/services/cloudfront/src/main/java/software/amazon/awssdk/services/cloudfront/model/CannedSignerRequest.java
@@ -15,6 +15,8 @@
 
 package software.amazon.awssdk.services.cloudfront.model;
 
+import software.amazon.awssdk.services.cloudfront.utils.SigningHashAlgorithm;
+
 import java.nio.file.Path;
 import java.security.PrivateKey;
 import java.time.Instant;
@@ -40,14 +42,14 @@ public final class CannedSignerRequest implements CloudFrontSignerRequest,
     private final PrivateKey privateKey;
     private final String keyPairId;
     private final Instant expirationDate;
-    private final HashAlgorithm hashAlgorithm;
+    private final SigningHashAlgorithm hashAlgorithm;
 
     private CannedSignerRequest(DefaultBuilder builder) {
         this.resourceUrl = builder.resourceUrl;
         this.privateKey = builder.privateKey;
         this.keyPairId = builder.keyPairId;
         this.expirationDate = builder.expirationDate;
-        this.hashAlgorithm = builder.hashAlgorithm != null ? builder.hashAlgorithm : HashAlgorithm.SHA1;
+        this.hashAlgorithm = builder.hashAlgorithm != null ? builder.hashAlgorithm : SigningHashAlgorithm.SHA1;
     }
 
     /**
@@ -83,7 +85,7 @@ public final class CannedSignerRequest implements CloudFrontSignerRequest,
     }
 
     @Override
-    public HashAlgorithm hashAlgorithm() {
+    public SigningHashAlgorithm hashAlgorithm() {
         return hashAlgorithm;
     }
 
@@ -153,9 +155,9 @@ public final class CannedSignerRequest implements CloudFrontSignerRequest,
         Builder expirationDate(Instant expirationDate);
 
         /**
-         * Configure the hash algorithm used to sign the policy. Defaults to {@link HashAlgorithm#SHA1}.
+         * Configure the hash algorithm used to sign the policy. Defaults to {@link SigningHashAlgorithm#SHA1}.
          */
-        Builder hashAlgorithm(HashAlgorithm hashAlgorithm);
+        Builder hashAlgorithm(SigningHashAlgorithm hashAlgorithm);
     }
 
     private static final class DefaultBuilder implements Builder {
@@ -163,7 +165,7 @@ public final class CannedSignerRequest implements CloudFrontSignerRequest,
         private PrivateKey privateKey;
         private String keyPairId;
         private Instant expirationDate;
-        private HashAlgorithm hashAlgorithm;
+        private SigningHashAlgorithm hashAlgorithm;
 
         private DefaultBuilder() {
         }
@@ -207,7 +209,7 @@ public final class CannedSignerRequest implements CloudFrontSignerRequest,
         }
 
         @Override
-        public Builder hashAlgorithm(HashAlgorithm hashAlgorithm) {
+        public Builder hashAlgorithm(SigningHashAlgorithm hashAlgorithm) {
             this.hashAlgorithm = hashAlgorithm;
             return this;
         }

--- a/services/cloudfront/src/main/java/software/amazon/awssdk/services/cloudfront/model/CannedSignerRequest.java
+++ b/services/cloudfront/src/main/java/software/amazon/awssdk/services/cloudfront/model/CannedSignerRequest.java
@@ -40,12 +40,14 @@ public final class CannedSignerRequest implements CloudFrontSignerRequest,
     private final PrivateKey privateKey;
     private final String keyPairId;
     private final Instant expirationDate;
+    private final HashAlgorithm hashAlgorithm;
 
     private CannedSignerRequest(DefaultBuilder builder) {
         this.resourceUrl = builder.resourceUrl;
         this.privateKey = builder.privateKey;
         this.keyPairId = builder.keyPairId;
         this.expirationDate = builder.expirationDate;
+        this.hashAlgorithm = builder.hashAlgorithm != null ? builder.hashAlgorithm : HashAlgorithm.SHA1;
     }
 
     /**
@@ -81,6 +83,11 @@ public final class CannedSignerRequest implements CloudFrontSignerRequest,
     }
 
     @Override
+    public HashAlgorithm hashAlgorithm() {
+        return hashAlgorithm;
+    }
+
+    @Override
     public boolean equals(Object o) {
         if (this == o) {
             return true;
@@ -93,7 +100,8 @@ public final class CannedSignerRequest implements CloudFrontSignerRequest,
         return Objects.equals(resourceUrl, cookie.resourceUrl)
                && Objects.equals(privateKey, cookie.privateKey)
                && Objects.equals(keyPairId, cookie.keyPairId)
-               && Objects.equals(expirationDate, cookie.expirationDate);
+               && Objects.equals(expirationDate, cookie.expirationDate)
+               && hashAlgorithm == cookie.hashAlgorithm;
     }
 
     @Override
@@ -102,6 +110,7 @@ public final class CannedSignerRequest implements CloudFrontSignerRequest,
         result = 31 * result + (privateKey != null ? privateKey.hashCode() : 0);
         result = 31 * result + (keyPairId != null ? keyPairId.hashCode() : 0);
         result = 31 * result + (expirationDate != null ? expirationDate.hashCode() : 0);
+        result = 31 * result + (hashAlgorithm != null ? hashAlgorithm.hashCode() : 0);
         return result;
     }
 
@@ -142,6 +151,11 @@ public final class CannedSignerRequest implements CloudFrontSignerRequest,
          * Configure the expiration date of the signed URL or signed cookie
          */
         Builder expirationDate(Instant expirationDate);
+
+        /**
+         * Configure the hash algorithm used to sign the policy. Defaults to {@link HashAlgorithm#SHA1}.
+         */
+        Builder hashAlgorithm(HashAlgorithm hashAlgorithm);
     }
 
     private static final class DefaultBuilder implements Builder {
@@ -149,6 +163,7 @@ public final class CannedSignerRequest implements CloudFrontSignerRequest,
         private PrivateKey privateKey;
         private String keyPairId;
         private Instant expirationDate;
+        private HashAlgorithm hashAlgorithm;
 
         private DefaultBuilder() {
         }
@@ -158,6 +173,7 @@ public final class CannedSignerRequest implements CloudFrontSignerRequest,
             this.privateKey = request.privateKey;
             this.keyPairId = request.keyPairId;
             this.expirationDate = request.expirationDate;
+            this.hashAlgorithm = request.hashAlgorithm;
         }
 
         @Override
@@ -187,6 +203,12 @@ public final class CannedSignerRequest implements CloudFrontSignerRequest,
         @Override
         public Builder expirationDate(Instant expirationDate) {
             this.expirationDate = expirationDate;
+            return this;
+        }
+
+        @Override
+        public Builder hashAlgorithm(HashAlgorithm hashAlgorithm) {
+            this.hashAlgorithm = hashAlgorithm;
             return this;
         }
 

--- a/services/cloudfront/src/main/java/software/amazon/awssdk/services/cloudfront/model/CannedSignerRequest.java
+++ b/services/cloudfront/src/main/java/software/amazon/awssdk/services/cloudfront/model/CannedSignerRequest.java
@@ -15,8 +15,6 @@
 
 package software.amazon.awssdk.services.cloudfront.model;
 
-import software.amazon.awssdk.services.cloudfront.utils.SigningHashAlgorithm;
-
 import java.nio.file.Path;
 import java.security.PrivateKey;
 import java.time.Instant;
@@ -26,6 +24,7 @@ import software.amazon.awssdk.annotations.NotThreadSafe;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.annotations.ThreadSafe;
 import software.amazon.awssdk.services.cloudfront.internal.utils.SigningUtils;
+import software.amazon.awssdk.services.cloudfront.utils.SigningHashAlgorithm;
 import software.amazon.awssdk.utils.builder.CopyableBuilder;
 import software.amazon.awssdk.utils.builder.ToCopyableBuilder;
 

--- a/services/cloudfront/src/main/java/software/amazon/awssdk/services/cloudfront/model/CloudFrontSignerRequest.java
+++ b/services/cloudfront/src/main/java/software/amazon/awssdk/services/cloudfront/model/CloudFrontSignerRequest.java
@@ -15,13 +15,12 @@
 
 package software.amazon.awssdk.services.cloudfront.model;
 
-import software.amazon.awssdk.services.cloudfront.utils.SigningHashAlgorithm;
-
 import java.security.PrivateKey;
 import java.time.Instant;
 import software.amazon.awssdk.annotations.Immutable;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.annotations.ThreadSafe;
+import software.amazon.awssdk.services.cloudfront.utils.SigningHashAlgorithm;
 
 /**
  * Base interface class for requests to generate a CloudFront signed URL or signed cookie

--- a/services/cloudfront/src/main/java/software/amazon/awssdk/services/cloudfront/model/CloudFrontSignerRequest.java
+++ b/services/cloudfront/src/main/java/software/amazon/awssdk/services/cloudfront/model/CloudFrontSignerRequest.java
@@ -15,6 +15,8 @@
 
 package software.amazon.awssdk.services.cloudfront.model;
 
+import software.amazon.awssdk.services.cloudfront.utils.SigningHashAlgorithm;
+
 import java.security.PrivateKey;
 import java.time.Instant;
 import software.amazon.awssdk.annotations.Immutable;
@@ -52,9 +54,9 @@ public interface CloudFrontSignerRequest {
     Instant expirationDate();
 
     /**
-     * Returns the hash algorithm used to sign the policy. Defaults to {@link HashAlgorithm#SHA1}.
+     * Returns the hash algorithm used to sign the policy. Defaults to {@link SigningHashAlgorithm#SHA1}.
      */
-    default HashAlgorithm hashAlgorithm() {
-        return HashAlgorithm.SHA1;
+    default SigningHashAlgorithm hashAlgorithm() {
+        return SigningHashAlgorithm.SHA1;
     }
 }

--- a/services/cloudfront/src/main/java/software/amazon/awssdk/services/cloudfront/model/CloudFrontSignerRequest.java
+++ b/services/cloudfront/src/main/java/software/amazon/awssdk/services/cloudfront/model/CloudFrontSignerRequest.java
@@ -50,4 +50,11 @@ public interface CloudFrontSignerRequest {
      * private content
      */
     Instant expirationDate();
+
+    /**
+     * Returns the hash algorithm used to sign the policy. Defaults to {@link HashAlgorithm#SHA1}.
+     */
+    default HashAlgorithm hashAlgorithm() {
+        return HashAlgorithm.SHA1;
+    }
 }

--- a/services/cloudfront/src/main/java/software/amazon/awssdk/services/cloudfront/model/CustomSignerRequest.java
+++ b/services/cloudfront/src/main/java/software/amazon/awssdk/services/cloudfront/model/CustomSignerRequest.java
@@ -43,6 +43,7 @@ public final class CustomSignerRequest implements CloudFrontSignerRequest,
     private final Instant activeDate;
     private final String ipRange;
     private final String resourceUrlPattern;
+    private final HashAlgorithm hashAlgorithm;
 
     private CustomSignerRequest(DefaultBuilder builder) {
         this.resourceUrl = Validate.notNull(builder.resourceUrl, "resourceUrl must not be null");
@@ -52,6 +53,7 @@ public final class CustomSignerRequest implements CloudFrontSignerRequest,
         this.activeDate = builder.activeDate;
         this.ipRange = builder.ipRange;
         this.resourceUrlPattern = builder.resourceUrlPattern;
+        this.hashAlgorithm = builder.hashAlgorithm != null ? builder.hashAlgorithm : HashAlgorithm.SHA1;
     }
 
     /**
@@ -106,6 +108,11 @@ public final class CustomSignerRequest implements CloudFrontSignerRequest,
     }
 
     @Override
+    public HashAlgorithm hashAlgorithm() {
+        return hashAlgorithm;
+    }
+
+    @Override
     public boolean equals(Object o) {
         if (this == o) {
             return true;
@@ -121,7 +128,8 @@ public final class CustomSignerRequest implements CloudFrontSignerRequest,
                && Objects.equals(expirationDate, cookie.expirationDate)
                && Objects.equals(activeDate, cookie.activeDate)
                && Objects.equals(ipRange, cookie.ipRange)
-               && Objects.equals(resourceUrlPattern, cookie.resourceUrlPattern);
+               && Objects.equals(resourceUrlPattern, cookie.resourceUrlPattern)
+               && hashAlgorithm == cookie.hashAlgorithm;
     }
 
     @Override
@@ -133,6 +141,7 @@ public final class CustomSignerRequest implements CloudFrontSignerRequest,
         result = 31 * result + (activeDate != null ? activeDate.hashCode() : 0);
         result = 31 * result + (ipRange != null ? ipRange.hashCode() : 0);
         result = 31 * result + (resourceUrlPattern != null ? resourceUrlPattern.hashCode() : 0);
+        result = 31 * result + (hashAlgorithm != null ? hashAlgorithm.hashCode() : 0);
         return result;
     }
 
@@ -197,6 +206,11 @@ public final class CustomSignerRequest implements CloudFrontSignerRequest,
          * will be used in the policy.
          */
         Builder resourceUrlPattern(String resourceUrlPattern);
+
+        /**
+         * Configure the hash algorithm used to sign the policy. Defaults to {@link HashAlgorithm#SHA1}.
+         */
+        Builder hashAlgorithm(HashAlgorithm hashAlgorithm);
     }
 
     private static final class DefaultBuilder implements Builder {
@@ -207,6 +221,7 @@ public final class CustomSignerRequest implements CloudFrontSignerRequest,
         private Instant activeDate;
         private String ipRange;
         private String resourceUrlPattern;
+        private HashAlgorithm hashAlgorithm;
 
         private DefaultBuilder() {
         }
@@ -219,6 +234,7 @@ public final class CustomSignerRequest implements CloudFrontSignerRequest,
             this.activeDate = request.activeDate;
             this.ipRange = request.ipRange;
             this.resourceUrlPattern = request.resourceUrlPattern;
+            this.hashAlgorithm = request.hashAlgorithm;
         }
 
         @Override
@@ -266,6 +282,12 @@ public final class CustomSignerRequest implements CloudFrontSignerRequest,
         @Override
         public Builder resourceUrlPattern(String resourceUrlPattern) {
             this.resourceUrlPattern = resourceUrlPattern;
+            return this;
+        }
+
+        @Override
+        public Builder hashAlgorithm(HashAlgorithm hashAlgorithm) {
+            this.hashAlgorithm = hashAlgorithm;
             return this;
         }
 

--- a/services/cloudfront/src/main/java/software/amazon/awssdk/services/cloudfront/model/CustomSignerRequest.java
+++ b/services/cloudfront/src/main/java/software/amazon/awssdk/services/cloudfront/model/CustomSignerRequest.java
@@ -15,6 +15,8 @@
 
 package software.amazon.awssdk.services.cloudfront.model;
 
+import software.amazon.awssdk.services.cloudfront.utils.SigningHashAlgorithm;
+
 import java.nio.file.Path;
 import java.security.PrivateKey;
 import java.time.Instant;
@@ -43,7 +45,7 @@ public final class CustomSignerRequest implements CloudFrontSignerRequest,
     private final Instant activeDate;
     private final String ipRange;
     private final String resourceUrlPattern;
-    private final HashAlgorithm hashAlgorithm;
+    private final SigningHashAlgorithm hashAlgorithm;
 
     private CustomSignerRequest(DefaultBuilder builder) {
         this.resourceUrl = Validate.notNull(builder.resourceUrl, "resourceUrl must not be null");
@@ -53,7 +55,7 @@ public final class CustomSignerRequest implements CloudFrontSignerRequest,
         this.activeDate = builder.activeDate;
         this.ipRange = builder.ipRange;
         this.resourceUrlPattern = builder.resourceUrlPattern;
-        this.hashAlgorithm = builder.hashAlgorithm != null ? builder.hashAlgorithm : HashAlgorithm.SHA1;
+        this.hashAlgorithm = builder.hashAlgorithm != null ? builder.hashAlgorithm : SigningHashAlgorithm.SHA1;
     }
 
     /**
@@ -108,7 +110,7 @@ public final class CustomSignerRequest implements CloudFrontSignerRequest,
     }
 
     @Override
-    public HashAlgorithm hashAlgorithm() {
+    public SigningHashAlgorithm hashAlgorithm() {
         return hashAlgorithm;
     }
 
@@ -208,9 +210,9 @@ public final class CustomSignerRequest implements CloudFrontSignerRequest,
         Builder resourceUrlPattern(String resourceUrlPattern);
 
         /**
-         * Configure the hash algorithm used to sign the policy. Defaults to {@link HashAlgorithm#SHA1}.
+         * Configure the hash algorithm used to sign the policy. Defaults to {@link SigningHashAlgorithm#SHA1}.
          */
-        Builder hashAlgorithm(HashAlgorithm hashAlgorithm);
+        Builder hashAlgorithm(SigningHashAlgorithm hashAlgorithm);
     }
 
     private static final class DefaultBuilder implements Builder {
@@ -221,7 +223,7 @@ public final class CustomSignerRequest implements CloudFrontSignerRequest,
         private Instant activeDate;
         private String ipRange;
         private String resourceUrlPattern;
-        private HashAlgorithm hashAlgorithm;
+        private SigningHashAlgorithm hashAlgorithm;
 
         private DefaultBuilder() {
         }
@@ -286,7 +288,7 @@ public final class CustomSignerRequest implements CloudFrontSignerRequest,
         }
 
         @Override
-        public Builder hashAlgorithm(HashAlgorithm hashAlgorithm) {
+        public Builder hashAlgorithm(SigningHashAlgorithm hashAlgorithm) {
             this.hashAlgorithm = hashAlgorithm;
             return this;
         }

--- a/services/cloudfront/src/main/java/software/amazon/awssdk/services/cloudfront/model/CustomSignerRequest.java
+++ b/services/cloudfront/src/main/java/software/amazon/awssdk/services/cloudfront/model/CustomSignerRequest.java
@@ -15,8 +15,6 @@
 
 package software.amazon.awssdk.services.cloudfront.model;
 
-import software.amazon.awssdk.services.cloudfront.utils.SigningHashAlgorithm;
-
 import java.nio.file.Path;
 import java.security.PrivateKey;
 import java.time.Instant;
@@ -26,6 +24,7 @@ import software.amazon.awssdk.annotations.NotThreadSafe;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.annotations.ThreadSafe;
 import software.amazon.awssdk.services.cloudfront.internal.utils.SigningUtils;
+import software.amazon.awssdk.services.cloudfront.utils.SigningHashAlgorithm;
 import software.amazon.awssdk.utils.Validate;
 import software.amazon.awssdk.utils.builder.CopyableBuilder;
 import software.amazon.awssdk.utils.builder.ToCopyableBuilder;

--- a/services/cloudfront/src/main/java/software/amazon/awssdk/services/cloudfront/model/HashAlgorithm.java
+++ b/services/cloudfront/src/main/java/software/amazon/awssdk/services/cloudfront/model/HashAlgorithm.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.cloudfront.model;
+
+import software.amazon.awssdk.annotations.SdkPublicApi;
+
+/**
+ * The hash algorithm to use when generating CloudFront signed URLs or signed cookies.
+ * <p>
+ * CloudFront supports SHA-1 (default) and SHA-256 for signed URLs and signed cookies.
+ * When using SHA-256, the signed URL will include a {@code Hash-Algorithm=SHA256} query parameter,
+ * and signed cookies will include a {@code CloudFront-Hash-Algorithm=SHA256} cookie.
+ */
+@SdkPublicApi
+public enum HashAlgorithm {
+    SHA1("SHA1"),
+    SHA256("SHA256");
+
+    private final String id;
+
+    HashAlgorithm(String id) {
+        this.id = id;
+    }
+
+    /**
+     * The algorithm identifier used in CloudFront's {@code Hash-Algorithm} parameter
+     * and in Java Security algorithm name construction (e.g., {@code "SHA256withRSA"}).
+     */
+    public String id() {
+        return id;
+    }
+}

--- a/services/cloudfront/src/main/java/software/amazon/awssdk/services/cloudfront/utils/SigningHashAlgorithm.java
+++ b/services/cloudfront/src/main/java/software/amazon/awssdk/services/cloudfront/utils/SigningHashAlgorithm.java
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-package software.amazon.awssdk.services.cloudfront.model;
+package software.amazon.awssdk.services.cloudfront.utils;
 
 import software.amazon.awssdk.annotations.SdkPublicApi;
 
@@ -25,13 +25,13 @@ import software.amazon.awssdk.annotations.SdkPublicApi;
  * and signed cookies will include a {@code CloudFront-Hash-Algorithm=SHA256} cookie.
  */
 @SdkPublicApi
-public enum HashAlgorithm {
+public enum SigningHashAlgorithm {
     SHA1("SHA1"),
     SHA256("SHA256");
 
     private final String id;
 
-    HashAlgorithm(String id) {
+    SigningHashAlgorithm(String id) {
         this.id = id;
     }
 

--- a/services/cloudfront/src/test/java/software/amazon/awssdk/services/cloudfront/CloudFrontUtilitiesIntegrationTest.java
+++ b/services/cloudfront/src/test/java/software/amazon/awssdk/services/cloudfront/CloudFrontUtilitiesIntegrationTest.java
@@ -61,6 +61,7 @@ import software.amazon.awssdk.services.cloudfront.model.CreateCloudFrontOriginAc
 import software.amazon.awssdk.services.cloudfront.model.CreatePublicKeyResponse;
 import software.amazon.awssdk.services.cloudfront.model.CustomSignerRequest;
 import software.amazon.awssdk.services.cloudfront.model.DefaultCacheBehavior;
+import software.amazon.awssdk.services.cloudfront.model.HashAlgorithm;
 import software.amazon.awssdk.services.cloudfront.model.Distribution;
 import software.amazon.awssdk.services.cloudfront.model.DistributionConfig;
 import software.amazon.awssdk.services.cloudfront.model.DistributionSummary;
@@ -89,7 +90,6 @@ public class CloudFrontUtilitiesIntegrationTest extends IntegrationTestBase {
     private static final String S3_OBJECT_KEY_ON_SUB_PATH = "foo/specific-file";
     private static final String S3_OBJECT_KEY_ON_SUB_PATH_OTHER = "foo/other-file";
 
-
     private static String bucket;
     private static String domainName;
     private static String resourceUrl;
@@ -98,18 +98,15 @@ public class CloudFrontUtilitiesIntegrationTest extends IntegrationTestBase {
     private static File rsaKeyFile;
     private static Path rsaKeyFilePath;
     private static String keyGroupId;
-
     private static String ecKeyPairId;
     private static PrivateKey ecPrivateKey;
     private static File ecKeyFile;
     private static Path ecKeyFilePath;
-
     private static String originAccessId;
-    private static String distributionId;
 
     @BeforeAll
     public static void init() throws Exception {
-        IntegrationTestBase.setUp();
+        setUp();
         initStaticFields();
     }
 
@@ -132,11 +129,33 @@ public class CloudFrontUtilitiesIntegrationTest extends IntegrationTestBase {
         }
     }
 
-    static Stream<KeyTestCase> keyCases() throws Exception {
+    static Stream<KeyTestCase> keyCases() {
         return Stream.of(
             new KeyTestCase("RSA", rsaKeyPairId, rsaPrivateKey, rsaKeyFilePath),
             new KeyTestCase("ECDSA", ecKeyPairId, ecPrivateKey, ecKeyFilePath)
         );
+    }
+
+    private static class SigningTestCase {
+        final KeyTestCase keyTestCase;
+        final HashAlgorithm hashAlgorithm;
+
+        SigningTestCase(KeyTestCase keyTestCase, HashAlgorithm hashAlgorithm) {
+            this.keyTestCase = keyTestCase;
+            this.hashAlgorithm = hashAlgorithm;
+        }
+
+        @Override
+        public String toString() {
+            return keyTestCase.name + "_" + hashAlgorithm;
+        }
+    }
+
+    static Stream<SigningTestCase> signingCases() {
+        return keyCases().flatMap(k -> Stream.of(
+            new SigningTestCase(k, HashAlgorithm.SHA1),
+            new SigningTestCase(k, HashAlgorithm.SHA256)
+        ));
     }
 
 
@@ -157,15 +176,16 @@ public class CloudFrontUtilitiesIntegrationTest extends IntegrationTestBase {
     }
 
     @ParameterizedTest(name = "{0}")
-    @MethodSource("keyCases")
-    void getSignedUrlWithCannedPolicy_producesValidUrl(KeyTestCase testCase) throws Exception {
+    @MethodSource("signingCases")
+    void getSignedUrlWithCannedPolicy_producesValidUrl(SigningTestCase testCase) throws Exception {
         InputStream originalBucketContent = s3Client.getObject(r -> r.bucket(bucket).key(S3_OBJECT_KEY));
         Instant expirationDate = LocalDate.of(2050, 1, 1).atStartOfDay().toInstant(ZoneOffset.of("Z"));
         CannedSignerRequest request = CannedSignerRequest.builder()
                                                          .resourceUrl(resourceUrl)
-                                                         .privateKey(testCase.keyFilePath)
-                                                         .keyPairId(testCase.keyPairId)
-                                                         .expirationDate(expirationDate).build();
+                                                         .privateKey(testCase.keyTestCase.keyFilePath)
+                                                         .keyPairId(testCase.keyTestCase.keyPairId)
+                                                         .expirationDate(expirationDate)
+                                                         .hashAlgorithm(testCase.hashAlgorithm).build();
         SignedUrl signedUrl = cloudFrontUtilities.getSignedUrlWithCannedPolicy(request);
         SdkHttpClient client = Apache5HttpClient.create();
         HttpExecuteResponse response = client.prepareRequest(HttpExecuteRequest.builder()
@@ -179,13 +199,14 @@ public class CloudFrontUtilitiesIntegrationTest extends IntegrationTestBase {
     }
 
     @ParameterizedTest(name = "{0}")
-    @MethodSource("keyCases")
-    void getSignedUrlWithCannedPolicy_withExpiredDate_shouldReturn403Response(KeyTestCase testCase) throws Exception {
+    @MethodSource("signingCases")
+    void getSignedUrlWithCannedPolicy_withExpiredDate_shouldReturn403Response(SigningTestCase testCase) throws Exception {
         Instant expirationDate = LocalDate.of(2020, 1, 1).atStartOfDay().toInstant(ZoneOffset.of("Z"));
         SignedUrl signedUrl = cloudFrontUtilities.getSignedUrlWithCannedPolicy(r -> r.resourceUrl(resourceUrl)
-                                                                                      .privateKey(testCase.privateKey)
-                                                                                      .keyPairId(testCase.keyPairId)
-                                                                                      .expirationDate(expirationDate));
+                                                                                      .privateKey(testCase.keyTestCase.privateKey)
+                                                                                      .keyPairId(testCase.keyTestCase.keyPairId)
+                                                                                      .expirationDate(expirationDate)
+                                                                                      .hashAlgorithm(testCase.hashAlgorithm));
         SdkHttpClient client = Apache5HttpClient.create();
         HttpExecuteResponse response = client.prepareRequest(HttpExecuteRequest.builder()
                                                                                .request(signedUrl.createHttpGetRequest())
@@ -195,17 +216,18 @@ public class CloudFrontUtilitiesIntegrationTest extends IntegrationTestBase {
     }
 
     @ParameterizedTest(name = "{0}")
-    @MethodSource("keyCases")
-    void getSignedUrlWithCustomPolicy_producesValidUrl(KeyTestCase testCase) throws Exception {
+    @MethodSource("signingCases")
+    void getSignedUrlWithCustomPolicy_producesValidUrl(SigningTestCase testCase) throws Exception {
         InputStream originalBucketContent = s3Client.getObject(r -> r.bucket(bucket).key(S3_OBJECT_KEY));
         Instant activeDate = LocalDate.of(2022, 1, 1).atStartOfDay().toInstant(ZoneOffset.of("Z"));
         Instant expirationDate = LocalDate.of(2050, 1, 1).atStartOfDay().toInstant(ZoneOffset.of("Z"));
         CustomSignerRequest request = CustomSignerRequest.builder()
                                                          .resourceUrl(resourceUrl)
-                                                         .privateKey(testCase.keyFilePath)
-                                                         .keyPairId(testCase.keyPairId)
+                                                         .privateKey(testCase.keyTestCase.keyFilePath)
+                                                         .keyPairId(testCase.keyTestCase.keyPairId)
                                                          .expirationDate(expirationDate)
-                                                         .activeDate(activeDate).build();
+                                                         .activeDate(activeDate)
+                                                         .hashAlgorithm(testCase.hashAlgorithm).build();
         SignedUrl signedUrl = cloudFrontUtilities.getSignedUrlWithCustomPolicy(request);
         SdkHttpClient client = Apache5HttpClient.create();
         HttpExecuteResponse response = client.prepareRequest(HttpExecuteRequest.builder()
@@ -236,14 +258,15 @@ public class CloudFrontUtilitiesIntegrationTest extends IntegrationTestBase {
     }
 
     @ParameterizedTest(name = "{0}")
-    @MethodSource("keyCases")
-    void getCookiesForCannedPolicy_producesValidCookies(KeyTestCase testCase) throws Exception {
+    @MethodSource("signingCases")
+    void getCookiesForCannedPolicy_producesValidCookies(SigningTestCase testCase) throws Exception {
         InputStream originalBucketContent = s3Client.getObject(r -> r.bucket(bucket).key(S3_OBJECT_KEY));
         Instant expirationDate = LocalDate.of(2050, 1, 1).atStartOfDay().toInstant(ZoneOffset.of("Z"));
         CookiesForCannedPolicy cookies = cloudFrontUtilities.getCookiesForCannedPolicy(r -> r.resourceUrl(resourceUrl)
-                                                                                             .privateKey(testCase.privateKey)
-                                                                                             .keyPairId(testCase.keyPairId)
-                                                                                             .expirationDate(expirationDate));
+                                                                                             .privateKey(testCase.keyTestCase.privateKey)
+                                                                                             .keyPairId(testCase.keyTestCase.keyPairId)
+                                                                                             .expirationDate(expirationDate)
+                                                                                             .hashAlgorithm(testCase.hashAlgorithm));
 
         SdkHttpClient client = Apache5HttpClient.create();
         HttpExecuteResponse response = client.prepareRequest(HttpExecuteRequest.builder()
@@ -275,16 +298,17 @@ public class CloudFrontUtilitiesIntegrationTest extends IntegrationTestBase {
     }
 
     @ParameterizedTest(name = "{0}")
-    @MethodSource("keyCases")
-    void getCookiesForCustomPolicy_producesValidCookies(KeyTestCase testCase) throws Exception {
+    @MethodSource("signingCases")
+    void getCookiesForCustomPolicy_producesValidCookies(SigningTestCase testCase) throws Exception {
         InputStream originalBucketContent = s3Client.getObject(r -> r.bucket(bucket).key(S3_OBJECT_KEY));
         Instant activeDate = LocalDate.of(2022, 1, 1).atStartOfDay().toInstant(ZoneOffset.of("Z"));
         Instant expirationDate = LocalDate.of(2050, 1, 1).atStartOfDay().toInstant(ZoneOffset.of("Z"));
         CookiesForCustomPolicy cookies = cloudFrontUtilities.getCookiesForCustomPolicy(r -> r.resourceUrl(resourceUrl)
-                                                                                             .privateKey(testCase.privateKey)
-                                                                                             .keyPairId(testCase.keyPairId)
+                                                                                             .privateKey(testCase.keyTestCase.privateKey)
+                                                                                             .keyPairId(testCase.keyTestCase.keyPairId)
                                                                                              .expirationDate(expirationDate)
-                                                                                             .activeDate(activeDate));
+                                                                                             .activeDate(activeDate)
+                                                                                             .hashAlgorithm(testCase.hashAlgorithm));
 
         SdkHttpClient client = Apache5HttpClient.create();
         HttpExecuteResponse response = client.prepareRequest(HttpExecuteRequest.builder()
@@ -318,8 +342,8 @@ public class CloudFrontUtilitiesIntegrationTest extends IntegrationTestBase {
     }
 
     @ParameterizedTest(name = "{0}")
-    @MethodSource("keyCases")
-    void getCookiesForCustomPolicy_shouldAllowQueryParametersWhenUsingWildcard(KeyTestCase testCase) throws Exception {
+    @MethodSource("signingCases")
+    void getCookiesForCustomPolicy_shouldAllowQueryParametersWhenUsingWildcard(SigningTestCase testCase) throws Exception {
         Instant expirationDate = LocalDate.of(2050, 1, 1)
                                           .atStartOfDay()
                                           .toInstant(ZoneOffset.of("Z"));
@@ -329,30 +353,33 @@ public class CloudFrontUtilitiesIntegrationTest extends IntegrationTestBase {
                                       .toInstant(ZoneOffset.of("Z"));
 
         CookiesForCustomPolicy cookies = cloudFrontUtilities.getCookiesForCustomPolicy(r -> r.resourceUrl(resourceUrl)
-                                                                                             .privateKey(testCase.privateKey)
-                                                                                             .keyPairId(testCase.keyPairId)
+                                                                                             .privateKey(testCase.keyTestCase.privateKey)
+                                                                                             .keyPairId(testCase.keyTestCase.keyPairId)
                                                                                              .resourceUrlPattern(resourceUrl + "*")
                                                                                              .activeDate(activeDate)
-                                                                                             .expirationDate(expirationDate));
+                                                                                             .expirationDate(expirationDate)
+                                                                                             .hashAlgorithm(testCase.hashAlgorithm));
 
         // Request the same resource with an additional query parameter - should still be allowed by the wildcard policy
         URI uri = URI.create(resourceUrl + "?foo=bar");
         SdkHttpClient client = Apache5HttpClient.create();
+        SdkHttpRequest.Builder requestBuilder = SdkHttpRequest.builder()
+                                                              .uri(uri)
+                                                              .appendHeader("Cookie", cookies.policyHeaderValue())
+                                                              .appendHeader("Cookie", cookies.signatureHeaderValue())
+                                                              .appendHeader("Cookie", cookies.keyPairIdHeaderValue());
+        if (cookies.hashAlgorithmHeaderValue() != null) {
+            requestBuilder.appendHeader("Cookie", cookies.hashAlgorithmHeaderValue());
+        }
         HttpExecuteResponse response = client.prepareRequest(HttpExecuteRequest.builder()
-                                                                               .request(SdkHttpRequest.builder()
-                                                                                                      .uri(uri)
-                                                                                                      .appendHeader("Cookie", cookies.policyHeaderValue())
-                                                                                                      .appendHeader("Cookie", cookies.signatureHeaderValue())
-                                                                                                      .appendHeader("Cookie", cookies.keyPairIdHeaderValue())
-                                                                                                      .method(SdkHttpMethod.GET)
-                                                                                                      .build())
+                                                                               .request(requestBuilder.method(SdkHttpMethod.GET).build())
                                                                                .build()).call();
         assertThat(response.httpResponse().statusCode()).isEqualTo(200);
     }
 
     @ParameterizedTest(name = "{0}")
-    @MethodSource("keyCases")
-    void getCookiesForCustomPolicy_wildCardPath(KeyTestCase testCase) throws Exception {
+    @MethodSource("signingCases")
+    void getCookiesForCustomPolicy_wildCardPath(SigningTestCase testCase) throws Exception {
         String resourceUri = "https://" + domainName;
         Instant expirationDate = LocalDate.of(2050, 1, 1)
                                           .atStartOfDay()
@@ -364,30 +391,33 @@ public class CloudFrontUtilitiesIntegrationTest extends IntegrationTestBase {
 
         CookiesForCustomPolicy cookies = cloudFrontUtilities.getCookiesForCustomPolicy(
             r -> r.resourceUrl(resourceUri + "/foo/specific-file")
-                  .privateKey(testCase.privateKey)
-                  .keyPairId(testCase.keyPairId)
+                  .privateKey(testCase.keyTestCase.privateKey)
+                  .keyPairId(testCase.keyTestCase.keyPairId)
                   .resourceUrlPattern(resourceUri + "/foo/*")
                   .activeDate(activeDate)
-                  .expirationDate(expirationDate));
+                  .expirationDate(expirationDate)
+                  .hashAlgorithm(testCase.hashAlgorithm));
 
         // Use the cookies to access a different file under the same wildcard path
         URI otherFileUri = URI.create(resourceUri + "/foo/other-file");
         SdkHttpClient client = Apache5HttpClient.create();
+        SdkHttpRequest.Builder requestBuilder = SdkHttpRequest.builder()
+                                                              .uri(otherFileUri)
+                                                              .appendHeader("Cookie", cookies.policyHeaderValue())
+                                                              .appendHeader("Cookie", cookies.signatureHeaderValue())
+                                                              .appendHeader("Cookie", cookies.keyPairIdHeaderValue());
+        if (cookies.hashAlgorithmHeaderValue() != null) {
+            requestBuilder.appendHeader("Cookie", cookies.hashAlgorithmHeaderValue());
+        }
         HttpExecuteResponse response = client.prepareRequest(HttpExecuteRequest.builder()
-                                                                               .request(SdkHttpRequest.builder()
-                                                                                                      .uri(otherFileUri)
-                                                                                                      .appendHeader("Cookie", cookies.policyHeaderValue())
-                                                                                                      .appendHeader("Cookie", cookies.signatureHeaderValue())
-                                                                                                      .appendHeader("Cookie", cookies.keyPairIdHeaderValue())
-                                                                                                      .method(SdkHttpMethod.GET)
-                                                                                                      .build())
+                                                                               .request(requestBuilder.method(SdkHttpMethod.GET).build())
                                                                                .build()).call();
         assertThat(response.httpResponse().statusCode()).isEqualTo(200);
     }
 
     @ParameterizedTest(name = "{0}")
-    @MethodSource("keyCases")
-    void getCookiesForCustomPolicy_wildCardPolicyResource_allowsAnyPath(KeyTestCase testCase) throws Exception {
+    @MethodSource("signingCases")
+    void getCookiesForCustomPolicy_wildCardPolicyResource_allowsAnyPath(SigningTestCase testCase) throws Exception {
         Instant expirationDate = LocalDate.of(2050, 1, 1)
                                           .atStartOfDay()
                                           .toInstant(ZoneOffset.of("Z"));
@@ -398,30 +428,33 @@ public class CloudFrontUtilitiesIntegrationTest extends IntegrationTestBase {
 
         CookiesForCustomPolicy cookies = cloudFrontUtilities.getCookiesForCustomPolicy(
             r -> r.resourceUrl(resourceUrl)
-                  .privateKey(testCase.privateKey)
-                  .keyPairId(testCase.keyPairId)
+                  .privateKey(testCase.keyTestCase.privateKey)
+                  .keyPairId(testCase.keyTestCase.keyPairId)
                   .resourceUrlPattern("*")
                   .activeDate(activeDate)
-                  .expirationDate(expirationDate));
+                  .expirationDate(expirationDate)
+                  .hashAlgorithm(testCase.hashAlgorithm));
 
         // Use the cookies to access a completely different path - the "*" pattern should allow any path
         URI differentPathUri = URI.create(resourceUrl.replace("/s3ObjectKey", "/foo/other-file"));
         SdkHttpClient client = Apache5HttpClient.create();
+        SdkHttpRequest.Builder requestBuilder = SdkHttpRequest.builder()
+                                                              .uri(differentPathUri)
+                                                              .appendHeader("Cookie", cookies.policyHeaderValue())
+                                                              .appendHeader("Cookie", cookies.signatureHeaderValue())
+                                                              .appendHeader("Cookie", cookies.keyPairIdHeaderValue());
+        if (cookies.hashAlgorithmHeaderValue() != null) {
+            requestBuilder.appendHeader("Cookie", cookies.hashAlgorithmHeaderValue());
+        }
         HttpExecuteResponse response = client.prepareRequest(HttpExecuteRequest.builder()
-                                                                               .request(SdkHttpRequest.builder()
-                                                                                                      .uri(differentPathUri)
-                                                                                                      .appendHeader("Cookie", cookies.policyHeaderValue())
-                                                                                                      .appendHeader("Cookie", cookies.signatureHeaderValue())
-                                                                                                      .appendHeader("Cookie", cookies.keyPairIdHeaderValue())
-                                                                                                      .method(SdkHttpMethod.GET)
-                                                                                                      .build())
+                                                                               .request(requestBuilder.method(SdkHttpMethod.GET).build())
                                                                                .build()).call();
         assertThat(response.httpResponse().statusCode()).isEqualTo(200);
     }
 
     @ParameterizedTest(name = "{0}")
-    @MethodSource("keyCases")
-    void getSignedUrlWithCustomPolicy_shouldAllowQueryParametersWhenUsingWildcard(KeyTestCase testCase) throws Exception {
+    @MethodSource("signingCases")
+    void getSignedUrlWithCustomPolicy_shouldAllowQueryParametersWhenUsingWildcard(SigningTestCase testCase) throws Exception {
         Instant expirationDate = LocalDate.of(2050, 1, 1)
                                           .atStartOfDay()
                                           .toInstant(ZoneOffset.of("Z"));
@@ -432,11 +465,12 @@ public class CloudFrontUtilitiesIntegrationTest extends IntegrationTestBase {
 
         CustomSignerRequest request = CustomSignerRequest.builder()
                                                          .resourceUrl(resourceUrl)
-                                                         .privateKey(testCase.keyFilePath)
-                                                         .keyPairId(testCase.keyPairId)
+                                                         .privateKey(testCase.keyTestCase.keyFilePath)
+                                                         .keyPairId(testCase.keyTestCase.keyPairId)
                                                          .resourceUrlPattern(resourceUrl + "*")
                                                          .activeDate(activeDate)
                                                          .expirationDate(expirationDate)
+                                                         .hashAlgorithm(testCase.hashAlgorithm)
                                                          .build();
 
         SignedUrl signedUrl = cloudFrontUtilities.getSignedUrlWithCustomPolicy(request);
@@ -458,8 +492,8 @@ public class CloudFrontUtilitiesIntegrationTest extends IntegrationTestBase {
     }
 
     @ParameterizedTest(name = "{0}")
-    @MethodSource("keyCases")
-    void getSignedUrlWithCustomPolicy_wildCardPath(KeyTestCase testCase) throws Exception {
+    @MethodSource("signingCases")
+    void getSignedUrlWithCustomPolicy_wildCardPath(SigningTestCase testCase) throws Exception {
         String resourceUri = "https://" + domainName;
         Instant expirationDate = LocalDate.of(2050, 1, 1)
                                           .atStartOfDay()
@@ -471,11 +505,12 @@ public class CloudFrontUtilitiesIntegrationTest extends IntegrationTestBase {
 
         CustomSignerRequest request = CustomSignerRequest.builder()
                                                          .resourceUrl(resourceUri + "/foo/specific-file")
-                                                         .privateKey(testCase.keyFilePath)
-                                                         .keyPairId(testCase.keyPairId)
+                                                         .privateKey(testCase.keyTestCase.keyFilePath)
+                                                         .keyPairId(testCase.keyTestCase.keyPairId)
                                                          .resourceUrlPattern(resourceUri + "/foo/*")
                                                          .activeDate(activeDate)
                                                          .expirationDate(expirationDate)
+                                                         .hashAlgorithm(testCase.hashAlgorithm)
                                                          .build();
 
         SignedUrl signedUrl = cloudFrontUtilities.getSignedUrlWithCustomPolicy(request);
@@ -495,8 +530,8 @@ public class CloudFrontUtilitiesIntegrationTest extends IntegrationTestBase {
     }
 
     @ParameterizedTest(name = "{0}")
-    @MethodSource("keyCases")
-    void getSignedUrlWithCustomPolicy_wildCardPolicyResource_allowsAnyPath(KeyTestCase testCase) throws Exception {
+    @MethodSource("signingCases")
+    void getSignedUrlWithCustomPolicy_wildCardPolicyResource_allowsAnyPath(SigningTestCase testCase) throws Exception {
         Instant expirationDate = LocalDate.of(2050, 1, 1)
                                           .atStartOfDay()
                                           .toInstant(ZoneOffset.of("Z"));
@@ -507,11 +542,12 @@ public class CloudFrontUtilitiesIntegrationTest extends IntegrationTestBase {
 
         CustomSignerRequest request = CustomSignerRequest.builder()
                                                          .resourceUrl(resourceUrl)
-                                                         .privateKey(testCase.keyFilePath)
-                                                         .keyPairId(testCase.keyPairId)
+                                                         .privateKey(testCase.keyTestCase.keyFilePath)
+                                                         .keyPairId(testCase.keyTestCase.keyPairId)
                                                          .resourceUrlPattern("*")
                                                          .activeDate(activeDate)
                                                          .expirationDate(expirationDate)
+                                                         .hashAlgorithm(testCase.hashAlgorithm)
                                                          .build();
 
         SignedUrl signedUrl = cloudFrontUtilities.getSignedUrlWithCustomPolicy(request);
@@ -541,7 +577,6 @@ public class CloudFrontUtilitiesIntegrationTest extends IntegrationTestBase {
 
         domainName = distribution.domainName;
         resourceUrl = "https://" + domainName + "/" + S3_OBJECT_KEY;
-        distributionId = distribution.id;
     }
 
     private static void initializeRsaKeyFileAndPair() throws Exception {

--- a/services/cloudfront/src/test/java/software/amazon/awssdk/services/cloudfront/CloudFrontUtilitiesIntegrationTest.java
+++ b/services/cloudfront/src/test/java/software/amazon/awssdk/services/cloudfront/CloudFrontUtilitiesIntegrationTest.java
@@ -61,7 +61,7 @@ import software.amazon.awssdk.services.cloudfront.model.CreateCloudFrontOriginAc
 import software.amazon.awssdk.services.cloudfront.model.CreatePublicKeyResponse;
 import software.amazon.awssdk.services.cloudfront.model.CustomSignerRequest;
 import software.amazon.awssdk.services.cloudfront.model.DefaultCacheBehavior;
-import software.amazon.awssdk.services.cloudfront.model.HashAlgorithm;
+import software.amazon.awssdk.services.cloudfront.utils.SigningHashAlgorithm;
 import software.amazon.awssdk.services.cloudfront.model.Distribution;
 import software.amazon.awssdk.services.cloudfront.model.DistributionConfig;
 import software.amazon.awssdk.services.cloudfront.model.DistributionSummary;
@@ -138,9 +138,9 @@ public class CloudFrontUtilitiesIntegrationTest extends IntegrationTestBase {
 
     private static class SigningTestCase {
         final KeyTestCase keyTestCase;
-        final HashAlgorithm hashAlgorithm;
+        final SigningHashAlgorithm hashAlgorithm;
 
-        SigningTestCase(KeyTestCase keyTestCase, HashAlgorithm hashAlgorithm) {
+        SigningTestCase(KeyTestCase keyTestCase, SigningHashAlgorithm hashAlgorithm) {
             this.keyTestCase = keyTestCase;
             this.hashAlgorithm = hashAlgorithm;
         }
@@ -153,8 +153,8 @@ public class CloudFrontUtilitiesIntegrationTest extends IntegrationTestBase {
 
     static Stream<SigningTestCase> signingCases() {
         return keyCases().flatMap(k -> Stream.of(
-            new SigningTestCase(k, HashAlgorithm.SHA1),
-            new SigningTestCase(k, HashAlgorithm.SHA256)
+            new SigningTestCase(k, SigningHashAlgorithm.SHA1),
+            new SigningTestCase(k, SigningHashAlgorithm.SHA256)
         ));
     }
 

--- a/services/cloudfront/src/test/java/software/amazon/awssdk/services/cloudfront/CloudFrontUtilitiesTest.java
+++ b/services/cloudfront/src/test/java/software/amazon/awssdk/services/cloudfront/CloudFrontUtilitiesTest.java
@@ -53,6 +53,7 @@ import software.amazon.awssdk.services.cloudfront.cookie.CookiesForCustomPolicy;
 import software.amazon.awssdk.services.cloudfront.internal.utils.SigningUtils;
 import software.amazon.awssdk.services.cloudfront.model.CannedSignerRequest;
 import software.amazon.awssdk.services.cloudfront.model.CustomSignerRequest;
+import software.amazon.awssdk.services.cloudfront.model.HashAlgorithm;
 import software.amazon.awssdk.services.cloudfront.url.SignedUrl;
 
 
@@ -524,5 +525,135 @@ class CloudFrontUtilitiesTest {
     void customSignerRequest_nullResourceUrlShouldThrow(){
         assertThatNullPointerException().isThrownBy(() -> CustomSignerRequest.builder().build())
                                         .withMessageContaining("resourceUrl must not be null");
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("keyCases")
+    void getSignedURLWithCannedPolicy_sha256_includesHashAlgorithmParam(KeyTestCase testCase) {
+        Instant expirationDate = LocalDate.of(2024, 1, 1).atStartOfDay().toInstant(ZoneOffset.of("Z"));
+        SignedUrl signedUrl =
+            cloudFrontUtilities.getSignedUrlWithCannedPolicy(r -> r
+                .resourceUrl(RESOURCE_URL)
+                .privateKey(testCase.keyPair.getPrivate())
+                .keyPairId("keyPairId")
+                .expirationDate(expirationDate)
+                .hashAlgorithm(HashAlgorithm.SHA256));
+        String url = signedUrl.url();
+        assertThat(url).contains("&Hash-Algorithm=SHA256");
+        assertThat(url).endsWith("&Hash-Algorithm=SHA256");
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("keyCases")
+    void getSignedURLWithCannedPolicy_sha1Default_doesNotIncludeHashAlgorithmParam(KeyTestCase testCase) {
+        Instant expirationDate = LocalDate.of(2024, 1, 1).atStartOfDay().toInstant(ZoneOffset.of("Z"));
+        SignedUrl signedUrl =
+            cloudFrontUtilities.getSignedUrlWithCannedPolicy(r -> r
+                .resourceUrl(RESOURCE_URL)
+                .privateKey(testCase.keyPair.getPrivate())
+                .keyPairId("keyPairId")
+                .expirationDate(expirationDate));
+        String url = signedUrl.url();
+        assertThat(url).doesNotContain("Hash-Algorithm");
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("keyCases")
+    void getSignedURLWithCustomPolicy_sha256_includesHashAlgorithmParam(KeyTestCase testCase) {
+        Instant expirationDate = LocalDate.of(2024, 1, 1).atStartOfDay().toInstant(ZoneOffset.of("Z"));
+        SignedUrl signedUrl =
+            cloudFrontUtilities.getSignedUrlWithCustomPolicy(r -> r
+                .resourceUrl(RESOURCE_URL)
+                .privateKey(testCase.keyPair.getPrivate())
+                .keyPairId("keyPairId")
+                .expirationDate(expirationDate)
+                .hashAlgorithm(HashAlgorithm.SHA256));
+        String url = signedUrl.url();
+        assertThat(url).contains("&Hash-Algorithm=SHA256");
+        assertThat(url).endsWith("&Hash-Algorithm=SHA256");
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("keyCases")
+    void getCookiesForCannedPolicy_sha256_includesHashAlgorithmHeader(KeyTestCase testCase) {
+        Instant expirationDate = LocalDate.of(2024, 1, 1).atStartOfDay().toInstant(ZoneOffset.of("Z"));
+        CannedSignerRequest request = CannedSignerRequest.builder()
+                                                         .resourceUrl(RESOURCE_URL)
+                                                         .privateKey(testCase.keyPair.getPrivate())
+                                                         .keyPairId("keyPairId")
+                                                         .expirationDate(expirationDate)
+                                                         .hashAlgorithm(HashAlgorithm.SHA256)
+                                                         .build();
+        CookiesForCannedPolicy cookies = cloudFrontUtilities.getCookiesForCannedPolicy(request);
+        assertThat(cookies.hashAlgorithmHeaderValue()).isEqualTo("CloudFront-Hash-Algorithm=SHA256");
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("keyCases")
+    void getCookiesForCannedPolicy_sha1Default_hashAlgorithmHeaderIsNull(KeyTestCase testCase) {
+        Instant expirationDate = LocalDate.of(2024, 1, 1).atStartOfDay().toInstant(ZoneOffset.of("Z"));
+        CannedSignerRequest request = CannedSignerRequest.builder()
+                                                         .resourceUrl(RESOURCE_URL)
+                                                         .privateKey(testCase.keyPair.getPrivate())
+                                                         .keyPairId("keyPairId")
+                                                         .expirationDate(expirationDate)
+                                                         .build();
+        CookiesForCannedPolicy cookies = cloudFrontUtilities.getCookiesForCannedPolicy(request);
+        assertThat(cookies.hashAlgorithmHeaderValue()).isNull();
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("keyCases")
+    void getCookiesForCustomPolicy_sha256_includesHashAlgorithmHeader(KeyTestCase testCase) {
+        Instant expirationDate = LocalDate.of(2024, 1, 1).atStartOfDay().toInstant(ZoneOffset.of("Z"));
+        CustomSignerRequest request = CustomSignerRequest.builder()
+                                                         .resourceUrl(RESOURCE_URL)
+                                                         .privateKey(testCase.keyPair.getPrivate())
+                                                         .keyPairId("keyPairId")
+                                                         .expirationDate(expirationDate)
+                                                         .hashAlgorithm(HashAlgorithm.SHA256)
+                                                         .build();
+        CookiesForCustomPolicy cookies = cloudFrontUtilities.getCookiesForCustomPolicy(request);
+        assertThat(cookies.hashAlgorithmHeaderValue()).isEqualTo("CloudFront-Hash-Algorithm=SHA256");
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("keyCases")
+    void getCookiesForCustomPolicy_sha1Default_hashAlgorithmHeaderIsNull(KeyTestCase testCase) {
+        Instant expirationDate = LocalDate.of(2024, 1, 1).atStartOfDay().toInstant(ZoneOffset.of("Z"));
+        CustomSignerRequest request = CustomSignerRequest.builder()
+                                                         .resourceUrl(RESOURCE_URL)
+                                                         .privateKey(testCase.keyPair.getPrivate())
+                                                         .keyPairId("keyPairId")
+                                                         .expirationDate(expirationDate)
+                                                         .build();
+        CookiesForCustomPolicy cookies = cloudFrontUtilities.getCookiesForCustomPolicy(request);
+        assertThat(cookies.hashAlgorithmHeaderValue()).isNull();
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("keyCases")
+    void getSignedURLWithCannedPolicy_sha256_producesDifferentSignatureThanSha1(KeyTestCase testCase) {
+        Instant expirationDate = LocalDate.of(2024, 1, 1).atStartOfDay().toInstant(ZoneOffset.of("Z"));
+        SignedUrl sha1Url =
+            cloudFrontUtilities.getSignedUrlWithCannedPolicy(r -> r
+                .resourceUrl(RESOURCE_URL)
+                .privateKey(testCase.keyPair.getPrivate())
+                .keyPairId("keyPairId")
+                .expirationDate(expirationDate)
+                .hashAlgorithm(HashAlgorithm.SHA1));
+        SignedUrl sha256Url =
+            cloudFrontUtilities.getSignedUrlWithCannedPolicy(r -> r
+                .resourceUrl(RESOURCE_URL)
+                .privateKey(testCase.keyPair.getPrivate())
+                .keyPairId("keyPairId")
+                .expirationDate(expirationDate)
+                .hashAlgorithm(HashAlgorithm.SHA256));
+
+        String sha1Sig = sha1Url.url().substring(
+            sha1Url.url().indexOf("&Signature=") + 11, sha1Url.url().indexOf("&Key-Pair-Id"));
+        String sha256Sig = sha256Url.url().substring(
+            sha256Url.url().indexOf("&Signature=") + 11, sha256Url.url().indexOf("&Key-Pair-Id"));
+        assertThat(sha1Sig).isNotEqualTo(sha256Sig);
     }
 }

--- a/services/cloudfront/src/test/java/software/amazon/awssdk/services/cloudfront/CloudFrontUtilitiesTest.java
+++ b/services/cloudfront/src/test/java/software/amazon/awssdk/services/cloudfront/CloudFrontUtilitiesTest.java
@@ -53,7 +53,7 @@ import software.amazon.awssdk.services.cloudfront.cookie.CookiesForCustomPolicy;
 import software.amazon.awssdk.services.cloudfront.internal.utils.SigningUtils;
 import software.amazon.awssdk.services.cloudfront.model.CannedSignerRequest;
 import software.amazon.awssdk.services.cloudfront.model.CustomSignerRequest;
-import software.amazon.awssdk.services.cloudfront.model.HashAlgorithm;
+import software.amazon.awssdk.services.cloudfront.utils.SigningHashAlgorithm;
 import software.amazon.awssdk.services.cloudfront.url.SignedUrl;
 
 
@@ -529,7 +529,7 @@ class CloudFrontUtilitiesTest {
 
     @ParameterizedTest(name = "{0}")
     @MethodSource("keyCases")
-    void getSignedURLWithCannedPolicy_sha256_includesHashAlgorithmParam(KeyTestCase testCase) {
+    void getSignedURLWithCannedPolicy_sha256_includesSigningHashAlgorithmParam(KeyTestCase testCase) {
         Instant expirationDate = LocalDate.of(2024, 1, 1).atStartOfDay().toInstant(ZoneOffset.of("Z"));
         SignedUrl signedUrl =
             cloudFrontUtilities.getSignedUrlWithCannedPolicy(r -> r
@@ -537,7 +537,7 @@ class CloudFrontUtilitiesTest {
                 .privateKey(testCase.keyPair.getPrivate())
                 .keyPairId("keyPairId")
                 .expirationDate(expirationDate)
-                .hashAlgorithm(HashAlgorithm.SHA256));
+                .hashAlgorithm(SigningHashAlgorithm.SHA256));
         String url = signedUrl.url();
         assertThat(url).contains("&Hash-Algorithm=SHA256");
         assertThat(url).endsWith("&Hash-Algorithm=SHA256");
@@ -545,7 +545,7 @@ class CloudFrontUtilitiesTest {
 
     @ParameterizedTest(name = "{0}")
     @MethodSource("keyCases")
-    void getSignedURLWithCannedPolicy_sha1Default_doesNotIncludeHashAlgorithmParam(KeyTestCase testCase) {
+    void getSignedURLWithCannedPolicy_sha1Default_doesNotIncludeSigningHashAlgorithmParam(KeyTestCase testCase) {
         Instant expirationDate = LocalDate.of(2024, 1, 1).atStartOfDay().toInstant(ZoneOffset.of("Z"));
         SignedUrl signedUrl =
             cloudFrontUtilities.getSignedUrlWithCannedPolicy(r -> r
@@ -559,7 +559,7 @@ class CloudFrontUtilitiesTest {
 
     @ParameterizedTest(name = "{0}")
     @MethodSource("keyCases")
-    void getSignedURLWithCustomPolicy_sha256_includesHashAlgorithmParam(KeyTestCase testCase) {
+    void getSignedURLWithCustomPolicy_sha256_includesSigningHashAlgorithmParam(KeyTestCase testCase) {
         Instant expirationDate = LocalDate.of(2024, 1, 1).atStartOfDay().toInstant(ZoneOffset.of("Z"));
         SignedUrl signedUrl =
             cloudFrontUtilities.getSignedUrlWithCustomPolicy(r -> r
@@ -567,7 +567,7 @@ class CloudFrontUtilitiesTest {
                 .privateKey(testCase.keyPair.getPrivate())
                 .keyPairId("keyPairId")
                 .expirationDate(expirationDate)
-                .hashAlgorithm(HashAlgorithm.SHA256));
+                .hashAlgorithm(SigningHashAlgorithm.SHA256));
         String url = signedUrl.url();
         assertThat(url).contains("&Hash-Algorithm=SHA256");
         assertThat(url).endsWith("&Hash-Algorithm=SHA256");
@@ -575,14 +575,14 @@ class CloudFrontUtilitiesTest {
 
     @ParameterizedTest(name = "{0}")
     @MethodSource("keyCases")
-    void getCookiesForCannedPolicy_sha256_includesHashAlgorithmHeader(KeyTestCase testCase) {
+    void getCookiesForCannedPolicy_sha256_includesSigningHashAlgorithmHeader(KeyTestCase testCase) {
         Instant expirationDate = LocalDate.of(2024, 1, 1).atStartOfDay().toInstant(ZoneOffset.of("Z"));
         CannedSignerRequest request = CannedSignerRequest.builder()
                                                          .resourceUrl(RESOURCE_URL)
                                                          .privateKey(testCase.keyPair.getPrivate())
                                                          .keyPairId("keyPairId")
                                                          .expirationDate(expirationDate)
-                                                         .hashAlgorithm(HashAlgorithm.SHA256)
+                                                         .hashAlgorithm(SigningHashAlgorithm.SHA256)
                                                          .build();
         CookiesForCannedPolicy cookies = cloudFrontUtilities.getCookiesForCannedPolicy(request);
         assertThat(cookies.hashAlgorithmHeaderValue()).isEqualTo("CloudFront-Hash-Algorithm=SHA256");
@@ -604,14 +604,14 @@ class CloudFrontUtilitiesTest {
 
     @ParameterizedTest(name = "{0}")
     @MethodSource("keyCases")
-    void getCookiesForCustomPolicy_sha256_includesHashAlgorithmHeader(KeyTestCase testCase) {
+    void getCookiesForCustomPolicy_sha256_includesSigningHashAlgorithmHeader(KeyTestCase testCase) {
         Instant expirationDate = LocalDate.of(2024, 1, 1).atStartOfDay().toInstant(ZoneOffset.of("Z"));
         CustomSignerRequest request = CustomSignerRequest.builder()
                                                          .resourceUrl(RESOURCE_URL)
                                                          .privateKey(testCase.keyPair.getPrivate())
                                                          .keyPairId("keyPairId")
                                                          .expirationDate(expirationDate)
-                                                         .hashAlgorithm(HashAlgorithm.SHA256)
+                                                         .hashAlgorithm(SigningHashAlgorithm.SHA256)
                                                          .build();
         CookiesForCustomPolicy cookies = cloudFrontUtilities.getCookiesForCustomPolicy(request);
         assertThat(cookies.hashAlgorithmHeaderValue()).isEqualTo("CloudFront-Hash-Algorithm=SHA256");
@@ -641,14 +641,14 @@ class CloudFrontUtilitiesTest {
                 .privateKey(testCase.keyPair.getPrivate())
                 .keyPairId("keyPairId")
                 .expirationDate(expirationDate)
-                .hashAlgorithm(HashAlgorithm.SHA1));
+                .hashAlgorithm(SigningHashAlgorithm.SHA1));
         SignedUrl sha256Url =
             cloudFrontUtilities.getSignedUrlWithCannedPolicy(r -> r
                 .resourceUrl(RESOURCE_URL)
                 .privateKey(testCase.keyPair.getPrivate())
                 .keyPairId("keyPairId")
                 .expirationDate(expirationDate)
-                .hashAlgorithm(HashAlgorithm.SHA256));
+                .hashAlgorithm(SigningHashAlgorithm.SHA256));
 
         String sha1Sig = sha1Url.url().substring(
             sha1Url.url().indexOf("&Signature=") + 11, sha1Url.url().indexOf("&Key-Pair-Id"));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
https://github.com/aws/aws-sdk-java-v2/issues/6841 and https://github.com/aws/aws-sdk-java-v2/issues/6842

Adds opt-in support for SHA256

## Modifications

- Add `SigningHashAlgorithm` enum (`SHA1`, `SHA256`) in new `utils` package, with an explicit `id()` field for algorithm name construction
- Add `hashAlgorithm()` default method to `CloudFrontSignerRequest` interface (defaults to `SHA1`)
- Add `hashAlgorithm(SigningHashAlgorithm)` builder method to `CannedSignerRequest` and `CustomSignerRequest`
- Consolidate signing methods in `SigningUtils` into a single `sign(byte[], PrivateKey, String)` method that accepts a Java Security algorithm name
- Add `javaSecuritySigningAlgorithm()` helper in `CloudFrontUtilities` that resolves the algorithm string from the key type and `SigningHashAlgorithm.id()`
- Update `CloudFrontUtilities` to:
  - Dispatch to SHA-256 signing when configured
  - Append `&Hash-Algorithm=SHA256` query parameter to signed URLs
  - Include `CloudFront-Hash-Algorithm=SHA256` cookie for signed cookies
- Add `hashAlgorithmHeaderValue()` default method to `SignedCookie` interface
- Add hash algorithm header support to `CookiesForCannedPolicy` and `CookiesForCustomPolicy` builders and implementations


## Testing

<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added unit and integ tests

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [[CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md)](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [[LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License

<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->

- [x] I confirm that this pull request can be released under the Apache 2 license