### PR TITLE
fix(http): trim nonProxyHosts entry whitespace

### DIFF
--- a/.changes/next-release/bugfix-Apache5HTTPClient-6c80c24.json
+++ b/.changes/next-release/bugfix-Apache5HTTPClient-6c80c24.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "Apache 5 HTTP Client",
+    "contributor": "",
+    "description": "Trimmed surrounding whitespace from `nonProxyHosts` / `no_proxy` entries so comma- or pipe-separated values with spaces (e.g. `no_proxy=a.com, *.foo.com`) are honored. Previously an entry with a leading or trailing space was treated as part of the host name and never matched, so the host was routed through the proxy instead of bypassing it."
+}

--- a/.changes/next-release/bugfix-ApacheHTTPClient-97e1afc.json
+++ b/.changes/next-release/bugfix-ApacheHTTPClient-97e1afc.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "Apache HTTP Client",
+    "contributor": "",
+    "description": "Trimmed surrounding whitespace from `nonProxyHosts` / `no_proxy` entries so comma- or pipe-separated values with spaces (e.g. `no_proxy=a.com, *.foo.com`) are honored. Previously an entry with a leading or trailing space was treated as part of the host name and never matched, so the host was routed through the proxy instead of bypassing it."
+}

--- a/.changes/next-release/bugfix-NettyNIOHTTPClient-93bb990.json
+++ b/.changes/next-release/bugfix-NettyNIOHTTPClient-93bb990.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "Netty NIO HTTP Client",
+    "contributor": "",
+    "description": "Trimmed surrounding whitespace from `nonProxyHosts` / `no_proxy` entries so comma- or pipe-separated values with spaces (e.g. `no_proxy=a.com, *.foo.com`) are honored. Previously an entry with a leading or trailing space was treated as part of the host name and never matched, so the host was routed through the proxy instead of bypassing it."
+}

--- a/.changes/next-release/bugfix-URLConnectionHTTPClient-da3b3e2.json
+++ b/.changes/next-release/bugfix-URLConnectionHTTPClient-da3b3e2.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "URL Connection HTTP Client",
+    "contributor": "",
+    "description": "Trimmed surrounding whitespace from `nonProxyHosts` / `no_proxy` entries so comma- or pipe-separated values with spaces (e.g. `no_proxy=a.com, *.foo.com`) are honored. Previously an entry with a leading or trailing space was treated as part of the host name and never matched, so the host was routed through the proxy instead of bypassing it."
+}

--- a/core/crt-core/src/main/java/software/amazon/awssdk/crtcore/CrtProxyConfiguration.java
+++ b/core/crt-core/src/main/java/software/amazon/awssdk/crtcore/CrtProxyConfiguration.java
@@ -259,6 +259,9 @@ public abstract class CrtProxyConfiguration {
          * are not provided during building the {@link CrtProxyConfiguration} object. To disable this behaviour, set this value to
          * false.It is important to note that when this property is set to "true," all proxy settings will exclusively originate
          * from system properties, and no partial settings will be obtained from EnvironmentVariableValues.
+         * <p>Pipe-separated host names in the {@code http.nonProxyHosts} system property indicate multiple hosts to exclude
+         * from proxy settings. Surrounding empty spaces around each host name are trimmed, so both {@code "a.com|b.com"} and
+         * {@code "a.com | b.com"} are accepted.
          *
          * @param useSystemPropertyValues The option whether to use system property values
          * @return This object for method chaining.
@@ -272,7 +275,8 @@ public abstract class CrtProxyConfiguration {
          * value to false.It is important to note that when this property is set to "true," all proxy settings will exclusively
          * originate from environment variableValues, and no partial settings will be obtained from SystemPropertyValues.
          * <p>Comma-separated host names in the NO_PROXY environment variable indicate multiple hosts to exclude from
-         * proxy settings.
+         * proxy settings. Surrounding empty spaces around each host name are trimmed, so both {@code "a.com,b.com"} and
+         * {@code "a.com, b.com"} are accepted.
          *
          * @param useEnvironmentVariableValues The option whether to use environment variable values
          * @return This object for method chaining.

--- a/http-clients/apache-client/src/main/java/software/amazon/awssdk/http/apache/ProxyConfiguration.java
+++ b/http-clients/apache-client/src/main/java/software/amazon/awssdk/http/apache/ProxyConfiguration.java
@@ -259,11 +259,18 @@ public final class ProxyConfiguration implements ToCopyableBuilder<ProxyConfigur
 
         /**
          * Configure the hosts that the client is allowed to access without going through the proxy.
+         * <p>Entries supplied here are treated as exact host names (e.g. {@code example.com}) or CIDR ranges for IP addresses
+         * (e.g. {@code 10.0.0.0/8}). Wildcard patterns such as {@code *.example.com} or a bare {@code *} are not supported for
+         * entries supplied here; to use wildcards, configure them through the {@code http.nonProxyHosts} system property or the
+         * {@code NO_PROXY} environment variable instead.
          */
         Builder nonProxyHosts(Set<String> nonProxyHosts);
 
         /**
          * Add a host that the client is allowed to access without going through the proxy.
+         * <p>The host is treated as an exact host name or CIDR range; wildcard patterns are not supported for entries supplied
+         * here. See {@link #nonProxyHosts(Set)} for details on wildcard support through the system property or environment
+         * variable.
          *
          * @see ProxyConfiguration#nonProxyHosts()
          */
@@ -281,6 +288,11 @@ public final class ProxyConfiguration implements ToCopyableBuilder<ProxyConfigur
          * are not provided during building the {@link ProxyConfiguration} object. To disable this behavior, set this value to
          * "false".It is important to note that when this property is set to "true," all proxy settings will exclusively originate
          * from system properties, and no partial settings will be obtained from EnvironmentVariableValues.
+         * <p>Pipe-separated host names in the {@code http.nonProxyHosts} system property indicate multiple hosts to exclude
+         * from proxy settings. Surrounding empty spaces around each host name are trimmed, so both {@code "a.com|b.com"} and
+         * {@code "a.com | b.com"} are accepted. Each entry may be an exact host name (e.g. {@code example.com}), a
+         * leading-wildcard suffix (e.g. {@code *.example.com}, which matches {@code example.com} and its subdomains),
+         * a single {@code *} (which matches all hosts), or a CIDR range for IP addresses (e.g. {@code 10.0.0.0/8}).
          */
         Builder useSystemPropertyValues(Boolean useSystemPropertyValues);
 
@@ -293,7 +305,10 @@ public final class ProxyConfiguration implements ToCopyableBuilder<ProxyConfigur
          * proxy settings will exclusively originate from environment variableValues, and no partial settings will be obtained
          * from SystemPropertyValues.
          * <p>Comma-separated host names in the NO_PROXY environment variable indicate multiple hosts to exclude from
-         * proxy settings.
+         * proxy settings. Surrounding empty spaces around each host name are trimmed, so both {@code "a.com,b.com"} and
+         * {@code "a.com, b.com"} are accepted. Each entry may be an exact host name (e.g. {@code example.com}), a
+         * leading-wildcard suffix (e.g. {@code *.example.com}, which matches {@code example.com} and its subdomains),
+         * a single {@code *} (which matches all hosts), or a CIDR range for IP addresses (e.g. {@code 10.0.0.0/8}).
          *
          * @param useEnvironmentVariableValues The option whether to use environment variable values.
          * @return This object for method chaining.

--- a/http-clients/apache5-client/src/main/java/software/amazon/awssdk/http/apache5/ProxyConfiguration.java
+++ b/http-clients/apache5-client/src/main/java/software/amazon/awssdk/http/apache5/ProxyConfiguration.java
@@ -259,11 +259,18 @@ public final class ProxyConfiguration implements ToCopyableBuilder<ProxyConfigur
 
         /**
          * Configure the hosts that the client is allowed to access without going through the proxy.
+         * <p>Entries supplied here are treated as exact host names (e.g. {@code example.com}) or CIDR ranges for IP addresses
+         * (e.g. {@code 10.0.0.0/8}). Wildcard patterns such as {@code *.example.com} or a bare {@code *} are not supported for
+         * entries supplied here; to use wildcards, configure them through the {@code http.nonProxyHosts} system property or the
+         * {@code NO_PROXY} environment variable instead.
          */
         Builder nonProxyHosts(Set<String> nonProxyHosts);
 
         /**
          * Add a host that the client is allowed to access without going through the proxy.
+         * <p>The host is treated as an exact host name or CIDR range; wildcard patterns are not supported for entries supplied
+         * here. See {@link #nonProxyHosts(Set)} for details on wildcard support through the system property or environment
+         * variable.
          *
          * @see ProxyConfiguration#nonProxyHosts()
          */
@@ -281,6 +288,11 @@ public final class ProxyConfiguration implements ToCopyableBuilder<ProxyConfigur
          * are not provided during building the {@link ProxyConfiguration} object. To disable this behavior, set this value to
          * "false".It is important to note that when this property is set to "true," all proxy settings will exclusively originate
          * from system properties, and no partial settings will be obtained from EnvironmentVariableValues.
+         * <p>Pipe-separated host names in the {@code http.nonProxyHosts} system property indicate multiple hosts to exclude
+         * from proxy settings. Surrounding empty spaces around each host name are trimmed, so both {@code "a.com|b.com"} and
+         * {@code "a.com | b.com"} are accepted. Each entry may be an exact host name (e.g. {@code example.com}), a
+         * leading-wildcard suffix (e.g. {@code *.example.com}, which matches {@code example.com} and its subdomains),
+         * a single {@code *} (which matches all hosts), or a CIDR range for IP addresses (e.g. {@code 10.0.0.0/8}).
          */
         Builder useSystemPropertyValues(Boolean useSystemPropertyValues);
 
@@ -293,7 +305,10 @@ public final class ProxyConfiguration implements ToCopyableBuilder<ProxyConfigur
          * proxy settings will exclusively originate from environment variableValues, and no partial settings will be obtained
          * from SystemPropertyValues.
          * <p>Comma-separated host names in the NO_PROXY environment variable indicate multiple hosts to exclude from
-         * proxy settings.
+         * proxy settings. Surrounding empty spaces around each host name are trimmed, so both {@code "a.com,b.com"} and
+         * {@code "a.com, b.com"} are accepted. Each entry may be an exact host name (e.g. {@code example.com}), a
+         * leading-wildcard suffix (e.g. {@code *.example.com}, which matches {@code example.com} and its subdomains),
+         * a single {@code *} (which matches all hosts), or a CIDR range for IP addresses (e.g. {@code 10.0.0.0/8}).
          *
          * @param useEnvironmentVariableValues The option whether to use environment variable values.
          * @return This object for method chaining.

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/ProxyConfiguration.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/ProxyConfiguration.java
@@ -235,8 +235,12 @@ public final class ProxyConfiguration implements ToCopyableBuilder<ProxyConfigur
         Builder scheme(String scheme);
 
         /**
-         * Set the set of hosts that should not be proxied. Any request whose host portion matches any of the patterns
-         * given in the set will be sent to the remote host directly instead of through the proxy.
+         * Set the set of hosts that should not be proxied. Any request whose host portion matches one of these entries will be
+         * sent to the remote host directly instead of through the proxy.
+         * <p>Entries supplied here are treated as exact host names (e.g. {@code example.com}) or CIDR ranges for IP addresses
+         * (e.g. {@code 10.0.0.0/8}). Wildcard patterns such as {@code *.example.com} or a bare {@code *} are not supported for
+         * entries supplied here; to use wildcards, configure them through the {@code http.nonProxyHosts} system property or the
+         * {@code NO_PROXY} environment variable instead.
          *
          * @param nonProxyHosts The set of hosts that should not be proxied.
          * @return This object for method chaining.
@@ -265,6 +269,11 @@ public final class ProxyConfiguration implements ToCopyableBuilder<ProxyConfigur
          * options are not provided during building the {@link ProxyConfiguration} object. To disable this behaviour, set this
          * value to false.It is important to note that when this property is set to "true," all proxy settings will exclusively
          * be obtained from System Property Values, and no partial settings will be obtained from Environment Variable Values.
+         * <p>Pipe-separated host names in the {@code http.nonProxyHosts} system property indicate multiple hosts to exclude
+         * from proxy settings. Surrounding empty spaces around each host name are trimmed, so both {@code "a.com|b.com"} and
+         * {@code "a.com | b.com"} are accepted. Each entry may be an exact host name (e.g. {@code example.com}), a
+         * leading-wildcard suffix (e.g. {@code *.example.com}, which matches {@code example.com} and its subdomains),
+         * a single {@code *} (which matches all hosts), or a CIDR range for IP addresses (e.g. {@code 10.0.0.0/8}).
          *
          * @param useSystemPropertyValues The option whether to use system property values
          * @return This object for method chaining.
@@ -280,7 +289,10 @@ public final class ProxyConfiguration implements ToCopyableBuilder<ProxyConfigur
          * proxy settings will exclusively originate from Environment Variable Values, and no partial settings will be obtained
          * from System Property Values.
          * <p>Comma-separated host names in the NO_PROXY environment variable indicate multiple hosts to exclude from
-         * proxy settings.
+         * proxy settings. Surrounding empty spaces around each host name are trimmed, so both {@code "a.com,b.com"} and
+         * {@code "a.com, b.com"} are accepted. Each entry may be an exact host name (e.g. {@code example.com}), a
+         * leading-wildcard suffix (e.g. {@code *.example.com}, which matches {@code example.com} and its subdomains),
+         * a single {@code *} (which matches all hosts), or a CIDR range for IP addresses (e.g. {@code 10.0.0.0/8}).
          *
          * @param useEnvironmentVariablesValues The option whether to use environment variable values
          * @return This object for method chaining.

--- a/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/ProxyWireMockTest.java
+++ b/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/ProxyWireMockTest.java
@@ -37,11 +37,14 @@ import software.amazon.awssdk.http.SdkHttpMethod;
 import software.amazon.awssdk.http.async.AsyncExecuteRequest;
 import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
 import software.amazon.awssdk.http.async.SdkAsyncHttpResponseHandler;
+import software.amazon.awssdk.testutils.EnvironmentVariableHelper;
 
 /**
  * Tests for HTTP proxy functionality in the Netty client.
  */
 public class ProxyWireMockTest {
+    private static final EnvironmentVariableHelper ENVIRONMENT_VARIABLE_HELPER = new EnvironmentVariableHelper();
+
     private static SdkAsyncHttpClient client;
 
     private static ProxyConfiguration proxyCfg;
@@ -79,6 +82,7 @@ public class ProxyWireMockTest {
             client.close();
         }
         client = null;
+        ENVIRONMENT_VARIABLE_HELPER.reset();
     }
 
     @Test(expected = IOException.class)
@@ -142,6 +146,32 @@ public class ProxyWireMockTest {
         client = NettyNioAsyncHttpClient.builder()
                                         .proxyConfiguration(cfg)
                                         .useNonBlockingDnsResolver(true)
+                                        .build();
+
+        client.execute(req).join();
+
+        responseHandler.completeFuture.join();
+        assertThat(responseHandler.fullResponseAsString()).isEqualTo("hello");
+    }
+
+    @Test
+    public void proxyConfigured_hostInCommaSpaceNoProxyEnv_doesNotConnect() {
+        ENVIRONMENT_VARIABLE_HELPER.set("no_proxy", "example.com, localhost");
+
+        RecordingResponseHandler responseHandler = new RecordingResponseHandler();
+        AsyncExecuteRequest req = AsyncExecuteRequest.builder()
+                                                     .request(testSdkRequest())
+                                                     .responseHandler(responseHandler)
+                                                     .requestContentPublisher(new EmptyPublisher())
+                                                     .build();
+
+        ProxyConfiguration cfg = ProxyConfiguration.builder()
+                                                   .host("localhost")
+                                                   .port(mockProxy.port())
+                                                   .build();
+
+        client = NettyNioAsyncHttpClient.builder()
+                                        .proxyConfiguration(cfg)
                                         .build();
 
         client.execute(req).join();

--- a/http-clients/url-connection-client/src/main/java/software/amazon/awssdk/http/urlconnection/ProxyConfiguration.java
+++ b/http-clients/url-connection-client/src/main/java/software/amazon/awssdk/http/urlconnection/ProxyConfiguration.java
@@ -219,11 +219,18 @@ public final class ProxyConfiguration implements ToCopyableBuilder<ProxyConfigur
 
         /**
          * Configure the hosts that the client is allowed to access without going through the proxy.
+         * <p>Entries supplied here are treated as exact host names (e.g. {@code example.com}) or CIDR ranges for IP addresses
+         * (e.g. {@code 10.0.0.0/8}). Wildcard patterns such as {@code *.example.com} or a bare {@code *} are not supported for
+         * entries supplied here; to use wildcards, configure them through the {@code http.nonProxyHosts} system property or the
+         * {@code NO_PROXY} environment variable instead.
          */
         Builder nonProxyHosts(Set<String> nonProxyHosts);
 
         /**
          * Add a host that the client is allowed to access without going through the proxy.
+         * <p>The host is treated as an exact host name or CIDR range; wildcard patterns are not supported for entries supplied
+         * here. See {@link #nonProxyHosts(Set)} for details on wildcard support through the system property or environment
+         * variable.
          *
          * @see ProxyConfiguration#nonProxyHosts()
          */
@@ -236,6 +243,11 @@ public final class ProxyConfiguration implements ToCopyableBuilder<ProxyConfigur
          * are not provided during building the {@link ProxyConfiguration} object. To disable this behavior, set this value to
          * "false".It is important to note that when this property is set to "true," all proxy settings will exclusively originate
          * from system properties, and no partial settings will be obtained from EnvironmentVariableValues
+         * <p>Pipe-separated host names in the {@code http.nonProxyHosts} system property indicate multiple hosts to exclude
+         * from proxy settings. Surrounding empty spaces around each host name are trimmed, so both {@code "a.com|b.com"} and
+         * {@code "a.com | b.com"} are accepted. Each entry may be an exact host name (e.g. {@code example.com}), a
+         * leading-wildcard suffix (e.g. {@code *.example.com}, which matches {@code example.com} and its subdomains),
+         * a single {@code *} (which matches all hosts), or a CIDR range for IP addresses (e.g. {@code 10.0.0.0/8}).
          */
         Builder useSystemPropertyValues(Boolean useSystemPropertyValues);
 
@@ -246,7 +258,10 @@ public final class ProxyConfiguration implements ToCopyableBuilder<ProxyConfigur
          * value to "false".It is important to note that when this property is set to "true," all proxy settings will exclusively
          * originate from environment variableValues, and no partial settings will be obtained from SystemPropertyValues.
          * <p>Comma-separated host names in the NO_PROXY environment variable indicate multiple hosts to exclude from
-         * proxy settings.
+         * proxy settings. Surrounding empty spaces around each host name are trimmed, so both {@code "a.com,b.com"} and
+         * {@code "a.com, b.com"} are accepted. Each entry may be an exact host name (e.g. {@code example.com}), a
+         * leading-wildcard suffix (e.g. {@code *.example.com}, which matches {@code example.com} and its subdomains),
+         * a single {@code *} (which matches all hosts), or a CIDR range for IP addresses (e.g. {@code 10.0.0.0/8}).
          *
          * @param useEnvironmentVariablesValues The option whether to use environment variable values
          * @return This object for method chaining.

--- a/test/http-client-tests/src/main/java/software/amazon/awssdk/http/proxy/ProxyConfigCommonTestData.java
+++ b/test/http-client-tests/src/main/java/software/amazon/awssdk/http/proxy/ProxyConfigCommonTestData.java
@@ -36,6 +36,7 @@ public final class ProxyConfigCommonTestData {
     public static final String ENVIRONMENT_HOST = "environmentVariable.com".toLowerCase(Locale.US);
     public static final String ENVIRONMENT_VARIABLE_PORT_NUMBER = "3333";
     public static final String ENVIRONMENT_VARIABLE_NON_PROXY = "environmentVariableNonProxy".toLowerCase(Locale.US);
+    public static final String ENVIRONMENT_VARIABLE_NON_PROXY_SECOND = "secondNonProxy.com".toLowerCase(Locale.US);
     public static final String USER_HOST_ON_BUILDER = "proxyBuilder.com";
     public static final int USER_PORT_NUMBER_ON_BUILDER = 9999;
     public static final String USER_USERNAME_ON_BUILDER = "proxyBuilderUser";
@@ -245,7 +246,16 @@ public final class ProxyConfigCommonTestData {
                 + "resolved",
                 getSystemPropertiesWithNoUserName(),
                 environmentSettingsWithNoPassword(),
-                new TestProxySetting(), false, true, getEnvironmentVariableProxySettings().password(null))
+                new TestProxySetting(), false, true, getEnvironmentVariableProxySettings().password(null)),
+
+            Arguments.of(
+                "Provided no system property and a comma-space separated no_proxy environment variable when "
+                + "useEnvironmentVariable is set then each non-proxy host is resolved with surrounding whitespace trimmed",
+                Collections.singletonList(Pair.of("", "")),
+                environmentSettingsWithCommaSpaceNonProxy(),
+                new TestProxySetting(), false, true,
+                getEnvironmentVariableProxySettings().nonProxyHost(ENVIRONMENT_VARIABLE_NON_PROXY,
+                                                                   ENVIRONMENT_VARIABLE_NON_PROXY_SECOND))
         );
     }
 
@@ -297,6 +307,15 @@ public final class ProxyConfigCommonTestData {
             Pair.of("%s_proxy",
                     "http://" + ENV_VARIABLE_USER + "@" + ENVIRONMENT_HOST + ":" + ENVIRONMENT_VARIABLE_PORT_NUMBER + "/"),
             Pair.of("no_proxy", ENVIRONMENT_VARIABLE_NON_PROXY)
+        );
+    }
+
+    private static List<Pair<String, String>> environmentSettingsWithCommaSpaceNonProxy() {
+        return Arrays.asList(
+            Pair.of("%s_proxy",
+                    "http://" + ENV_VARIABLE_USER + ":" + ENV_VARIABLE_PASSWORD + "@" + ENVIRONMENT_HOST
+                    + ":" + ENVIRONMENT_VARIABLE_PORT_NUMBER + "/"),
+            Pair.of("no_proxy", ENVIRONMENT_VARIABLE_NON_PROXY + ", " + ENVIRONMENT_VARIABLE_NON_PROXY_SECOND)
         );
     }
 

--- a/utils/src/main/java/software/amazon/awssdk/utils/http/SdkHttpUtils.java
+++ b/utils/src/main/java/software/amazon/awssdk/utils/http/SdkHttpUtils.java
@@ -438,6 +438,7 @@ public final class SdkHttpUtils {
     private static Set<String> extractNonProxyHosts(String nonProxyHosts) {
         if (nonProxyHosts != null && !isEmpty(nonProxyHosts)) {
             return Arrays.stream(nonProxyHosts.split("\\|"))
+                         .map(String::trim)
                          .map(String::toLowerCase)
                          .map(s -> StringUtils.replace(s, "*", ".*?"))
                          .collect(Collectors.toSet());

--- a/utils/src/test/java/software/amazon/awssdk/utils/SdkHttpUtilsTest.java
+++ b/utils/src/test/java/software/amazon/awssdk/utils/SdkHttpUtilsTest.java
@@ -333,4 +333,29 @@ public class SdkHttpUtilsTest {
             }
         }
     }
+
+    @Test
+    void parseListOfNonProxyHostWithCommaSpace_trimsSurroundingWhitespace(){
+        String multipleHostNames = "example.com, *greedy.org, 192.168.1.1";
+        ENVIRONMENT_VARIABLE_HELPER.set("no_proxy", multipleHostNames);
+        Set<String> strings = SdkHttpUtils.parseNonProxyHostsEnvironmentVariable();
+        assertThat(strings).isEqualTo(Stream.of("example.com", ".*?greedy.org", "192.168.1.1")
+                                            .collect(Collectors.toSet()));
+    }
+
+    @Test
+    void parseNonProxyHostWithSurroundingWhitespace_isTrimmed(){
+        ENVIRONMENT_VARIABLE_HELPER.set("no_proxy", "   example.com   ");
+        Set<String> strings = SdkHttpUtils.parseNonProxyHostsEnvironmentVariable();
+        assertThat(strings).containsExactly("example.com");
+    }
+
+    @Test
+    void parseListOfNonProxyHostWithoutWhitespace_isUnchanged(){
+        String multipleHostNames = "example.com,*greedy.org,192.168.1.1";
+        ENVIRONMENT_VARIABLE_HELPER.set("no_proxy", multipleHostNames);
+        Set<String> strings = SdkHttpUtils.parseNonProxyHostsEnvironmentVariable();
+        assertThat(strings).isEqualTo(Stream.of("example.com", ".*?greedy.org", "192.168.1.1")
+                                            .collect(Collectors.toSet()));
+    }
 }

--- a/utils/src/test/java/software/amazon/awssdk/utils/SdkHttpUtilsTest.java
+++ b/utils/src/test/java/software/amazon/awssdk/utils/SdkHttpUtilsTest.java
@@ -349,13 +349,4 @@ public class SdkHttpUtilsTest {
         Set<String> strings = SdkHttpUtils.parseNonProxyHostsEnvironmentVariable();
         assertThat(strings).containsExactly("example.com");
     }
-
-    @Test
-    void parseListOfNonProxyHostWithoutWhitespace_isUnchanged(){
-        String multipleHostNames = "example.com,*greedy.org,192.168.1.1";
-        ENVIRONMENT_VARIABLE_HELPER.set("no_proxy", multipleHostNames);
-        Set<String> strings = SdkHttpUtils.parseNonProxyHostsEnvironmentVariable();
-        assertThat(strings).isEqualTo(Stream.of("example.com", ".*?greedy.org", "192.168.1.1")
-                                            .collect(Collectors.toSet()));
-    }
 }


### PR DESCRIPTION
## Motivation and Context

`nonProxyHosts` / `no_proxy` values are pipe- or comma-separated lists, and users commonly write them with spaces after the separator, e.g.:

```
export no_proxy="example.com, *.foo.com, 10.0.0.0/8"
-Dhttp.nonProxyHosts="example.com | *.foo.com"
```

The shared parser (`SdkHttpUtils`) split these lists but did **not** trim the resulting entries, so an entry with a leading (or trailing) space, e.g. `" *.foo.com"`, was stored with the space as part of the host name. It then never matched the real host, so the host was routed **through the proxy** instead of bypassing it. This silently defeated `no_proxy` for any list written with the conventional comma-space style.

## Modifications

- **Fix (behavior):** `SdkHttpUtils.extractNonProxyHosts` now trims each entry (`.map(String::trim)`) after splitting, before lowercasing and the glob-to-regex rewrite. This shared parser feeds the four Java-regex clients (`netty-nio`, `apache`, `apache5`, `url-connection`) on the system-property (`http.nonProxyHosts`) and environment-variable (`no_proxy`/`NO_PROXY`) resolution paths, so the fix applies to those four uniformly.

- **Documentation (no behavior change):** added documentation

- **CRT scope (why no CRT changelog entry):** CRT already trims `nonProxyHosts` entries via its own path (`rawNonProxyHosts()` → `ProxyUtils.splitToGlobTokens`) as of the merged CRT wildcard change, so this PR's shared-parser trim does not change CRT behavior — it affects only the four Java-regex clients. The changelog therefore has four entries (one per regex client) and no CRT entry.

  No public API surface changes; builder-supplied nonProxyHosts semantics are unchanged (documented, not altered).

## Testing

- **Shared cross-client suite:** added a comma-space `no_proxy` case to `ProxyConfigCommonTestData` (drives `HttpProxyTestSuite` for all five clients) asserting each entry resolves with surrounding whitespace trimmed.
- **Netty routing:** added `ProxyWireMockTest.proxyConfigured_hostInCommaSpaceNoProxyEnv_doesNotConnect`, verifying a host listed in a comma-space `no_proxy` bypasses the proxy end to end.
- **Unit:** added `SdkHttpUtilsTest` cases for comma-space entries, surrounding whitespace on a single entry, and the no-whitespace regression (unchanged behavior preserved).

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds <!-- only per-module builds were run, not a full-repo mvn install -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed <!-- except two pre-existing, environment-specific netty fault tests unrelated to this change; see Testing -->
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
- [x] I confirm that this pull request can be released under the Apache 2 license
