### PR TITLE
fix(SdkWarmUp) Use anonymous credentials for generated CRaC warm-up clients

### DIFF
--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/warmup/WarmUpOperationSelector.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/warmup/WarmUpOperationSelector.java
@@ -84,9 +84,10 @@ public final class WarmUpOperationSelector {
     }
 
     /**
-     * Preference order: returns output (so the unmarshaller is primed too), is authenticated (so signing is primed
-     * too; {@code noAuth} operations skip signing entirely), verified simple method, accepts an empty request,
-     * fewest required input members, read-only verb, then operation name as the deterministic tie-break.
+     * Preference order: returns output (so the unmarshaller is primed too), is authenticated (so auth-scheme
+     * resolution and the signer are primed too; {@code noAuth} operations resolve to a no-op signer instead), verified
+     * simple method, accepts an empty request, fewest required input members, read-only verb, then operation name as
+     * the deterministic tie-break.
      */
     private static Comparator<OperationModel> warmUpPreference(List<String> verifiedSimpleMethods) {
         return BY_HAS_OUTPUT_FIRST

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/warmup/WarmUpProviderSpec.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/warmup/WarmUpProviderSpec.java
@@ -41,21 +41,19 @@ import software.amazon.awssdk.core.warmup.SdkWarmUpProvider;
  *
  * <p>The {@code warmUpClient(ClientType)} body instantiates and closes a synthetic sync client (when the service
  * generates one) and a synthetic async client, each guarded by the requested {@link ClientType} and wired to an
- * in-memory canned HTTP client, dummy credentials, a fixed region and a local {@code endpointOverride}. Building the
- * clients JIT-compiles the client construction and configuration-resolution path before a CRaC checkpoint. Each client
- * also invokes the operation chosen by {@link WarmUpOperationSelector}, if any, to prime the marshalling, signing and
- * unmarshalling paths. The {@code syncClientClassName()}/{@code asyncClientClassName()} strings let
- * {@code SdkWarmUp.prime(Class...)} match a requested client class to this provider.
+ * in-memory canned HTTP client, anonymous credentials, a fixed region and a local {@code endpointOverride}. Building
+ * the clients JIT-compiles the client construction and configuration-resolution path before a CRaC checkpoint. Each
+ * client also invokes the operation chosen by {@link WarmUpOperationSelector}, if any, to prime the marshalling,
+ * auth-scheme resolution and unmarshalling paths. The {@code syncClientClassName()}/{@code asyncClientClassName()}
+ * strings let {@code SdkWarmUp.warmUp(Class...)} match a requested client class to this provider.
  */
 public class WarmUpProviderSpec implements ClassSpec {
 
     private static final String CANNED_RESPONSE_FIELD = "CANNED_RESPONSE";
 
-    // Values emitted into the warm-up call. Dummy credentials and a local endpoint keep the call offline; a 200 status
-    // exercises the success path.
+    // Values emitted into the warm-up call. Anonymous credentials and a local endpoint keep the call offline; a 200
+    // status exercises the success path.
     private static final int SUCCESS_STATUS_CODE = 200;
-    private static final String DUMMY_ACCESS_KEY_ID = "akid";
-    private static final String DUMMY_SECRET_ACCESS_KEY = "skid";
     private static final String DUMMY_TOKEN = "warmup-dummy-token";
     private static final String LOCAL_ENDPOINT = "http://localhost";
 
@@ -69,10 +67,8 @@ public class WarmUpProviderSpec implements ClassSpec {
         ClassName.get("software.amazon.awssdk.http", "SdkHttpClient");
     private static final ClassName SDK_ASYNC_HTTP_CLIENT =
         ClassName.get("software.amazon.awssdk.http.async", "SdkAsyncHttpClient");
-    private static final ClassName STATIC_CREDENTIALS_PROVIDER =
-        ClassName.get("software.amazon.awssdk.auth.credentials", "StaticCredentialsProvider");
-    private static final ClassName AWS_BASIC_CREDENTIALS =
-        ClassName.get("software.amazon.awssdk.auth.credentials", "AwsBasicCredentials");
+    private static final ClassName ANONYMOUS_CREDENTIALS_PROVIDER =
+        ClassName.get("software.amazon.awssdk.auth.credentials", "AnonymousCredentialsProvider");
     private static final ClassName STATIC_TOKEN_PROVIDER =
         ClassName.get("software.amazon.awssdk.auth.token.credentials", "StaticTokenProvider");
     private static final ClassName REGION =
@@ -178,15 +174,14 @@ public class WarmUpProviderSpec implements ClassSpec {
     }
 
     /**
-     * Builds the warm-up client: canned HTTP client, dummy credentials, local endpoint, plus any service-specific
+     * Builds the warm-up client: canned HTTP client, anonymous credentials, local endpoint, plus any service-specific
      * options from {@link #addServiceSpecificOptions}.
      */
     private CodeBlock clientBuilder(ClassName clientType, String clientVar, String httpClientVar) {
         CodeBlock.Builder builder = CodeBlock.builder()
             .add("$1T $2N = $1T.builder()\n", clientType, clientVar)
             .add(".httpClient($N)\n", httpClientVar)
-            .add(".credentialsProvider($T.create($T.create($S, $S)))\n",
-                 STATIC_CREDENTIALS_PROVIDER, AWS_BASIC_CREDENTIALS, DUMMY_ACCESS_KEY_ID, DUMMY_SECRET_ACCESS_KEY);
+            .add(".credentialsProvider($T.create())\n", ANONYMOUS_CREDENTIALS_PROVIDER);
         addServiceSpecificOptions(builder);
         return builder.add(".region($T.US_EAST_1)\n", REGION)
                       .add(".endpointOverride($T.create($S))\n", URI.class, LOCAL_ENDPOINT)

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/warmup/warmup-provider-async-only.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/warmup/warmup-provider-async-only.java
@@ -4,8 +4,7 @@ import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.annotations.SdkInternalApi;
-import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
-import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
 import software.amazon.awssdk.auth.token.credentials.StaticTokenProvider;
 import software.amazon.awssdk.core.ClientType;
 import software.amazon.awssdk.core.warmup.SdkWarmUpProvider;
@@ -36,7 +35,7 @@ public final class QueryWarmUpProvider implements SdkWarmUpProvider {
             SdkAsyncHttpClient asyncHttpClient = CannedResponseAsyncHttpClient.builder().responseBody(CANNED_RESPONSE)
                     .statusCode(200).build();
             try (QueryAsyncClient asyncClient = QueryAsyncClient.builder().httpClient(asyncHttpClient)
-                    .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("akid", "skid")))
+                    .credentialsProvider(AnonymousCredentialsProvider.create())
                     .tokenProvider(StaticTokenProvider.create(() -> "warmup-dummy-token"))
                     .region(Region.US_EAST_1).endpointOverride(URI.create("http://localhost")).build()) {
                 asyncClient.getOperationWithChecksum(GetOperationWithChecksumRequest.builder().build()).join();

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/warmup/warmup-provider-bearer-auth.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/warmup/warmup-provider-bearer-auth.java
@@ -4,8 +4,7 @@ import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.annotations.SdkInternalApi;
-import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
-import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
 import software.amazon.awssdk.auth.token.credentials.StaticTokenProvider;
 import software.amazon.awssdk.core.ClientType;
 import software.amazon.awssdk.core.warmup.SdkWarmUpProvider;
@@ -39,7 +38,7 @@ public final class JsonWarmUpProvider implements SdkWarmUpProvider {
       SdkHttpClient httpClient = CannedResponseHttpClient.builder().responseBody(CANNED_RESPONSE).statusCode(200).build();
       try (JsonClient client = JsonClient.builder()
       .httpClient(httpClient)
-      .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("akid", "skid")))
+      .credentialsProvider(AnonymousCredentialsProvider.create())
       .tokenProvider(StaticTokenProvider.create(() -> "warmup-dummy-token"))
       .region(Region.US_EAST_1)
       .endpointOverride(URI.create("http://localhost"))
@@ -51,7 +50,7 @@ public final class JsonWarmUpProvider implements SdkWarmUpProvider {
       SdkAsyncHttpClient asyncHttpClient = CannedResponseAsyncHttpClient.builder().responseBody(CANNED_RESPONSE).statusCode(200).build();
       try (JsonAsyncClient asyncClient = JsonAsyncClient.builder()
       .httpClient(asyncHttpClient)
-      .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("akid", "skid")))
+      .credentialsProvider(AnonymousCredentialsProvider.create())
       .tokenProvider(StaticTokenProvider.create(() -> "warmup-dummy-token"))
       .region(Region.US_EAST_1)
       .endpointOverride(URI.create("http://localhost"))

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/warmup/warmup-provider-cbor.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/warmup/warmup-provider-cbor.java
@@ -3,8 +3,7 @@ package software.amazon.awssdk.services.json.internal.warmup;
 import java.net.URI;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.annotations.SdkInternalApi;
-import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
-import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
 import software.amazon.awssdk.core.ClientType;
 import software.amazon.awssdk.core.warmup.SdkWarmUpProvider;
 import software.amazon.awssdk.core.warmup.http.CannedResponseAsyncHttpClient;
@@ -35,7 +34,7 @@ public final class JsonWarmUpProvider implements SdkWarmUpProvider {
         if (clientType == ClientType.SYNC) {
             SdkHttpClient httpClient = CannedResponseHttpClient.builder().responseBody(CANNED_RESPONSE).statusCode(200).build();
             try (JsonClient client = JsonClient.builder().httpClient(httpClient)
-                    .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("akid", "skid")))
+                    .credentialsProvider(AnonymousCredentialsProvider.create())
                     .region(Region.US_EAST_1).endpointOverride(URI.create("http://localhost")).build()) {
                 client.paginatedOperationWithResultKey();
             }
@@ -44,7 +43,7 @@ public final class JsonWarmUpProvider implements SdkWarmUpProvider {
             SdkAsyncHttpClient asyncHttpClient = CannedResponseAsyncHttpClient.builder().responseBody(CANNED_RESPONSE)
                     .statusCode(200).build();
             try (JsonAsyncClient asyncClient = JsonAsyncClient.builder().httpClient(asyncHttpClient)
-                    .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("akid", "skid")))
+                    .credentialsProvider(AnonymousCredentialsProvider.create())
                     .region(Region.US_EAST_1).endpointOverride(URI.create("http://localhost")).build()) {
                 asyncClient.paginatedOperationWithResultKey().join();
             }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/warmup/warmup-provider-endpoint-discovery.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/warmup/warmup-provider-endpoint-discovery.java
@@ -4,8 +4,7 @@ import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.annotations.SdkInternalApi;
-import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
-import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
 import software.amazon.awssdk.core.ClientType;
 import software.amazon.awssdk.core.warmup.SdkWarmUpProvider;
 import software.amazon.awssdk.core.warmup.http.CannedResponseAsyncHttpClient;
@@ -38,7 +37,7 @@ public final class EndpointDiscoveryTestWarmUpProvider implements SdkWarmUpProvi
       SdkHttpClient httpClient = CannedResponseHttpClient.builder().responseBody(CANNED_RESPONSE).statusCode(200).build();
       try (EndpointDiscoveryTestClient client = EndpointDiscoveryTestClient.builder()
       .httpClient(httpClient)
-      .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("akid", "skid")))
+      .credentialsProvider(AnonymousCredentialsProvider.create())
       .endpointDiscoveryEnabled(false)
       .region(Region.US_EAST_1)
       .endpointOverride(URI.create("http://localhost"))
@@ -50,7 +49,7 @@ public final class EndpointDiscoveryTestWarmUpProvider implements SdkWarmUpProvi
       SdkAsyncHttpClient asyncHttpClient = CannedResponseAsyncHttpClient.builder().responseBody(CANNED_RESPONSE).statusCode(200).build();
       try (EndpointDiscoveryTestAsyncClient asyncClient = EndpointDiscoveryTestAsyncClient.builder()
       .httpClient(asyncHttpClient)
-      .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("akid", "skid")))
+      .credentialsProvider(AnonymousCredentialsProvider.create())
       .endpointDiscoveryEnabled(false)
       .region(Region.US_EAST_1)
       .endpointOverride(URI.create("http://localhost"))

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/warmup/warmup-provider-query.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/warmup/warmup-provider-query.java
@@ -4,8 +4,7 @@ import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.annotations.SdkInternalApi;
-import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
-import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
 import software.amazon.awssdk.auth.token.credentials.StaticTokenProvider;
 import software.amazon.awssdk.core.ClientType;
 import software.amazon.awssdk.core.warmup.SdkWarmUpProvider;
@@ -38,7 +37,7 @@ public final class QueryWarmUpProvider implements SdkWarmUpProvider {
         if (clientType == ClientType.SYNC) {
             SdkHttpClient httpClient = CannedResponseHttpClient.builder().responseBody(CANNED_RESPONSE).statusCode(200).build();
             try (QueryClient client = QueryClient.builder().httpClient(httpClient)
-                    .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("akid", "skid")))
+                    .credentialsProvider(AnonymousCredentialsProvider.create())
                     .tokenProvider(StaticTokenProvider.create(() -> "warmup-dummy-token"))
                     .region(Region.US_EAST_1).endpointOverride(URI.create("http://localhost")).build()) {
                 client.getOperationWithChecksum(GetOperationWithChecksumRequest.builder().build());
@@ -48,7 +47,7 @@ public final class QueryWarmUpProvider implements SdkWarmUpProvider {
             SdkAsyncHttpClient asyncHttpClient = CannedResponseAsyncHttpClient.builder().responseBody(CANNED_RESPONSE)
                     .statusCode(200).build();
             try (QueryAsyncClient asyncClient = QueryAsyncClient.builder().httpClient(asyncHttpClient)
-                    .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("akid", "skid")))
+                    .credentialsProvider(AnonymousCredentialsProvider.create())
                     .tokenProvider(StaticTokenProvider.create(() -> "warmup-dummy-token"))
                     .region(Region.US_EAST_1).endpointOverride(URI.create("http://localhost")).build()) {
                 asyncClient.getOperationWithChecksum(GetOperationWithChecksumRequest.builder().build()).join();

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/warmup/warmup-provider-rest-json.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/warmup/warmup-provider-rest-json.java
@@ -4,8 +4,7 @@ import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.annotations.SdkInternalApi;
-import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
-import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
 import software.amazon.awssdk.auth.token.credentials.StaticTokenProvider;
 import software.amazon.awssdk.core.ClientType;
 import software.amazon.awssdk.core.warmup.SdkWarmUpProvider;
@@ -37,7 +36,7 @@ public final class JsonWarmUpProvider implements SdkWarmUpProvider {
         if (clientType == ClientType.SYNC) {
             SdkHttpClient httpClient = CannedResponseHttpClient.builder().responseBody(CANNED_RESPONSE).statusCode(200).build();
             try (JsonClient client = JsonClient.builder().httpClient(httpClient)
-                    .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("akid", "skid")))
+                    .credentialsProvider(AnonymousCredentialsProvider.create())
                     .tokenProvider(StaticTokenProvider.create(() -> "warmup-dummy-token"))
                     .region(Region.US_EAST_1).endpointOverride(URI.create("http://localhost")).build()) {
                 client.paginatedOperationWithResultKey();
@@ -47,7 +46,7 @@ public final class JsonWarmUpProvider implements SdkWarmUpProvider {
             SdkAsyncHttpClient asyncHttpClient = CannedResponseAsyncHttpClient.builder().responseBody(CANNED_RESPONSE)
                     .statusCode(200).build();
             try (JsonAsyncClient asyncClient = JsonAsyncClient.builder().httpClient(asyncHttpClient)
-                    .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("akid", "skid")))
+                    .credentialsProvider(AnonymousCredentialsProvider.create())
                     .tokenProvider(StaticTokenProvider.create(() -> "warmup-dummy-token"))
                     .region(Region.US_EAST_1).endpointOverride(URI.create("http://localhost")).build()) {
                 asyncClient.paginatedOperationWithResultKey().join();

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/warmup/warmup-provider-rpcv2.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/warmup/warmup-provider-rpcv2.java
@@ -3,8 +3,7 @@ package software.amazon.awssdk.services.smithyrpcv2protocol.internal.warmup;
 import java.net.URI;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.annotations.SdkInternalApi;
-import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
-import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
 import software.amazon.awssdk.core.ClientType;
 import software.amazon.awssdk.core.warmup.SdkWarmUpProvider;
 import software.amazon.awssdk.core.warmup.http.CannedResponseAsyncHttpClient;
@@ -36,7 +35,7 @@ public final class SmithyRpcV2ProtocolWarmUpProvider implements SdkWarmUpProvide
         if (clientType == ClientType.SYNC) {
             SdkHttpClient httpClient = CannedResponseHttpClient.builder().responseBody(CANNED_RESPONSE).statusCode(200).build();
             try (SmithyRpcV2ProtocolClient client = SmithyRpcV2ProtocolClient.builder().httpClient(httpClient)
-                    .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("akid", "skid")))
+                    .credentialsProvider(AnonymousCredentialsProvider.create())
                     .region(Region.US_EAST_1).endpointOverride(URI.create("http://localhost")).build()) {
                 client.emptyInputOutput(EmptyInputOutputRequest.builder().build());
             }
@@ -46,7 +45,7 @@ public final class SmithyRpcV2ProtocolWarmUpProvider implements SdkWarmUpProvide
                     .statusCode(200).build();
             try (SmithyRpcV2ProtocolAsyncClient asyncClient = SmithyRpcV2ProtocolAsyncClient.builder()
                     .httpClient(asyncHttpClient)
-                    .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("akid", "skid")))
+                    .credentialsProvider(AnonymousCredentialsProvider.create())
                     .region(Region.US_EAST_1).endpointOverride(URI.create("http://localhost")).build()) {
                 asyncClient.emptyInputOutput(EmptyInputOutputRequest.builder().build()).join();
             }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/warmup/warmup-provider-s3control.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/warmup/warmup-provider-s3control.java
@@ -4,8 +4,7 @@ import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.annotations.SdkInternalApi;
-import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
-import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
 import software.amazon.awssdk.core.ClientType;
 import software.amazon.awssdk.core.warmup.SdkWarmUpProvider;
 import software.amazon.awssdk.core.warmup.http.CannedResponseAsyncHttpClient;
@@ -38,7 +37,7 @@ public final class S3ControlWarmUpProvider implements SdkWarmUpProvider {
       SdkHttpClient httpClient = CannedResponseHttpClient.builder().responseBody(CANNED_RESPONSE).statusCode(200).build();
       try (S3ControlClient client = S3ControlClient.builder()
       .httpClient(httpClient)
-      .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("akid", "skid")))
+      .credentialsProvider(AnonymousCredentialsProvider.create())
       .region(Region.US_EAST_1)
       .endpointOverride(URI.create("http://localhost"))
       .build()) {
@@ -49,7 +48,7 @@ public final class S3ControlWarmUpProvider implements SdkWarmUpProvider {
       SdkAsyncHttpClient asyncHttpClient = CannedResponseAsyncHttpClient.builder().responseBody(CANNED_RESPONSE).statusCode(200).build();
       try (S3ControlAsyncClient asyncClient = S3ControlAsyncClient.builder()
       .httpClient(asyncHttpClient)
-      .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("akid", "skid")))
+      .credentialsProvider(AnonymousCredentialsProvider.create())
       .region(Region.US_EAST_1)
       .endpointOverride(URI.create("http://localhost"))
       .build()) {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/warmup/warmup-provider-xml.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/warmup/warmup-provider-xml.java
@@ -4,8 +4,7 @@ import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.annotations.SdkInternalApi;
-import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
-import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
 import software.amazon.awssdk.auth.token.credentials.StaticTokenProvider;
 import software.amazon.awssdk.core.ClientType;
 import software.amazon.awssdk.core.warmup.SdkWarmUpProvider;
@@ -38,7 +37,7 @@ public final class XmlWarmUpProvider implements SdkWarmUpProvider {
         if (clientType == ClientType.SYNC) {
             SdkHttpClient httpClient = CannedResponseHttpClient.builder().responseBody(CANNED_RESPONSE).statusCode(200).build();
             try (XmlClient client = XmlClient.builder().httpClient(httpClient)
-                    .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("akid", "skid")))
+                    .credentialsProvider(AnonymousCredentialsProvider.create())
                     .tokenProvider(StaticTokenProvider.create(() -> "warmup-dummy-token"))
                     .region(Region.US_EAST_1).endpointOverride(URI.create("http://localhost")).build()) {
                 client.getOperationWithChecksum(GetOperationWithChecksumRequest.builder().build());
@@ -48,7 +47,7 @@ public final class XmlWarmUpProvider implements SdkWarmUpProvider {
             SdkAsyncHttpClient asyncHttpClient = CannedResponseAsyncHttpClient.builder().responseBody(CANNED_RESPONSE)
                     .statusCode(200).build();
             try (XmlAsyncClient asyncClient = XmlAsyncClient.builder().httpClient(asyncHttpClient)
-                    .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("akid", "skid")))
+                    .credentialsProvider(AnonymousCredentialsProvider.create())
                     .tokenProvider(StaticTokenProvider.create(() -> "warmup-dummy-token"))
                     .region(Region.US_EAST_1).endpointOverride(URI.create("http://localhost")).build()) {
                 asyncClient.getOperationWithChecksum(GetOperationWithChecksumRequest.builder().build()).join();

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/warmup/PrimedClientRegistry.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/warmup/PrimedClientRegistry.java
@@ -23,7 +23,7 @@ import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.annotations.ThreadSafe;
 
 /**
- * Tracks which service clients {@code SdkWarmUp.prime(Class...)} has already warmed, so each is warmed at most once per
+ * Tracks which service clients {@code SdkWarmUp.warmUp(Class...)} has already warmed, so each is warmed at most once per
  * JVM. State is per-instance, so it is unit-testable with fresh instances; production uses a single long-lived instance.
  */
 @ThreadSafe

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/warmup/TargetedWarmUpInvoker.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/warmup/TargetedWarmUpInvoker.java
@@ -28,7 +28,7 @@ import software.amazon.awssdk.core.warmup.SdkWarmUpProvider;
 import software.amazon.awssdk.utils.Logger;
 
 /**
- * Warms only the service clients named by {@code SdkWarmUp.prime(Class...)}. Matches each requested client class name
+ * Warms only the service clients named by {@code SdkWarmUp.warmUp(Class...)}. Matches each requested client class name
  * against the discovered {@link SdkWarmUpProvider}s' sync and async class names, then warms the matched client type only.
  */
 @SdkInternalApi

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/warmup/WarmUpInvoker.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/warmup/WarmUpInvoker.java
@@ -19,7 +19,7 @@ import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.core.warmup.SdkWarmUpProvider;
 
 /**
- * Discovers {@link SdkWarmUpProvider}s and invokes their warm-up behind the public {@code SdkWarmUp.prime()}.
+ * Discovers {@link SdkWarmUpProvider}s and invokes their warm-up behind the public {@code SdkWarmUp.warmUp()}.
  * Mirrors the {@code SdkHttpServiceProvider} loader abstraction, except warm-up invokes every discovered
  * provider rather than selecting one.
  */

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/warmup/WarmedHttpClientTypeRegistry.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/warmup/WarmedHttpClientTypeRegistry.java
@@ -20,7 +20,7 @@ import software.amazon.awssdk.annotations.ThreadSafe;
 import software.amazon.awssdk.core.ClientType;
 
 /**
- * Tracks whether each HTTP client type has been warmed, so {@code SdkWarmUp.prime(Class...)} warms each at most once
+ * Tracks whether each HTTP client type has been warmed, so {@code SdkWarmUp.warmUp(Class...)} warms each at most once
  * per JVM. Only {@link ClientType#SYNC} and {@link ClientType#ASYNC} are tracked.
  */
 @ThreadSafe

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/warmup/SdkWarmUp.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/warmup/SdkWarmUp.java
@@ -42,12 +42,12 @@ import software.amazon.awssdk.utils.Logger;
  *
  * <p>Behavior contract:
  * <ul>
- *     <li><b>Idempotent:</b> {@code prime()} runs the warm-up at most once per JVM. Once a call completes
+ *     <li><b>Idempotent:</b> {@code warmUp()} runs the warm-up at most once per JVM. Once a call completes
  *     successfully, later calls return immediately. If a call throws before completing, a later call retries.
  *     Concurrent callers block until the in-flight call finishes, then observe its result.</li>
  *     <li><b>Per-provider resilience:</b> a single provider that throws from {@code warmUp()}, or that fails
  *     to load, does not prevent the remaining providers from running.</li>
- *     <li><b>Safe when empty:</b> if no providers are registered, {@code prime()} is a no-op.</li>
+ *     <li><b>Safe when empty:</b> if no providers are registered, {@code warmUp()} is a no-op.</li>
  * </ul>
  *
  * <p>Call this once during application initialization, before a CRaC checkpoint is taken.
@@ -109,7 +109,7 @@ public final class SdkWarmUp {
     @SafeVarargs
     public static void warmUp(Class<? extends SdkClient>... clients) {
         if (clients == null || clients.length == 0) {
-            log.debug(() -> "SdkWarmUp.prime(Class...) called with no clients; nothing to do.");
+            log.debug(() -> "SdkWarmUp.warmUp(Class...) called with no clients; nothing to do.");
             return;
         }
 


### PR DESCRIPTION

## Motivation and Context

The generated warm-up providers used `AwsBasicCredentials` with placeholder values:

```java
.credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("akid", "skid")))
```

These are not real credentials and the warm-up request never leaves the process. Some scanning tools report the string literal as a hardcoded credential. Codegen emits a provider for every service, so the report repeats for every client.

`AnonymousCredentialsProvider` needs no literal.


## Modifications

`WarmUpProviderSpec` emits `AnonymousCredentialsProvider.create()` instead of `StaticCredentialsProvider.create(AwsBasicCredentials.create(...))`, and the unused `DUMMY_ACCESS_KEY_ID`, `DUMMY_SECRET_ACCESS_KEY` and `ClassName` constants are removed. The nine warm-up golden files are updated to match.

Javadoc on `WarmUpProviderSpec` and `WarmUpOperationSelector` said warm-up primes signing. It now says auth-scheme resolution. The operation preference order is unchanged.

Javadoc in five `sdk-core` warm-up classes and one debug log message referenced `SdkWarmUp.prime()`, which was renamed to `warmUp()`. Fixed.

Bearer auth is unchanged. Those services still pass a placeholder token through `StaticTokenProvider`.


## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

There is no performance impact. Anonymous credentials do not remove the signer from the warm-up path. `DefaultAwsV4HttpSigner` is still loaded and invoked, and returns before it computes a signature.

Both builds were measured two ways.

The existing warm-up benchmarks in the `test/sdk-benchmarks` module, `software.amazon.awssdk.benchmark.coldstart.V2SdkWarmUpExecutionTimeBenchmark` and `V2WarmedUpFirstRequestBenchmark`, ran 3 repetitions per build at 20 forks each. `primeSingleService` calls `SdkWarmUp.warmUp(DynamoDbClient.class)`. `firstRequest` calls `warmUp` in an untimed setup and then times the first `PutItem` against a mock HTTP server.

A Java 17 Lambda function at 1024 MB built a DynamoDB client and an S3 client during initialization, then called `PutItem` on a real table and `ListObjectsV2` on a real bucket. It ran 20 cold starts per build, each forced by changing an environment variable so Lambda created a new execution environment.

Both columns run warm-up. The credentials are the only difference.

### Lambda, real DynamoDB `PutItem` and S3 `ListObjectsV2`, 20 cold starts per build, p50

| Metric | Basic (ms) | Anonymous (ms) | Difference (ms) |
|---|---|---|---|
| `warmUp()` | 5354.3 | 5341.9 | -12.4 |
| Init Duration | 5696.3 | 5689.4 | -6.9 |
| Invocation Duration | 386.8 | 392.9 | +6.1 |
| DynamoDB `PutItem` | 239.7 | 245.5 | +5.8 |
| S3 `ListObjectsV2` | 135.1 | 139.1 | +4.0 |
| Billed Duration | 6099.5 | 6081.0 | -18.5 |

### JMH from `test/sdk-benchmarks`, median of 3 repetitions per build, 20 forks each

| Benchmark | Basic (ms) | Anonymous (ms) | Difference (ms) |
|---|---|---|---|
| `V2SdkWarmUpExecutionTimeBenchmark.primeSingleService` | 1703.18 | 1699.38 | -3.80 |
| `V2WarmedUpFirstRequestBenchmark.firstRequest` | 96.08 | 88.84 | -7.24 |

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)


## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
