### PR TITLE
Support ProxyAuthScheme

### DIFF
--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/ProxyConfiguration.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/ProxyConfiguration.java
@@ -41,6 +41,7 @@ public final class ProxyConfiguration implements ToCopyableBuilder<ProxyConfigur
     private final int port;
     private final String username;
     private final String password;
+    private final ProxyAuthScheme proxyAuthScheme;
     private final Set<String> nonProxyHosts;
 
     private ProxyConfiguration(BuilderImpl builder) {
@@ -56,6 +57,7 @@ public final class ProxyConfiguration implements ToCopyableBuilder<ProxyConfigur
         this.port = resolvePort(builder, proxyConfigProvider);
         this.username = resolveUserName(builder, proxyConfigProvider);
         this.password = resolvePassword(builder, proxyConfigProvider);
+        this.proxyAuthScheme = builder.proxyAuthScheme;
         this.nonProxyHosts = resolveNonProxyHosts(builder, proxyConfigProvider);
     }
 
@@ -151,6 +153,13 @@ public final class ProxyConfiguration implements ToCopyableBuilder<ProxyConfigur
         return Collections.unmodifiableSet(nonProxyHosts != null ? nonProxyHosts : Collections.emptySet());
     }
 
+    /**
+     * @return The auth scheme to use to authenticate with the proxy.
+     */
+    public ProxyAuthScheme proxyAuthScheme() {
+        return proxyAuthScheme;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -183,6 +192,10 @@ public final class ProxyConfiguration implements ToCopyableBuilder<ProxyConfigur
             return false;
         }
 
+        if (proxyAuthScheme != null ? !proxyAuthScheme.equals(that.proxyAuthScheme) : that.proxyAuthScheme != null) {
+            return false;
+        }
+
         return nonProxyHosts.equals(that.nonProxyHosts);
 
     }
@@ -195,6 +208,7 @@ public final class ProxyConfiguration implements ToCopyableBuilder<ProxyConfigur
         result = 31 * result + nonProxyHosts.hashCode();
         result = 31 * result + (username != null ? username.hashCode() : 0);
         result = 31 * result + (password != null ? password.hashCode() : 0);
+        result = 31 * result + (proxyAuthScheme != null ? proxyAuthScheme.hashCode() : 0);
         return result;
     }
 
@@ -242,6 +256,17 @@ public final class ProxyConfiguration implements ToCopyableBuilder<ProxyConfigur
          * @return This object for method chaining.
          */
         Builder nonProxyHosts(Set<String> nonProxyHosts);
+
+        /**
+         * Configure the auth scheme to use to authenticate with the proxy.
+         * <p>
+         * If unset and {@link #username(String)} and {@link #password(String)} are set, the client will
+         * assume {@link ProxyAuthScheme#BASIC} auth.
+         *
+         * @param proxyAuthScheme The auth scheme.
+         * @return This object for method chaining.
+         */
+        Builder proxyAuthScheme(ProxyAuthScheme proxyAuthScheme);
 
         /**
          * Set the username used to authenticate with the proxy username.
@@ -293,6 +318,7 @@ public final class ProxyConfiguration implements ToCopyableBuilder<ProxyConfigur
         private String scheme = "http";
         private String host;
         private int port = 0;
+        private ProxyAuthScheme proxyAuthScheme;
         private String username;
         private String password;
         private Set<String> nonProxyHosts;
@@ -310,6 +336,7 @@ public final class ProxyConfiguration implements ToCopyableBuilder<ProxyConfigur
             this.port = proxyConfiguration.port;
             this.nonProxyHosts = proxyConfiguration.nonProxyHosts != null ?
                                  new HashSet<>(proxyConfiguration.nonProxyHosts) : null;
+            this.proxyAuthScheme = proxyConfiguration.proxyAuthScheme;
             this.username = proxyConfiguration.username;
             this.password = proxyConfiguration.password;
         }
@@ -339,6 +366,12 @@ public final class ProxyConfiguration implements ToCopyableBuilder<ProxyConfigur
             } else {
                 this.nonProxyHosts = Collections.emptySet();
             }
+            return this;
+        }
+
+        @Override
+        public Builder proxyAuthScheme(ProxyAuthScheme proxyAuthScheme) {
+            this.proxyAuthScheme = proxyAuthScheme;
             return this;
         }
 

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/AwaitCloseChannelPoolMap.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/AwaitCloseChannelPoolMap.java
@@ -36,10 +36,12 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
+import javax.security.auth.login.Configuration;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.annotations.SdkTestInternalApi;
 import software.amazon.awssdk.http.Protocol;
 import software.amazon.awssdk.http.ProtocolNegotiation;
+import software.amazon.awssdk.http.nio.netty.ProxyAuthScheme;
 import software.amazon.awssdk.http.nio.netty.ProxyConfiguration;
 import software.amazon.awssdk.http.nio.netty.SdkEventLoopGroup;
 import software.amazon.awssdk.http.nio.netty.internal.http2.HttpOrHttp2ChannelPool;
@@ -88,6 +90,8 @@ public final class AwaitCloseChannelPoolMap extends SdkChannelPoolMap<URI, Simpl
     private final SslContextProvider sslContextProvider;
     private final Boolean useNonBlockingDnsResolver;
 
+    private final Configuration negotiateAuthConfig;
+
     private AwaitCloseChannelPoolMap(Builder builder, Function<Builder, BootstrapProvider> createBootStrapProvider) {
         this.configuration = builder.configuration;
         this.protocol = builder.protocol;
@@ -100,6 +104,7 @@ public final class AwaitCloseChannelPoolMap extends SdkChannelPoolMap<URI, Simpl
         this.bootstrapProvider = createBootStrapProvider.apply(builder);
         this.sslContextProvider = new SslContextProvider(configuration, protocol, protocolNegotiation, sslProvider);
         this.useNonBlockingDnsResolver = builder.useNonBlockingDnsResolver;
+        this.negotiateAuthConfig = builder.negotiateAuthConfig;
     }
 
     private AwaitCloseChannelPoolMap(Builder builder) {
@@ -158,6 +163,26 @@ public final class AwaitCloseChannelPoolMap extends SdkChannelPoolMap<URI, Simpl
     }
 
     private ProxyAuthGenerator resolveProxyAuthGenerator(ProxyConfiguration proxyConfiguration) {
+        ProxyAuthScheme proxyAuthScheme = proxyConfiguration.proxyAuthScheme();
+
+        if (proxyAuthScheme != null) {
+            switch (proxyAuthScheme) {
+                case NEGOTIATE:
+                    return new NegotiateProxyAuthGenerator(negotiateAuthConfig);
+                case BASIC: {
+                    String username = proxyConfiguration.username();
+                    String password = proxyConfiguration.password();
+                    if (!StringUtils.isEmpty(username) && !StringUtils.isEmpty(password)) {
+                        return new BasicProxyAuthGenerator(username, password);
+                    }
+                    throw new IllegalArgumentException("username and password must be configured when using BASIC proxy auth");
+                }
+                default:
+                    throw new RuntimeException("Unknown proxy auth scheme: " + proxyAuthScheme);
+            }
+        }
+
+        // for back-compat, BASIC if scheme not configured but username password are set
         String username = proxyConfiguration.username();
         String password = proxyConfiguration.password();
         if (!StringUtils.isEmpty(username) && !StringUtils.isEmpty(password)) {
@@ -304,6 +329,9 @@ public final class AwaitCloseChannelPoolMap extends SdkChannelPoolMap<URI, Simpl
         private ProxyConfiguration proxyConfiguration;
         private Boolean useNonBlockingDnsResolver;
 
+        // testing only
+        private Configuration negotiateAuthConfig;
+
         private Builder() {
         }
 
@@ -359,6 +387,12 @@ public final class AwaitCloseChannelPoolMap extends SdkChannelPoolMap<URI, Simpl
 
         public Builder useNonBlockingDnsResolver(Boolean useNonBlockingDnsResolver) {
             this.useNonBlockingDnsResolver = useNonBlockingDnsResolver;
+            return this;
+        }
+
+        @SdkTestInternalApi
+        public Builder negotiateAuthConfig(Configuration negotiateAuthConfig) {
+            this.negotiateAuthConfig = negotiateAuthConfig;
             return this;
         }
 

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/NegotiateProxyAuthGenerator.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/NegotiateProxyAuthGenerator.java
@@ -32,7 +32,6 @@ import org.ietf.jgss.GSSManager;
 import org.ietf.jgss.GSSName;
 import org.ietf.jgss.Oid;
 import software.amazon.awssdk.annotations.SdkInternalApi;
-import software.amazon.awssdk.annotations.SdkTestInternalApi;
 import software.amazon.awssdk.http.nio.netty.ProxyAuthScheme;
 import software.amazon.awssdk.utils.BinaryUtils;
 
@@ -52,9 +51,12 @@ public class NegotiateProxyAuthGenerator implements ProxyAuthGenerator {
         this(createDefaultConfig());
     }
 
-    @SdkTestInternalApi
-    NegotiateProxyAuthGenerator(Configuration config) {
-        this.config = config;
+    public NegotiateProxyAuthGenerator(Configuration config) {
+        if (config != null) {
+            this.config = config;
+        } else {
+            this.config = createDefaultConfig();
+        }
     }
 
     @Override
@@ -69,8 +71,12 @@ public class NegotiateProxyAuthGenerator implements ProxyAuthGenerator {
 
             byte[] token = Subject.doAs(subject, (PrivilegedExceptionAction<byte[]>) () -> {
                 GSSContext ctx = createGssContext(getManager(), proxyEndpoint);
-                ctx.requestMutualAuth(true);
-                return ctx.initSecContext(new byte[0], 0, 0);
+                try {
+                    ctx.requestMutualAuth(true);
+                    return ctx.initSecContext(new byte[0], 0, 0);
+                } finally {
+                    ctx.dispose();
+                }
             });
 
             return BinaryUtils.toBase64(token);

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/ProxyTunnelInitHandler.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/ProxyTunnelInitHandler.java
@@ -67,7 +67,7 @@ public final class ProxyTunnelInitHandler extends ChannelDuplexHandler {
         this.proxyAddress = proxyAddress;
         this.remoteHost = remoteHost;
         this.initPromise = initPromise;
-        if (!StringUtils.isBlank(proxyPassword) && !StringUtils.isBlank(proxyPassword)) {
+        if (!StringUtils.isBlank(proxyUsername) && !StringUtils.isBlank(proxyPassword)) {
             this.authGenerator = new BasicProxyAuthGenerator(proxyUsername, proxyPassword);
         } else {
             this.authGenerator = null;
@@ -94,7 +94,15 @@ public final class ProxyTunnelInitHandler extends ChannelDuplexHandler {
     public void handlerAdded(ChannelHandlerContext ctx) {
         ChannelPipeline pipeline = ctx.pipeline();
         pipeline.addBefore(ctx.name(), null, httpCodecSupplier.get());
-        HttpRequest connectRequest = connectRequest();
+
+        HttpRequest connectRequest;
+        try {
+            connectRequest = connectRequest();
+        } catch (Throwable t) {
+            handleConnectRequestFailure(ctx, t);
+            return;
+        }
+
         ctx.channel().writeAndFlush(connectRequest).addListener(f -> {
             if (!f.isSuccess()) {
                 handleConnectRequestFailure(ctx, f.cause());

--- a/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/ProxyConfigurationTest.java
+++ b/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/ProxyConfigurationTest.java
@@ -185,7 +185,11 @@ public class ProxyConfigurationTest {
             setter.invoke(o, randomSet());
         } else if (Boolean.class.equals(paramClass)) {
             setter.invoke(o, RNG.nextBoolean());
-        } else {
+        } else if (ProxyAuthScheme.class.equals(paramClass)) {
+            ProxyAuthScheme authScheme = ProxyAuthScheme.values()[RNG.nextInt(ProxyAuthScheme.values().length)];
+            setter.invoke(o, authScheme);
+        }
+        else {
             throw new RuntimeException("Don't know how create random value for type " + paramClass);
         }
     }

--- a/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/AwaitCloseChannelPoolMapTest.java
+++ b/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/AwaitCloseChannelPoolMapTest.java
@@ -23,45 +23,76 @@ import static org.mockito.Mockito.verify;
 import static software.amazon.awssdk.http.SdkHttpConfigurationOption.GLOBAL_HTTP_DEFAULTS;
 import static software.amazon.awssdk.http.SdkHttpConfigurationOption.TLS_KEY_MANAGERS_PROVIDER;
 
-import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.github.tomakehurst.wiremock.WireMockServer;
 import io.netty.channel.Channel;
 import io.netty.channel.pool.ChannelPool;
 import io.netty.handler.ssl.SslProvider;
-import io.netty.util.CharsetUtil;
 import io.netty.util.concurrent.Future;
+import java.net.InetSocketAddress;
+import java.net.Socket;
 import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import javax.security.auth.login.AppConfigurationEntry;
+import javax.security.auth.login.Configuration;
 import org.apache.commons.lang3.RandomStringUtils;
-import org.junit.After;
-import org.junit.Rule;
-import org.junit.Test;
+import org.apache.kerby.kerberos.kerb.client.KrbClient;
+import org.apache.kerby.kerberos.kerb.server.SimpleKdcServer;
+import org.apache.kerby.kerberos.kerb.type.ticket.TgtTicket;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
 import software.amazon.awssdk.http.Protocol;
 import software.amazon.awssdk.http.ProtocolNegotiation;
 import software.amazon.awssdk.http.TlsKeyManagersProvider;
+import software.amazon.awssdk.http.nio.netty.ProxyAuthScheme;
 import software.amazon.awssdk.http.nio.netty.ProxyConfiguration;
 import software.amazon.awssdk.http.nio.netty.RecordingNetworkTrafficListener;
 import software.amazon.awssdk.http.nio.netty.SdkEventLoopGroup;
 import software.amazon.awssdk.utils.AttributeMap;
 
 public class AwaitCloseChannelPoolMapTest {
+    private static final RecordingNetworkTrafficListener recorder = new RecordingNetworkTrafficListener();
 
-    private final RecordingNetworkTrafficListener recorder = new RecordingNetworkTrafficListener();
+    private static WireMockServer mockProxy;
+
+    private static Path tempDir;
+    private static Path keytabFile;
+    private static Path ccacheFile;
+    private static int port;
+
+    private static SimpleKdcServer kdc;
+
+    private static Configuration negotiateAuthConfig;
 
     private AwaitCloseChannelPoolMap channelPoolMap;
 
-    @Rule
-    public WireMockRule mockProxy = new WireMockRule(wireMockConfig()
-                                                         .dynamicPort()
-                                                         .networkTrafficListener(recorder));
+    @BeforeAll
+    public static void setup() throws Exception {
+        mockProxy = new WireMockServer(wireMockConfig().dynamicPort().networkTrafficListener(recorder));
+        mockProxy.start();
 
-    @After
+        setupMockKerberos();
+    }
+
+    @AfterAll
+    public static void teardown() throws Exception {
+        mockProxy.stop();
+        kdc.stop();
+    }
+
+    @AfterEach
     public void methodTeardown() {
         if (channelPoolMap != null) {
             channelPoolMap.close();
@@ -69,6 +100,50 @@ public class AwaitCloseChannelPoolMapTest {
         channelPoolMap = null;
 
         recorder.reset();
+    }
+
+    private static void setupMockKerberos() throws Exception {
+        tempDir = Files.createTempDirectory(null);
+        keytabFile = tempDir.resolve("keytab");
+        ccacheFile = tempDir.resolve("ccache");
+
+        try (Socket freePort = new Socket()) {
+            freePort.setReuseAddress(true);
+            freePort.bind(new InetSocketAddress(0));
+            port = freePort.getLocalPort();
+        }
+
+        kdc = new SimpleKdcServer();
+        kdc.setKdcRealm("EXAMPLE.COM");
+        kdc.setKdcHost("localhost");
+        kdc.setWorkDir(tempDir.toFile());
+        kdc.setKdcTcpPort(port);
+        kdc.init();
+        kdc.start();
+
+        kdc.createPrincipal("alice@EXAMPLE.COM", "alicePassword");
+        kdc.createAndExportPrincipals(keytabFile.toFile(), "HTTP/localhost@EXAMPLE.COM");
+
+        // initialize the ticket cache
+        KrbClient krbClient = kdc.getKrbClient();
+        TgtTicket tgt = krbClient.requestTgt("alice@EXAMPLE.COM", "alicePassword");
+        krbClient.storeTicket(tgt, ccacheFile.toFile());
+
+        // Override config so we look at the testing cache instead of the real system cache
+        negotiateAuthConfig = new Configuration() {
+            @Override
+            public AppConfigurationEntry[] getAppConfigurationEntry(String name) {
+                Map<String, String> opts = new HashMap<>();
+                opts.put("useTicketCache", "true");
+                opts.put("ticketCache", ccacheFile.toAbsolutePath().toString());
+                opts.put("doNotPrompt", "true");
+                return new AppConfigurationEntry[] {
+                    new AppConfigurationEntry(
+                        "com.sun.security.auth.module.Krb5LoginModule",
+                        AppConfigurationEntry.LoginModuleControlFlag.REQUIRED, opts)
+                };
+            }
+        };
     }
 
     @Test
@@ -216,13 +291,16 @@ public class AwaitCloseChannelPoolMapTest {
         assertThat(requests).contains("CONNECT some-awesome-service:443");
     }
 
-    @Test
-    public void usingProxy_withAuth() {
+    @ParameterizedTest
+    @MethodSource("proxyAuthTestParams")
+    public void usingProxy_authHeaderCorrect(ProxyAuthScheme authScheme, String username, String password,
+                                             String proxyAuthHeader) {
         ProxyConfiguration proxyConfiguration = ProxyConfiguration.builder()
                                                                   .host("localhost")
                                                                   .port(mockProxy.port())
-                                                                  .username("myuser")
-                                                                  .password("mypassword")
+                                                                  .proxyAuthScheme(authScheme)
+                                                                  .username(username)
+                                                                  .password(password)
                                                                   .build();
 
         channelPoolMap = AwaitCloseChannelPoolMap.builder()
@@ -233,6 +311,7 @@ public class AwaitCloseChannelPoolMapTest {
                                                  .protocol(Protocol.HTTP1_1)
                                                  .maxStreams(100)
                                                  .sslProvider(SslProvider.OPENSSL)
+                                                 .negotiateAuthConfig(negotiateAuthConfig)
                                                  .build();
 
         SimpleChannelPoolAwareChannelPool simpleChannelPoolAwareChannelPool = channelPoolMap.newPool(
@@ -244,9 +323,11 @@ public class AwaitCloseChannelPoolMapTest {
 
         assertThat(requests).contains("CONNECT some-awesome-service:443");
 
-        String authB64 = Base64.getEncoder().encodeToString("myuser:mypassword".getBytes(CharsetUtil.UTF_8));
-        String authHeaderValue = String.format("Basic %s", authB64);
-        assertThat(requests).contains(String.format("proxy-authorization: %s", authHeaderValue));
+        if (proxyAuthHeader == null) {
+            assertThat(requests).doesNotContain("proxy-authorization:");
+        } else {
+            assertThat(requests).contains(String.format("proxy-authorization: %s", proxyAuthHeader));
+        }
     }
 
     @Test
@@ -309,4 +390,14 @@ public class AwaitCloseChannelPoolMapTest {
         assertThat(channel.config().isAutoRead()).isTrue();
     }
 
+    private static Stream<Arguments> proxyAuthTestParams() {
+        return Stream.of(
+            Arguments.of(null, null, null, null),
+            Arguments.of(null, "user", "pass", "Basic dXNlcjpwYXNz"),
+            Arguments.of(ProxyAuthScheme.BASIC, "user", "pass", "Basic dXNlcjpwYXNz"),
+            Arguments.of(ProxyAuthScheme.NEGOTIATE, null, null, "Negotiate YII"),
+            Arguments.of(ProxyAuthScheme.NEGOTIATE, "user", "pass", "Negotiate YII")
+
+        );
+    }
 }

--- a/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/AwaitCloseChannelPoolMapTest.java
+++ b/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/AwaitCloseChannelPoolMapTest.java
@@ -63,6 +63,7 @@ import software.amazon.awssdk.http.nio.netty.SdkEventLoopGroup;
 import software.amazon.awssdk.utils.AttributeMap;
 
 public class AwaitCloseChannelPoolMapTest {
+    private static final String KRB5_PROP = "java.security.krb5.conf";
     private static final RecordingNetworkTrafficListener recorder = new RecordingNetworkTrafficListener();
 
     private static WireMockServer mockProxy;
@@ -73,6 +74,7 @@ public class AwaitCloseChannelPoolMapTest {
     private static int port;
 
     private static SimpleKdcServer kdc;
+    private static String krb5PropSave;
 
     private static Configuration negotiateAuthConfig;
 
@@ -88,6 +90,11 @@ public class AwaitCloseChannelPoolMapTest {
 
     @AfterAll
     public static void teardown() throws Exception {
+        if (krb5PropSave != null) {
+            System.setProperty(KRB5_PROP, krb5PropSave);
+        } else {
+            System.clearProperty(KRB5_PROP);
+        }
         mockProxy.stop();
         kdc.stop();
     }
@@ -111,39 +118,45 @@ public class AwaitCloseChannelPoolMapTest {
             freePort.setReuseAddress(true);
             freePort.bind(new InetSocketAddress(0));
             port = freePort.getLocalPort();
+
+            kdc = new SimpleKdcServer();
+            kdc.setKdcRealm("EXAMPLE.COM");
+            kdc.setKdcHost("localhost");
+            kdc.setWorkDir(tempDir.toFile());
+            kdc.setKdcTcpPort(port);
+            kdc.setAllowUdp(false);
+            kdc.init();
+
+            krb5PropSave = System.getProperty(KRB5_PROP);
+
+            System.setProperty(KRB5_PROP, tempDir.resolve("krb5.conf").toAbsolutePath().toString());
+            kdc.start();
+
+            kdc.createPrincipal("alice@EXAMPLE.COM", "alicePassword");
+            kdc.createAndExportPrincipals(keytabFile.toFile(), "HTTP/localhost@EXAMPLE.COM");
+
+            // initialize the ticket cache
+            KrbClient krbClient = kdc.getKrbClient();
+            TgtTicket tgt = krbClient.requestTgt("alice@EXAMPLE.COM", "alicePassword");
+            krbClient.storeTicket(tgt, ccacheFile.toFile());
+
+            // Override config so we look at the testing cache instead of the real system cache
+            negotiateAuthConfig = new Configuration() {
+                @Override
+                public AppConfigurationEntry[] getAppConfigurationEntry(String name) {
+                    Map<String, String> opts = new HashMap<>();
+                    opts.put("useTicketCache", "true");
+                    opts.put("ticketCache", ccacheFile.toAbsolutePath().toString());
+                    opts.put("refreshKrb5Config", "true");
+                    opts.put("doNotPrompt", "true");
+                    return new AppConfigurationEntry[] {
+                        new AppConfigurationEntry(
+                            "com.sun.security.auth.module.Krb5LoginModule",
+                            AppConfigurationEntry.LoginModuleControlFlag.REQUIRED, opts)
+                    };
+                }
+            };
         }
-
-        kdc = new SimpleKdcServer();
-        kdc.setKdcRealm("EXAMPLE.COM");
-        kdc.setKdcHost("localhost");
-        kdc.setWorkDir(tempDir.toFile());
-        kdc.setKdcTcpPort(port);
-        kdc.init();
-        kdc.start();
-
-        kdc.createPrincipal("alice@EXAMPLE.COM", "alicePassword");
-        kdc.createAndExportPrincipals(keytabFile.toFile(), "HTTP/localhost@EXAMPLE.COM");
-
-        // initialize the ticket cache
-        KrbClient krbClient = kdc.getKrbClient();
-        TgtTicket tgt = krbClient.requestTgt("alice@EXAMPLE.COM", "alicePassword");
-        krbClient.storeTicket(tgt, ccacheFile.toFile());
-
-        // Override config so we look at the testing cache instead of the real system cache
-        negotiateAuthConfig = new Configuration() {
-            @Override
-            public AppConfigurationEntry[] getAppConfigurationEntry(String name) {
-                Map<String, String> opts = new HashMap<>();
-                opts.put("useTicketCache", "true");
-                opts.put("ticketCache", ccacheFile.toAbsolutePath().toString());
-                opts.put("doNotPrompt", "true");
-                return new AppConfigurationEntry[] {
-                    new AppConfigurationEntry(
-                        "com.sun.security.auth.module.Krb5LoginModule",
-                        AppConfigurationEntry.LoginModuleControlFlag.REQUIRED, opts)
-                };
-            }
-        };
     }
 
     @Test

--- a/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/Http1TunnelConnectionPoolTest.java
+++ b/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/Http1TunnelConnectionPoolTest.java
@@ -42,6 +42,8 @@ import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.Promise;
 import java.io.IOException;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import javax.net.ssl.SSLEngine;
@@ -271,8 +273,9 @@ public class Http1TunnelConnectionPoolTest {
 
         tunnelPool.acquire().awaitUninterruptibly();
 
-        // assertThat(data.proxyUser()).isEqualTo(PROXY_USER);
-        // assertThat(data.proxyPassword()).isEqualTo(PROXY_PASSWORD);
+        String expectedAuthHeader = Base64.getEncoder().encodeToString((PROXY_USER + ":" + PROXY_PASSWORD)
+                                                                           .getBytes(StandardCharsets.UTF_8));
+        assertThat(data.authHeader()).isEqualTo(expectedAuthHeader);
     }
 
     private static class TestInitHandlerData {

--- a/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/NegotiateProxyAuthGeneratorTest.java
+++ b/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/NegotiateProxyAuthGeneratorTest.java
@@ -37,12 +37,14 @@ import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.testutils.FileUtils;
 
 public class NegotiateProxyAuthGeneratorTest {
+    private static final String KRB5_PROP = "java.security.krb5.conf";
     private static Path tempDir;
     private static Path keytabFile;
     private static Path ccacheFile;
     private static int port;
 
     private static SimpleKdcServer kdc;
+    private static String krb5PropSave;
 
     private static Configuration config;
 
@@ -56,44 +58,56 @@ public class NegotiateProxyAuthGeneratorTest {
             freePort.setReuseAddress(true);
             freePort.bind(new InetSocketAddress(0));
             port = freePort.getLocalPort();
+
+            kdc = new SimpleKdcServer();
+            kdc.setKdcRealm("EXAMPLE.COM");
+            kdc.setKdcHost("localhost");
+            kdc.setWorkDir(tempDir.toFile());
+            kdc.setKdcTcpPort(port);
+            kdc.setAllowUdp(false);
+            kdc.init();
+
+            krb5PropSave = System.getProperty(KRB5_PROP);
+
+            System.setProperty(KRB5_PROP, tempDir.resolve("krb5.conf").toAbsolutePath().toString());
+
+            kdc.start();
+
+            kdc.createPrincipal("alice@EXAMPLE.COM", "alicePassword");
+            kdc.createAndExportPrincipals(keytabFile.toFile(), "HTTP/localhost@EXAMPLE.COM");
+
+            // initialize the ticket cache
+            KrbClient krbClient = kdc.getKrbClient();
+            TgtTicket tgt = krbClient.requestTgt("alice@EXAMPLE.COM", "alicePassword");
+            krbClient.storeTicket(tgt, ccacheFile.toFile());
+
+            // Override config so we look at the testing cache instead of the real system cache
+            config = new Configuration() {
+                @Override
+                public AppConfigurationEntry[] getAppConfigurationEntry(String name) {
+                    Map<String, String> opts = new HashMap<>();
+                    opts.put("useTicketCache", "true");
+                    opts.put("ticketCache", ccacheFile.toAbsolutePath().toString());
+                    opts.put("doNotPrompt", "true");
+                    opts.put("refreshKrb5Config", "true");
+                    return new AppConfigurationEntry[] {
+                        new AppConfigurationEntry(
+                            "com.sun.security.auth.module.Krb5LoginModule",
+                            AppConfigurationEntry.LoginModuleControlFlag.REQUIRED, opts)
+                    };
+                }
+            };
         }
-
-        kdc = new SimpleKdcServer();
-        kdc.setKdcRealm("EXAMPLE.COM");
-        kdc.setKdcHost("localhost");
-        kdc.setWorkDir(tempDir.toFile());
-        kdc.setKdcTcpPort(port);
-        kdc.init();
-        kdc.start();
-
-        kdc.createPrincipal("alice@EXAMPLE.COM", "alicePassword");
-        kdc.createAndExportPrincipals(keytabFile.toFile(), "HTTP/localhost@EXAMPLE.COM");
-
-        // initialize the ticket cache
-        KrbClient krbClient = kdc.getKrbClient();
-        TgtTicket tgt = krbClient.requestTgt("alice@EXAMPLE.COM", "alicePassword");
-        krbClient.storeTicket(tgt, ccacheFile.toFile());
-
-        // Override config so we look at the testing cache instead of the real system cache
-        config = new Configuration() {
-            @Override
-            public AppConfigurationEntry[] getAppConfigurationEntry(String name) {
-                Map<String, String> opts = new HashMap<>();
-                opts.put("useTicketCache", "true");
-                opts.put("ticketCache", ccacheFile.toAbsolutePath().toString());
-                opts.put("doNotPrompt", "true");
-                return new AppConfigurationEntry[] {
-                    new AppConfigurationEntry(
-                        "com.sun.security.auth.module.Krb5LoginModule",
-                        AppConfigurationEntry.LoginModuleControlFlag.REQUIRED, opts)
-                };
-            }
-        };
 
     }
 
     @AfterAll
     static void teardown() throws KrbException {
+        if (krb5PropSave != null) {
+            System.setProperty(KRB5_PROP, krb5PropSave);
+        } else {
+            System.clearProperty(KRB5_PROP);
+        }
         kdc.stop();
         FileUtils.cleanUpTestDirectory(tempDir);
     }

--- a/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/ProxyTunnelInitHandlerTest.java
+++ b/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/ProxyTunnelInitHandlerTest.java
@@ -16,6 +16,7 @@
 package software.amazon.awssdk.http.nio.netty.internal;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -45,6 +46,7 @@ import io.netty.util.concurrent.Promise;
 import java.io.IOException;
 import java.net.URI;
 import java.util.Base64;
+import java.util.concurrent.ExecutionException;
 import java.util.function.Supplier;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -53,6 +55,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import software.amazon.awssdk.http.nio.netty.ProxyAuthScheme;
 
 /**
  * Unit tests for {@link ProxyTunnelInitHandler}.
@@ -237,6 +240,23 @@ public class ProxyTunnelInitHandlerTest {
         expectedRequest.headers().add(HttpHeaderNames.PROXY_AUTHORIZATION, String.format("Basic %s", authB64));
 
         assertThat(requestCaptor.getValue()).isEqualTo(expectedRequest);
+    }
+
+    @Test
+    public void handlerAdded_authParamsGeneratorThrows_failsFuture() {
+        ProxyAuthGenerator authGenerator = mock(ProxyAuthGenerator.class);
+        when(authGenerator.scheme()).thenReturn(ProxyAuthScheme.BASIC);
+        when(authGenerator.generateAuthParams(any(URI.class))).thenThrow(new RuntimeException("auth generator error"));
+
+        Promise<Channel> promise = GROUP.next().newPromise();
+        ProxyTunnelInitHandler handler = new ProxyTunnelInitHandler(mockChannelPool, URI.create("https://amazon.com"),
+                                                                    authGenerator,
+                                                                    REMOTE_HOST,
+                                                                    promise);
+        handler.handlerAdded(mockCtx);
+
+        assertThatThrownBy(promise::get).hasMessageContaining("Unable to send CONNECT request to proxy")
+                                        .hasRootCauseMessage("auth generator error");
     }
 
     private void successResponse(ProxyTunnelInitHandler handler) {


### PR DESCRIPTION
This commit Adds a `ProxyAuthScheme` configuration option in `ProxyConfiguration` and adds support for `NEGOTIATE` auth scheme.

For backwards compatibility, if username and password are set on the config and the proxy auth scheme is *not* set, the client assumes `BASIC` auth scheme. If `NEGOTIATE` is configured, `username` and `password` are ignored.

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Modifications
<!--- Describe your changes in detail -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
