### PR TITLE
Upgrade httpclient5 to 5.6.3

### DIFF
--- a/.changes/next-release/feature-ApacheHTTPClient5-6432bbc.json
+++ b/.changes/next-release/feature-ApacheHTTPClient5-6432bbc.json
@@ -1,0 +1,6 @@
+{
+    "type": "feature",
+    "category": "Apache HTTP Client 5",
+    "contributor": "",
+    "description": "Upgrade httpcomponents.client5 to 5.6.3 to address CVE-2026-64607"
+}

--- a/pom.xml
+++ b/pom.xml
@@ -189,7 +189,7 @@
         <jre.version>1.8</jre.version>
         <httpcomponents.httpclient.version>4.5.13</httpcomponents.httpclient.version>
         <httpcomponents.httpcore.version>4.4.16</httpcomponents.httpcore.version>
-        <httpcomponents.client5.version>5.6.2</httpcomponents.client5.version>
+        <httpcomponents.client5.version>5.6.3</httpcomponents.client5.version>
         <httpcomponents.core5.version>5.4.3</httpcomponents.core5.version>
         <!-- Reactive Streams version -->
         <reactive-streams.version>1.0.4</reactive-streams.version>


### PR DESCRIPTION
## Motivation and Context
   Upgrade `httpcomponents.client5` from 5.6.2 to 5.6.3 to address CVE-2026-64607 — connection release failure in the classic i/o model when encountering an invalid or unsupported Content-Encoding header value.

   The SDK's `apache5-client` uses the classic i/o model and is affected.

   - CVE: https://www.cve.org/CVERecord?id=CVE-2026-64607
   - NVD: https://nvd.nist.gov/vuln/detail/CVE-2026-64607
   - GHSA: https://github.com/advisories/GHSA-hjcp-jmpx-g3qm
   - Release notes: https://downloads.apache.org/httpcomponents/httpclient/RELEASE_NOTES-5.6.x.txt

   httpclient5 5.6.3 depends on httpcore5 5.4.3 (same as current SDK version) — no other version changes needed.

   ## Testing
   Relying on PR build for unit tests