### PR TITLE
Remove enableGenerateCompiledEndpointRules entries from all customization.config files

### DIFF
--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/s3-test/customization.config
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/s3-test/customization.config
@@ -331,7 +331,6 @@
     }
   },
 
-  "enableGenerateCompiledEndpointRules": true,
   "endpointParameters": {
     "DeleteObjectKeys": {
       "required": false,

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/s3control-test/customization.config
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/s3control-test/customization.config
@@ -1,6 +1,5 @@
 {
 
-    "enableGenerateCompiledEndpointRules": true,
     "serviceConfig": {
       "className": "S3ControlConfiguration",
       "hasDualstackProperty": true,

--- a/services/accessanalyzer/src/main/resources/codegen-resources/customization.config
+++ b/services/accessanalyzer/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/account/src/main/resources/codegen-resources/customization.config
+++ b/services/account/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/acm/src/main/resources/codegen-resources/customization.config
+++ b/services/acm/src/main/resources/codegen-resources/customization.config
@@ -1,6 +1,5 @@
 {
     "verifiedSimpleMethods": [
         "listCertificates"
-    ],
-    "enableGenerateCompiledEndpointRules": true
+    ]
 }

--- a/services/acmpca/src/main/resources/codegen-resources/customization.config
+++ b/services/acmpca/src/main/resources/codegen-resources/customization.config
@@ -1,6 +1,5 @@
 {
     "verifiedSimpleMethods": [
         "listCertificateAuthorities"
-    ],
-    "enableGenerateCompiledEndpointRules": true
+    ]
 }

--- a/services/amp/src/main/resources/codegen-resources/customization.config
+++ b/services/amp/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/amplify/src/main/resources/codegen-resources/customization.config
+++ b/services/amplify/src/main/resources/codegen-resources/customization.config
@@ -1,6 +1,5 @@
 {
     "verifiedSimpleMethods": [
         "listApps"
-    ],
-    "enableGenerateCompiledEndpointRules": true
+    ]
 }

--- a/services/amplifybackend/src/main/resources/codegen-resources/customization.config
+++ b/services/amplifybackend/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/amplifyuibuilder/src/main/resources/codegen-resources/customization.config
+++ b/services/amplifyuibuilder/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/apigateway/src/main/resources/codegen-resources/customization.config
+++ b/services/apigateway/src/main/resources/codegen-resources/customization.config
@@ -23,6 +23,5 @@
     ],
     "interceptors": [
         "software.amazon.awssdk.services.apigateway.internal.AcceptJsonInterceptor"
-    ],
-    "enableGenerateCompiledEndpointRules": true
+    ]
 }

--- a/services/apigatewaymanagementapi/src/main/resources/codegen-resources/customization.config
+++ b/services/apigatewaymanagementapi/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/apigatewayv2/src/main/resources/codegen-resources/customization.config
+++ b/services/apigatewayv2/src/main/resources/codegen-resources/customization.config
@@ -2,6 +2,5 @@
     "verifiedSimpleMethods": [
         "getApis",
         "getDomainNames"
-    ],
-    "enableGenerateCompiledEndpointRules": true
+    ]
 }

--- a/services/appconfig/src/main/resources/codegen-resources/customization.config
+++ b/services/appconfig/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/appconfigdata/src/main/resources/codegen-resources/customization.config
+++ b/services/appconfigdata/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/appfabric/src/main/resources/codegen-resources/customization.config
+++ b/services/appfabric/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/appflow/src/main/resources/codegen-resources/customization.config
+++ b/services/appflow/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/appintegrations/src/main/resources/codegen-resources/customization.config
+++ b/services/appintegrations/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/applicationautoscaling/src/main/resources/codegen-resources/customization.config
+++ b/services/applicationautoscaling/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/applicationcostprofiler/src/main/resources/codegen-resources/customization.config
+++ b/services/applicationcostprofiler/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/applicationdiscovery/src/main/resources/codegen-resources/customization.config
+++ b/services/applicationdiscovery/src/main/resources/codegen-resources/customization.config
@@ -16,6 +16,5 @@
     "deprecatedOperations": [
         "DescribeExportConfigurations",
         "ExportConfigurations"
-    ],
-    "enableGenerateCompiledEndpointRules": true
+    ]
 }

--- a/services/applicationinsights/src/main/resources/codegen-resources/customization.config
+++ b/services/applicationinsights/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/appmesh/src/main/resources/codegen-resources/customization.config
+++ b/services/appmesh/src/main/resources/codegen-resources/customization.config
@@ -1,6 +1,5 @@
 {
     "verifiedSimpleMethods": [
         "listMeshes"
-    ],
-    "enableGenerateCompiledEndpointRules": true
+    ]
 }

--- a/services/apprunner/src/main/resources/codegen-resources/customization.config
+++ b/services/apprunner/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/appstream/src/main/resources/codegen-resources/customization.config
+++ b/services/appstream/src/main/resources/codegen-resources/customization.config
@@ -9,6 +9,5 @@
         "describeImageBuilders",
         "describeImages",
         "describeStacks"
-    ],
-    "enableGenerateCompiledEndpointRules": true
+    ]
 }

--- a/services/appsync/src/main/resources/codegen-resources/customization.config
+++ b/services/appsync/src/main/resources/codegen-resources/customization.config
@@ -1,6 +1,5 @@
 {
     "verifiedSimpleMethods": [
         "listGraphqlApis"
-    ],
-    "enableGenerateCompiledEndpointRules": true
+    ]
 }

--- a/services/arczonalshift/src/main/resources/codegen-resources/customization.config
+++ b/services/arczonalshift/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/artifact/src/main/resources/codegen-resources/customization.config
+++ b/services/artifact/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/athena/src/main/resources/codegen-resources/customization.config
+++ b/services/athena/src/main/resources/codegen-resources/customization.config
@@ -2,6 +2,5 @@
     "verifiedSimpleMethods": [
         "listNamedQueries",
         "listQueryExecutions"
-    ],
-    "enableGenerateCompiledEndpointRules": true
+    ]
 }

--- a/services/auditmanager/src/main/resources/codegen-resources/customization.config
+++ b/services/auditmanager/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/autoscaling/src/main/resources/codegen-resources/customization.config
+++ b/services/autoscaling/src/main/resources/codegen-resources/customization.config
@@ -15,8 +15,6 @@
         "describeScheduledActions",
         "describeTags",
         "describeTerminationPolicyTypes"
-    ],
-
-    "enableGenerateCompiledEndpointRules": true
+    ]
 
 }

--- a/services/autoscalingplans/src/main/resources/codegen-resources/customization.config
+++ b/services/autoscalingplans/src/main/resources/codegen-resources/customization.config
@@ -1,6 +1,5 @@
 {
     "verifiedSimpleMethods": [
         "describeScalingPlans"
-    ],
-    "enableGenerateCompiledEndpointRules": true
+    ]
 }

--- a/services/b2bi/src/main/resources/codegen-resources/customization.config
+++ b/services/b2bi/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/backup/src/main/resources/codegen-resources/customization.config
+++ b/services/backup/src/main/resources/codegen-resources/customization.config
@@ -9,6 +9,5 @@
         "listBackupVaults",
         "listProtectedResources",
         "listRestoreJobs"
-    ],
-    "enableGenerateCompiledEndpointRules": true
+    ]
 }

--- a/services/backupgateway/src/main/resources/codegen-resources/customization.config
+++ b/services/backupgateway/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/batch/src/main/resources/codegen-resources/customization.config
+++ b/services/batch/src/main/resources/codegen-resources/customization.config
@@ -6,6 +6,5 @@
     ],
     "excludedSimpleMethods": [
         "listJobs"
-    ],
-    "enableGenerateCompiledEndpointRules": true
+    ]
 }

--- a/services/bcmdataexports/src/main/resources/codegen-resources/customization.config
+++ b/services/bcmdataexports/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/bedrock/src/main/resources/codegen-resources/customization.config
+++ b/services/bedrock/src/main/resources/codegen-resources/customization.config
@@ -1,4 +1,3 @@
 {
-    "enableGenerateCompiledEndpointRules": true,
     "enableEnvironmentBearerToken": true
 }

--- a/services/bedrockagent/src/main/resources/codegen-resources/customization.config
+++ b/services/bedrockagent/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/bedrockagentruntime/src/main/resources/codegen-resources/customization.config
+++ b/services/bedrockagentruntime/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/bedrockruntime/src/main/resources/codegen-resources/customization.config
+++ b/services/bedrockruntime/src/main/resources/codegen-resources/customization.config
@@ -1,4 +1,3 @@
 {
-    "enableGenerateCompiledEndpointRules": true,
     "enableEnvironmentBearerToken": true
 }

--- a/services/billingconductor/src/main/resources/codegen-resources/customization.config
+++ b/services/billingconductor/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/braket/src/main/resources/codegen-resources/customization.config
+++ b/services/braket/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/budgets/src/main/resources/codegen-resources/customization.config
+++ b/services/budgets/src/main/resources/codegen-resources/customization.config
@@ -9,6 +9,5 @@
                 }
             ]
         }
-    },
-    "enableGenerateCompiledEndpointRules": true
+    }
 }

--- a/services/chatbot/src/main/resources/codegen-resources/customization.config
+++ b/services/chatbot/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/chime/src/main/resources/codegen-resources/customization.config
+++ b/services/chime/src/main/resources/codegen-resources/customization.config
@@ -2,6 +2,5 @@
     "verifiedSimpleMethods": [
         "listAccounts"
     ],
-    "generateEndpointClientTests": true,
-    "enableGenerateCompiledEndpointRules": true
+    "generateEndpointClientTests": true
 }

--- a/services/chimesdkidentity/src/main/resources/codegen-resources/customization.config
+++ b/services/chimesdkidentity/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/chimesdkmediapipelines/src/main/resources/codegen-resources/customization.config
+++ b/services/chimesdkmediapipelines/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/chimesdkmeetings/src/main/resources/codegen-resources/customization.config
+++ b/services/chimesdkmeetings/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/chimesdkmessaging/src/main/resources/codegen-resources/customization.config
+++ b/services/chimesdkmessaging/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/chimesdkvoice/src/main/resources/codegen-resources/customization.config
+++ b/services/chimesdkvoice/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/cleanrooms/src/main/resources/codegen-resources/customization.config
+++ b/services/cleanrooms/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/cleanroomsml/src/main/resources/codegen-resources/customization.config
+++ b/services/cleanroomsml/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/cloud9/src/main/resources/codegen-resources/customization.config
+++ b/services/cloud9/src/main/resources/codegen-resources/customization.config
@@ -2,6 +2,5 @@
     "verifiedSimpleMethods": [
         "describeEnvironmentMemberships",
         "listEnvironments"
-    ],
-    "enableGenerateCompiledEndpointRules": true
+    ]
 }

--- a/services/cloudcontrol/src/main/resources/codegen-resources/customization.config
+++ b/services/cloudcontrol/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/clouddirectory/src/main/resources/codegen-resources/customization.config
+++ b/services/clouddirectory/src/main/resources/codegen-resources/customization.config
@@ -9,6 +9,5 @@
         "TypedAttributeValue": {
             "union": true
         }
-    },
-    "enableGenerateCompiledEndpointRules": true
+    }
 }

--- a/services/cloudformation/src/main/resources/codegen-resources/customization.config
+++ b/services/cloudformation/src/main/resources/codegen-resources/customization.config
@@ -24,8 +24,6 @@
         "describeStackResources",
         "describeStackEvents",
         "getTemplateSummary"
-    ],
-
-    "enableGenerateCompiledEndpointRules": true
+    ]
 
 }

--- a/services/cloudfront/src/main/resources/codegen-resources/customization.config
+++ b/services/cloudfront/src/main/resources/codegen-resources/customization.config
@@ -10,8 +10,6 @@
     "utilitiesMethod": {
         "returnType": "software.amazon.awssdk.services.cloudfront.CloudFrontUtilities",
         "createMethodParams": []
-    },
-
-    "enableGenerateCompiledEndpointRules": true
+    }
 
 }

--- a/services/cloudfrontkeyvaluestore/src/main/resources/codegen-resources/customization.config
+++ b/services/cloudfrontkeyvaluestore/src/main/resources/codegen-resources/customization.config
@@ -1,4 +1,3 @@
 {
-    "enableGenerateCompiledEndpointRules": true,
     "enableEndpointAuthSchemeParams": true
 }

--- a/services/cloudhsm/src/main/resources/codegen-resources/customization.config
+++ b/services/cloudhsm/src/main/resources/codegen-resources/customization.config
@@ -29,6 +29,5 @@
         "listHapgs",
         "listHsms",
         "listLunaClients"
-    ],
-    "enableGenerateCompiledEndpointRules": true
+    ]
 }

--- a/services/cloudhsmv2/src/main/resources/codegen-resources/customization.config
+++ b/services/cloudhsmv2/src/main/resources/codegen-resources/customization.config
@@ -2,6 +2,5 @@
     "verifiedSimpleMethods": [
         "describeBackups",
         "describeClusters"
-    ],
-    "enableGenerateCompiledEndpointRules": true
+    ]
 }

--- a/services/cloudsearch/src/main/resources/codegen-resources/customization.config
+++ b/services/cloudsearch/src/main/resources/codegen-resources/customization.config
@@ -2,8 +2,6 @@
     "verifiedSimpleMethods": [
         "describeDomains",
         "listDomainNames"
-    ],
-
-    "enableGenerateCompiledEndpointRules": true
+    ]
 
 }

--- a/services/cloudsearchdomain/src/main/resources/codegen-resources/customization.config
+++ b/services/cloudsearchdomain/src/main/resources/codegen-resources/customization.config
@@ -23,6 +23,5 @@
     },
     "interceptors": [
         "software.amazon.awssdk.services.cloudsearchdomain.internal.SwitchToPostInterceptor"
-    ],
-    "enableGenerateCompiledEndpointRules": true
+    ]
 }

--- a/services/cloudtrail/src/main/resources/codegen-resources/customization.config
+++ b/services/cloudtrail/src/main/resources/codegen-resources/customization.config
@@ -6,6 +6,5 @@
         "describeTrails",
         "listPublicKeys",
         "lookupEvents"
-    ],
-    "enableGenerateCompiledEndpointRules": true
+    ]
 }

--- a/services/cloudtraildata/src/main/resources/codegen-resources/customization.config
+++ b/services/cloudtraildata/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/cloudwatch/src/main/resources/codegen-resources/customization.config
+++ b/services/cloudwatch/src/main/resources/codegen-resources/customization.config
@@ -9,8 +9,6 @@
         "deleteDashboards",
         "putDashboard",
         "getDashboard"
-    ],
-
-    "enableGenerateCompiledEndpointRules": true
+    ]
 
 }

--- a/services/cloudwatchevents/src/main/resources/codegen-resources/customization.config
+++ b/services/cloudwatchevents/src/main/resources/codegen-resources/customization.config
@@ -2,6 +2,5 @@
     "verifiedSimpleMethods": [
         "describeEventBus",
         "listRules"
-    ],
-    "enableGenerateCompiledEndpointRules": true
+    ]
 }

--- a/services/cloudwatchlogs/src/main/resources/codegen-resources/customization.config
+++ b/services/cloudwatchlogs/src/main/resources/codegen-resources/customization.config
@@ -13,6 +13,5 @@
     ],
     "paginationCustomization": {
         "GetLogEvents": "LastPageHasPreviousToken"
-    },
-    "enableGenerateCompiledEndpointRules": true
+    }
 }

--- a/services/codeartifact/src/main/resources/codegen-resources/customization.config
+++ b/services/codeartifact/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/codebuild/src/main/resources/codegen-resources/customization.config
+++ b/services/codebuild/src/main/resources/codegen-resources/customization.config
@@ -4,6 +4,5 @@
         "listCuratedEnvironmentImages",
         "listProjects",
         "listSourceCredentials"
-    ],
-    "enableGenerateCompiledEndpointRules": true
+    ]
 }

--- a/services/codecatalyst/src/main/resources/codegen-resources/customization.config
+++ b/services/codecatalyst/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/codecommit/src/main/resources/codegen-resources/customization.config
+++ b/services/codecommit/src/main/resources/codegen-resources/customization.config
@@ -4,6 +4,5 @@
     ],
     "excludedSimpleMethods": [
         "getBranch"
-    ],
-    "enableGenerateCompiledEndpointRules": true
+    ]
 }

--- a/services/codedeploy/src/main/resources/codegen-resources/customization.config
+++ b/services/codedeploy/src/main/resources/codegen-resources/customization.config
@@ -30,6 +30,5 @@
         "InstanceIdRequiredException",
         "InstanceStatus",
         "InstanceSummary"
-    ],
-    "enableGenerateCompiledEndpointRules": true
+    ]
 }

--- a/services/codeguruprofiler/src/main/resources/codegen-resources/customization.config
+++ b/services/codeguruprofiler/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/codegurureviewer/src/main/resources/codegen-resources/customization.config
+++ b/services/codegurureviewer/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/codegurusecurity/src/main/resources/codegen-resources/customization.config
+++ b/services/codegurusecurity/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/codepipeline/src/main/resources/codegen-resources/customization.config
+++ b/services/codepipeline/src/main/resources/codegen-resources/customization.config
@@ -7,6 +7,5 @@
     "excludedSimpleMethods": [
         "deregisterWebhookWithThirdParty",
         "registerWebhookWithThirdParty"
-    ],
-    "enableGenerateCompiledEndpointRules": true
+    ]
 }

--- a/services/codestarconnections/src/main/resources/codegen-resources/customization.config
+++ b/services/codestarconnections/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/codestarnotifications/src/main/resources/codegen-resources/customization.config
+++ b/services/codestarnotifications/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/cognitoidentity/src/main/resources/codegen-resources/customization.config
+++ b/services/cognitoidentity/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/cognitoidentityprovider/src/main/resources/codegen-resources/customization.config
+++ b/services/cognitoidentityprovider/src/main/resources/codegen-resources/customization.config
@@ -1,5 +1,4 @@
 {
-    "enableGenerateCompiledEndpointRules": true,
     "excludedSimpleMethods" : [
         "associateSoftwareToken"
     ],

--- a/services/cognitosync/src/main/resources/codegen-resources/customization.config
+++ b/services/cognitosync/src/main/resources/codegen-resources/customization.config
@@ -1,6 +1,5 @@
 {
     "verifiedSimpleMethods": [
         "listIdentityPoolUsage"
-    ],
-    "enableGenerateCompiledEndpointRules": true
+    ]
 }

--- a/services/comprehend/src/main/resources/codegen-resources/customization.config
+++ b/services/comprehend/src/main/resources/codegen-resources/customization.config
@@ -8,6 +8,5 @@
         "listKeyPhrasesDetectionJobs",
         "listSentimentDetectionJobs",
         "listTopicsDetectionJobs"
-    ],
-    "enableGenerateCompiledEndpointRules": true
+    ]
 }

--- a/services/comprehendmedical/src/main/resources/codegen-resources/customization.config
+++ b/services/comprehendmedical/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/computeoptimizer/src/main/resources/codegen-resources/customization.config
+++ b/services/computeoptimizer/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/config/src/main/resources/codegen-resources/customization.config
+++ b/services/config/src/main/resources/codegen-resources/customization.config
@@ -18,6 +18,5 @@
     ],
     "excludedSimpleMethods": [
         "startConfigRulesEvaluation"
-    ],
-    "enableGenerateCompiledEndpointRules": true
+    ]
 }

--- a/services/connect/src/main/resources/codegen-resources/customization.config
+++ b/services/connect/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/connectcampaigns/src/main/resources/codegen-resources/customization.config
+++ b/services/connectcampaigns/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/connectcases/src/main/resources/codegen-resources/customization.config
+++ b/services/connectcases/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/connectcontactlens/src/main/resources/codegen-resources/customization.config
+++ b/services/connectcontactlens/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/connectparticipant/src/main/resources/codegen-resources/customization.config
+++ b/services/connectparticipant/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/controltower/src/main/resources/codegen-resources/customization.config
+++ b/services/controltower/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/costandusagereport/src/main/resources/codegen-resources/customization.config
+++ b/services/costandusagereport/src/main/resources/codegen-resources/customization.config
@@ -4,6 +4,5 @@
     ],
     "excludedSimpleMethods": [
         "deleteReportDefinition"
-    ],
-    "enableGenerateCompiledEndpointRules": true
+    ]
 }

--- a/services/costexplorer/src/main/resources/codegen-resources/customization.config
+++ b/services/costexplorer/src/main/resources/codegen-resources/customization.config
@@ -1,6 +1,5 @@
 {
     "excludedSimpleMethods": [
         "getCostAndUsage"
-    ],
-    "enableGenerateCompiledEndpointRules": true
+    ]
 }

--- a/services/costoptimizationhub/src/main/resources/codegen-resources/customization.config
+++ b/services/costoptimizationhub/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/customerprofiles/src/main/resources/codegen-resources/customization.config
+++ b/services/customerprofiles/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/databasemigration/src/main/resources/codegen-resources/customization.config
+++ b/services/databasemigration/src/main/resources/codegen-resources/customization.config
@@ -15,6 +15,5 @@
     ],
     "excludedSimpleMethods": [
         "describeReplicationTaskAssessmentResults"
-    ],
-    "enableGenerateCompiledEndpointRules": true
+    ]
 }

--- a/services/databrew/src/main/resources/codegen-resources/customization.config
+++ b/services/databrew/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/dataexchange/src/main/resources/codegen-resources/customization.config
+++ b/services/dataexchange/src/main/resources/codegen-resources/customization.config
@@ -1,4 +1,3 @@
 {
-    "generateEndpointClientTests": true,
-    "enableGenerateCompiledEndpointRules": true
+    "generateEndpointClientTests": true
 }

--- a/services/datapipeline/src/main/resources/codegen-resources/customization.config
+++ b/services/datapipeline/src/main/resources/codegen-resources/customization.config
@@ -1,6 +1,5 @@
 {
     "verifiedSimpleMethods": [
         "listPipelines"
-    ],
-    "enableGenerateCompiledEndpointRules": true
+    ]
 }

--- a/services/datasync/src/main/resources/codegen-resources/customization.config
+++ b/services/datasync/src/main/resources/codegen-resources/customization.config
@@ -5,6 +5,5 @@
         "listTaskExecutions",
         "listTasks"
     ],
-    "generateEndpointClientTests": true,
-    "enableGenerateCompiledEndpointRules": true
+    "generateEndpointClientTests": true
 }

--- a/services/datazone/src/main/resources/codegen-resources/customization.config
+++ b/services/datazone/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/dax/src/main/resources/codegen-resources/customization.config
+++ b/services/dax/src/main/resources/codegen-resources/customization.config
@@ -5,6 +5,5 @@
         "describeEvents",
         "describeParameterGroups",
         "describeSubnetGroups"
-    ],
-    "enableGenerateCompiledEndpointRules": true
+    ]
 }

--- a/services/detective/src/main/resources/codegen-resources/customization.config
+++ b/services/detective/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/devicefarm/src/main/resources/codegen-resources/customization.config
+++ b/services/devicefarm/src/main/resources/codegen-resources/customization.config
@@ -14,6 +14,5 @@
         "purchaseOffering",
         "renewOffering",
         "listVPCEConfigurations"
-    ],
-    "enableGenerateCompiledEndpointRules": true
+    ]
 }

--- a/services/devopsguru/src/main/resources/codegen-resources/customization.config
+++ b/services/devopsguru/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/directconnect/src/main/resources/codegen-resources/customization.config
+++ b/services/directconnect/src/main/resources/codegen-resources/customization.config
@@ -19,6 +19,5 @@
         "DescribeConnectionLoa",
         "DescribeConnectionsOnInterconnect",
         "DescribeInterconnectLoa"
-    ],
-    "enableGenerateCompiledEndpointRules": true
+    ]
 }

--- a/services/directory/src/main/resources/codegen-resources/customization.config
+++ b/services/directory/src/main/resources/codegen-resources/customization.config
@@ -215,6 +215,5 @@
                 }
             ]
         }
-    },
-    "enableGenerateCompiledEndpointRules": true
+    }
 }

--- a/services/dlm/src/main/resources/codegen-resources/customization.config
+++ b/services/dlm/src/main/resources/codegen-resources/customization.config
@@ -1,6 +1,5 @@
 {
     "verifiedSimpleMethods": [
         "getLifecyclePolicies"
-    ],
-    "enableGenerateCompiledEndpointRules": true
+    ]
 }

--- a/services/docdb/src/main/resources/codegen-resources/customization.config
+++ b/services/docdb/src/main/resources/codegen-resources/customization.config
@@ -1,6 +1,5 @@
 {
 
-    "enableGenerateCompiledEndpointRules": true,
     "verifiedSimpleMethods" : [
         "describeDBClusterParameterGroups",
         "describeDBClusterSnapshots",

--- a/services/docdbelastic/src/main/resources/codegen-resources/customization.config
+++ b/services/docdbelastic/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/drs/src/main/resources/codegen-resources/customization.config
+++ b/services/drs/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/dynamodb/src/main/resources/codegen-resources/dynamodb/customization.config
+++ b/services/dynamodb/src/main/resources/codegen-resources/dynamodb/customization.config
@@ -37,6 +37,5 @@
   ],
   "customRetryStrategy" : "software.amazon.awssdk.services.dynamodb.DynamoDbRetryPolicy",
   "enableEndpointDiscoveryMethodRequired": true,
-  "enableGenerateCompiledEndpointRules": true,
   "enableEndpointProviderUriCaching": true
 }

--- a/services/dynamodb/src/main/resources/codegen-resources/dynamodbstreams/customization.config
+++ b/services/dynamodb/src/main/resources/codegen-resources/dynamodbstreams/customization.config
@@ -21,6 +21,5 @@
     },
     "verifiedSimpleMethods" : [
         "listStreams"
-    ],
-    "enableGenerateCompiledEndpointRules": true
+    ]
 }

--- a/services/ebs/src/main/resources/codegen-resources/customization.config
+++ b/services/ebs/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/ec2/src/main/resources/codegen-resources/customization.config
+++ b/services/ec2/src/main/resources/codegen-resources/customization.config
@@ -348,8 +348,6 @@
     "interceptors": [
         "software.amazon.awssdk.services.ec2.transform.internal.GeneratePreSignUrlInterceptor",
         "software.amazon.awssdk.services.ec2.transform.internal.TimestampFormatInterceptor"
-    ],
-
-    "enableGenerateCompiledEndpointRules": true
+    ]
 
 }

--- a/services/ec2instanceconnect/src/main/resources/codegen-resources/customization.config
+++ b/services/ec2instanceconnect/src/main/resources/codegen-resources/customization.config
@@ -1,5 +1,3 @@
 {
 
-    "enableGenerateCompiledEndpointRules": true
-
 }

--- a/services/ecr/src/main/resources/codegen-resources/customization.config
+++ b/services/ecr/src/main/resources/codegen-resources/customization.config
@@ -2,6 +2,5 @@
     "verifiedSimpleMethods": [
         "describeRepositories",
         "getAuthorizationToken"
-    ],
-    "enableGenerateCompiledEndpointRules": true
+    ]
 }

--- a/services/ecrpublic/src/main/resources/codegen-resources/customization.config
+++ b/services/ecrpublic/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/ecs/src/main/resources/codegen-resources/customization.config
+++ b/services/ecs/src/main/resources/codegen-resources/customization.config
@@ -15,6 +15,5 @@
         "registerContainerInstance",
         "submitContainerStateChange",
         "submitTaskStateChange"
-    ],
-    "enableGenerateCompiledEndpointRules": true
+    ]
 }

--- a/services/efs/src/main/resources/codegen-resources/customization.config
+++ b/services/efs/src/main/resources/codegen-resources/customization.config
@@ -4,6 +4,5 @@
     ],
     "excludedSimpleMethods": [
         "describeMountTargets"
-    ],
-    "enableGenerateCompiledEndpointRules": true
+    ]
 }

--- a/services/eks/src/main/resources/codegen-resources/customization.config
+++ b/services/eks/src/main/resources/codegen-resources/customization.config
@@ -1,6 +1,5 @@
 {
     "verifiedSimpleMethods": [
         "listClusters"
-    ],
-    "enableGenerateCompiledEndpointRules": true
+    ]
 }

--- a/services/eksauth/src/main/resources/codegen-resources/customization.config
+++ b/services/eksauth/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/elasticache/src/main/resources/codegen-resources/customization.config
+++ b/services/elasticache/src/main/resources/codegen-resources/customization.config
@@ -13,8 +13,6 @@
     "excludedSimpleMethods": [
         "describeCacheSecurityGroups",
         "listAllowedNodeTypeModifications"
-    ],
-
-    "enableGenerateCompiledEndpointRules": true
+    ]
 
 }

--- a/services/elasticbeanstalk/src/main/resources/codegen-resources/customization.config
+++ b/services/elasticbeanstalk/src/main/resources/codegen-resources/customization.config
@@ -42,8 +42,6 @@
         "describeEvents",
         "listAvailableSolutionStacks",
         "listPlatformVersions"
-    ],
-
-    "enableGenerateCompiledEndpointRules": true
+    ]
 
 }

--- a/services/elasticloadbalancing/src/main/resources/codegen-resources/customization.config
+++ b/services/elasticloadbalancing/src/main/resources/codegen-resources/customization.config
@@ -10,8 +10,6 @@
         "DuplicateAccessPointNameException": "DuplicateLoadBalancerNameException",
         "TooManyAccessPointsException": "TooManyLoadBalancersException",
         "InvalidEndPointException": "InvalidInstanceException"
-    },
-
-    "enableGenerateCompiledEndpointRules": true
+    }
 
 }

--- a/services/elasticloadbalancingv2/src/main/resources/codegen-resources/customization.config
+++ b/services/elasticloadbalancingv2/src/main/resources/codegen-resources/customization.config
@@ -8,8 +8,6 @@
     "excludedSimpleMethods": [
         "describeRules",
         "describeListeners"
-    ],
-
-    "enableGenerateCompiledEndpointRules": true
+    ]
 
 }

--- a/services/elasticsearch/src/main/resources/codegen-resources/customization.config
+++ b/services/elasticsearch/src/main/resources/codegen-resources/customization.config
@@ -6,6 +6,5 @@
         "getCompatibleElasticsearchVersions",
         "listDomainNames",
         "listElasticsearchVersions"
-    ],
-    "enableGenerateCompiledEndpointRules": true
+    ]
 }

--- a/services/emr/src/main/resources/codegen-resources/customization.config
+++ b/services/emr/src/main/resources/codegen-resources/customization.config
@@ -21,6 +21,5 @@
     ],
     "deprecatedOperations": [
         "DescribeJobFlows"
-    ],
-    "enableGenerateCompiledEndpointRules": true
+    ]
 }

--- a/services/emrcontainers/src/main/resources/codegen-resources/customization.config
+++ b/services/emrcontainers/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/emrserverless/src/main/resources/codegen-resources/customization.config
+++ b/services/emrserverless/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/entityresolution/src/main/resources/codegen-resources/customization.config
+++ b/services/entityresolution/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/eventbridge/src/main/resources/codegen-resources/customization.config
+++ b/services/eventbridge/src/main/resources/codegen-resources/customization.config
@@ -2,6 +2,5 @@
     "enableEndpointAuthSchemeParams": true,
     "allowedEndpointAuthSchemeParams": [
         "EndpointId"
-    ],
-    "enableGenerateCompiledEndpointRules": true
+    ]
 }

--- a/services/finspace/src/main/resources/codegen-resources/customization.config
+++ b/services/finspace/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/finspacedata/src/main/resources/codegen-resources/customization.config
+++ b/services/finspacedata/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/firehose/src/main/resources/codegen-resources/customization.config
+++ b/services/firehose/src/main/resources/codegen-resources/customization.config
@@ -1,6 +1,5 @@
 {
     "verifiedSimpleMethods": [
         "listDeliveryStreams"
-    ],
-    "enableGenerateCompiledEndpointRules": true
+    ]
 }

--- a/services/fis/src/main/resources/codegen-resources/customization.config
+++ b/services/fis/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/fms/src/main/resources/codegen-resources/customization.config
+++ b/services/fms/src/main/resources/codegen-resources/customization.config
@@ -4,6 +4,5 @@
         "getNotificationChannel",
         "listMemberAccounts",
         "listPolicies"
-    ],
-    "enableGenerateCompiledEndpointRules": true
+    ]
 }

--- a/services/forecast/src/main/resources/codegen-resources/customization.config
+++ b/services/forecast/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/forecastquery/src/main/resources/codegen-resources/customization.config
+++ b/services/forecastquery/src/main/resources/codegen-resources/customization.config
@@ -1,5 +1,3 @@
 {
 
-    "enableGenerateCompiledEndpointRules": true
-
 }

--- a/services/frauddetector/src/main/resources/codegen-resources/customization.config
+++ b/services/frauddetector/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/freetier/src/main/resources/codegen-resources/customization.config
+++ b/services/freetier/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/fsx/src/main/resources/codegen-resources/customization.config
+++ b/services/fsx/src/main/resources/codegen-resources/customization.config
@@ -2,6 +2,5 @@
     "verifiedSimpleMethods": [
         "describeBackups",
         "describeFileSystems"
-    ],
-    "enableGenerateCompiledEndpointRules": true
+    ]
 }

--- a/services/glacier/src/main/resources/codegen-resources/customization.config
+++ b/services/glacier/src/main/resources/codegen-resources/customization.config
@@ -1,5 +1,4 @@
 {
-    "enableGenerateCompiledEndpointRules": true,
     "customErrorCodeFieldName": "code",
     "shapeModifiers" : {
         "UploadArchiveInput" : {

--- a/services/globalaccelerator/src/main/resources/codegen-resources/customization.config
+++ b/services/globalaccelerator/src/main/resources/codegen-resources/customization.config
@@ -5,6 +5,5 @@
     "defaultSimpleMethodTestRegion": "US_WEST_2",
     "excludedSimpleMethods": [
         "describeAcceleratorAttributes"
-    ],
-    "enableGenerateCompiledEndpointRules": true
+    ]
 }

--- a/services/glue/src/main/resources/codegen-resources/customization.config
+++ b/services/glue/src/main/resources/codegen-resources/customization.config
@@ -1,6 +1,5 @@
 {
     "excludedSimpleMethods": [
         "*"
-    ],
-    "enableGenerateCompiledEndpointRules": true
+    ]
 }

--- a/services/grafana/src/main/resources/codegen-resources/customization.config
+++ b/services/grafana/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/greengrass/src/main/resources/codegen-resources/customization.config
+++ b/services/greengrass/src/main/resources/codegen-resources/customization.config
@@ -23,6 +23,5 @@
         "createSubscriptionDefinition",
         "createResourceDefinition",
         "createSoftwareUpdateJob"
-    ],
-    "enableGenerateCompiledEndpointRules": true
+    ]
 }

--- a/services/greengrassv2/src/main/resources/codegen-resources/customization.config
+++ b/services/greengrassv2/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/groundstation/src/main/resources/codegen-resources/customization.config
+++ b/services/groundstation/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/guardduty/src/main/resources/codegen-resources/customization.config
+++ b/services/guardduty/src/main/resources/codegen-resources/customization.config
@@ -8,6 +8,5 @@
         "createDetector",
         "declineInvitations",
         "deleteInvitations"
-    ],
-    "enableGenerateCompiledEndpointRules": true
+    ]
 }

--- a/services/health/src/main/resources/codegen-resources/customization.config
+++ b/services/health/src/main/resources/codegen-resources/customization.config
@@ -3,6 +3,5 @@
         "describeEvents",
         "describeEntityAggregates",
         "describeEventTypes"
-    ],
-    "enableGenerateCompiledEndpointRules": true
+    ]
 }

--- a/services/healthlake/src/main/resources/codegen-resources/customization.config
+++ b/services/healthlake/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/iam/src/main/resources/codegen-resources/customization.config
+++ b/services/iam/src/main/resources/codegen-resources/customization.config
@@ -1,6 +1,5 @@
 {
 
-  "enableGenerateCompiledEndpointRules": true,
   "verifiedSimpleMethods": [
     "createAccessKey",
     "deleteAccountPasswordPolicy",

--- a/services/identitystore/src/main/resources/codegen-resources/customization.config
+++ b/services/identitystore/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/imagebuilder/src/main/resources/codegen-resources/customization.config
+++ b/services/imagebuilder/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/inspector/src/main/resources/codegen-resources/customization.config
+++ b/services/inspector/src/main/resources/codegen-resources/customization.config
@@ -54,6 +54,5 @@
                 }
             ]
         }
-    },
-    "enableGenerateCompiledEndpointRules": true
+    }
 }

--- a/services/inspector2/src/main/resources/codegen-resources/customization.config
+++ b/services/inspector2/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/inspectorscan/src/main/resources/codegen-resources/customization.config
+++ b/services/inspectorscan/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/internetmonitor/src/main/resources/codegen-resources/customization.config
+++ b/services/internetmonitor/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/iot/src/main/resources/codegen-resources/customization.config
+++ b/services/iot/src/main/resources/codegen-resources/customization.config
@@ -48,6 +48,5 @@
         "AssetPropertyVariant": {
             "union": true
         }
-    },
-    "enableGenerateCompiledEndpointRules": true
+    }
 }

--- a/services/iotdataplane/src/main/resources/codegen-resources/customization.config
+++ b/services/iotdataplane/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/iotdeviceadvisor/src/main/resources/codegen-resources/customization.config
+++ b/services/iotdeviceadvisor/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/iotfleetwise/src/main/resources/codegen-resources/customization.config
+++ b/services/iotfleetwise/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/iotjobsdataplane/src/main/resources/codegen-resources/customization.config
+++ b/services/iotjobsdataplane/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/iotsecuretunneling/src/main/resources/codegen-resources/customization.config
+++ b/services/iotsecuretunneling/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/iotsitewise/src/main/resources/codegen-resources/customization.config
+++ b/services/iotsitewise/src/main/resources/codegen-resources/customization.config
@@ -1,4 +1,3 @@
 {
-    "generateEndpointClientTests": true,
-    "enableGenerateCompiledEndpointRules": true
+    "generateEndpointClientTests": true
 }

--- a/services/iotthingsgraph/src/main/resources/codegen-resources/customization.config
+++ b/services/iotthingsgraph/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/iottwinmaker/src/main/resources/codegen-resources/customization.config
+++ b/services/iottwinmaker/src/main/resources/codegen-resources/customization.config
@@ -1,4 +1,3 @@
 {
-    "generateEndpointClientTests": true,
-    "enableGenerateCompiledEndpointRules": true
+    "generateEndpointClientTests": true
 }

--- a/services/iotwireless/src/main/resources/codegen-resources/customization.config
+++ b/services/iotwireless/src/main/resources/codegen-resources/customization.config
@@ -1,4 +1,3 @@
 {
-    "underscoresInNameBehavior": "ALLOW",
-    "enableGenerateCompiledEndpointRules": true
+    "underscoresInNameBehavior": "ALLOW"
 }

--- a/services/ivs/src/main/resources/codegen-resources/customization.config
+++ b/services/ivs/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/ivschat/src/main/resources/codegen-resources/customization.config
+++ b/services/ivschat/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/ivsrealtime/src/main/resources/codegen-resources/customization.config
+++ b/services/ivsrealtime/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/kafka/src/main/resources/codegen-resources/customization.config
+++ b/services/kafka/src/main/resources/codegen-resources/customization.config
@@ -1,6 +1,5 @@
 {
     "verifiedSimpleMethods": [
         "listClusters"
-    ],
-    "enableGenerateCompiledEndpointRules": true
+    ]
 }

--- a/services/kafkaconnect/src/main/resources/codegen-resources/customization.config
+++ b/services/kafkaconnect/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/kendra/src/main/resources/codegen-resources/customization.config
+++ b/services/kendra/src/main/resources/codegen-resources/customization.config
@@ -3,6 +3,5 @@
         "DocumentAttributeValue": {
             "union": true
         }
-    },
-    "enableGenerateCompiledEndpointRules": true
+    }
 }

--- a/services/kendraranking/src/main/resources/codegen-resources/customization.config
+++ b/services/kendraranking/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/keyspaces/src/main/resources/codegen-resources/customization.config
+++ b/services/keyspaces/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/kinesis/src/main/resources/codegen-resources/customization.config
+++ b/services/kinesis/src/main/resources/codegen-resources/customization.config
@@ -1,5 +1,4 @@
 {
-  "enableGenerateCompiledEndpointRules": true,
   "verifiedSimpleMethods": [
     "describeLimits",
     "listStreams"

--- a/services/kinesisanalytics/src/main/resources/codegen-resources/customization.config
+++ b/services/kinesisanalytics/src/main/resources/codegen-resources/customization.config
@@ -4,6 +4,5 @@
     ],
     "excludedSimpleMethods": [
         "discoverInputSchema"
-    ],
-    "enableGenerateCompiledEndpointRules": true
+    ]
 }

--- a/services/kinesisanalyticsv2/src/main/resources/codegen-resources/customization.config
+++ b/services/kinesisanalyticsv2/src/main/resources/codegen-resources/customization.config
@@ -1,6 +1,5 @@
 {
     "verifiedSimpleMethods": [
         "listApplications"
-    ],
-    "enableGenerateCompiledEndpointRules": true
+    ]
 }

--- a/services/kinesisvideo/src/main/resources/codegen-resources/customization.config
+++ b/services/kinesisvideo/src/main/resources/codegen-resources/customization.config
@@ -5,6 +5,5 @@
     "excludedSimpleMethods": [
         "listTagsForStream",
         "describeStream"
-    ],
-    "enableGenerateCompiledEndpointRules": true
+    ]
 }

--- a/services/kinesisvideoarchivedmedia/src/main/resources/codegen-resources/customization.config
+++ b/services/kinesisvideoarchivedmedia/src/main/resources/codegen-resources/customization.config
@@ -1,6 +1,5 @@
 {
     "excludedSimpleMethods": [
         "getHLSStreamingSessionURL"
-    ],
-    "enableGenerateCompiledEndpointRules": true
+    ]
 }

--- a/services/kinesisvideomedia/src/main/resources/codegen-resources/customization.config
+++ b/services/kinesisvideomedia/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/kinesisvideosignaling/src/main/resources/codegen-resources/customization.config
+++ b/services/kinesisvideosignaling/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/kinesisvideowebrtcstorage/src/main/resources/codegen-resources/customization.config
+++ b/services/kinesisvideowebrtcstorage/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/kms/src/main/resources/codegen-resources/customization.config
+++ b/services/kms/src/main/resources/codegen-resources/customization.config
@@ -6,6 +6,5 @@
         "describeCustomKeyStores",
         "listAliases",
         "listKeys"
-    ],
-    "enableGenerateCompiledEndpointRules": true
+    ]
 }

--- a/services/lakeformation/src/main/resources/codegen-resources/customization.config
+++ b/services/lakeformation/src/main/resources/codegen-resources/customization.config
@@ -1,4 +1,3 @@
 {
-    "generateEndpointClientTests": true,
-    "enableGenerateCompiledEndpointRules": true
+    "generateEndpointClientTests": true
 }

--- a/services/lambda/src/main/resources/codegen-resources/customization.config
+++ b/services/lambda/src/main/resources/codegen-resources/customization.config
@@ -7,6 +7,5 @@
     ],
     "deprecatedOperations": [
         "InvokeAsync"
-    ],
-    "enableGenerateCompiledEndpointRules": true
+    ]
 }

--- a/services/launchwizard/src/main/resources/codegen-resources/customization.config
+++ b/services/launchwizard/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/lexmodelbuilding/src/main/resources/codegen-resources/customization.config
+++ b/services/lexmodelbuilding/src/main/resources/codegen-resources/customization.config
@@ -5,6 +5,5 @@
         "getBuiltinSlotTypes",
         "getIntents",
         "getSlotTypes"
-    ],
-    "enableGenerateCompiledEndpointRules": true
+    ]
 }

--- a/services/lexmodelsv2/src/main/resources/codegen-resources/customization.config
+++ b/services/lexmodelsv2/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/lexruntime/src/main/resources/codegen-resources/customization.config
+++ b/services/lexruntime/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/lexruntimev2/src/main/resources/codegen-resources/customization.config
+++ b/services/lexruntimev2/src/main/resources/codegen-resources/customization.config
@@ -2,6 +2,5 @@
     "customServiceMetadata": {
         "contentType": "application/json"
     },
-    "enableGenerateCompiledEndpointRules": true,
     "usePriorKnowledgeForH2": true
 }

--- a/services/licensemanager/src/main/resources/codegen-resources/customization.config
+++ b/services/licensemanager/src/main/resources/codegen-resources/customization.config
@@ -7,6 +7,5 @@
         "getServiceSettings",
         "listLicenseConfigurations",
         "listResourceInventory"
-    ],
-    "enableGenerateCompiledEndpointRules": true
+    ]
 }

--- a/services/licensemanagerlinuxsubscriptions/src/main/resources/codegen-resources/customization.config
+++ b/services/licensemanagerlinuxsubscriptions/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/licensemanagerusersubscriptions/src/main/resources/codegen-resources/customization.config
+++ b/services/licensemanagerusersubscriptions/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/lightsail/src/main/resources/codegen-resources/customization.config
+++ b/services/lightsail/src/main/resources/codegen-resources/customization.config
@@ -23,6 +23,5 @@
         "getRelationalDatabaseSnapshots",
         "getRelationalDatabases",
         "getStaticIps"
-    ],
-    "enableGenerateCompiledEndpointRules": true
+    ]
 }

--- a/services/location/src/main/resources/codegen-resources/customization.config
+++ b/services/location/src/main/resources/codegen-resources/customization.config
@@ -1,4 +1,3 @@
 {
-    "generateEndpointClientTests": true,
-    "enableGenerateCompiledEndpointRules": true
+    "generateEndpointClientTests": true
 }

--- a/services/lookoutequipment/src/main/resources/codegen-resources/customization.config
+++ b/services/lookoutequipment/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/m2/src/main/resources/codegen-resources/customization.config
+++ b/services/m2/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/machinelearning/src/main/resources/codegen-resources/customization.config
+++ b/services/machinelearning/src/main/resources/codegen-resources/customization.config
@@ -8,6 +8,5 @@
     "interceptors": [
         "software.amazon.awssdk.services.machinelearning.internal.PredictEndpointInterceptor",
         "software.amazon.awssdk.services.machinelearning.internal.RandomIdInterceptor"
-    ],
-    "enableGenerateCompiledEndpointRules": true
+    ]
 }

--- a/services/macie2/src/main/resources/codegen-resources/customization.config
+++ b/services/macie2/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/managedblockchain/src/main/resources/codegen-resources/customization.config
+++ b/services/managedblockchain/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/managedblockchainquery/src/main/resources/codegen-resources/customization.config
+++ b/services/managedblockchainquery/src/main/resources/codegen-resources/customization.config
@@ -1,5 +1,3 @@
 {
 
-    "enableGenerateCompiledEndpointRules": true
-
 }

--- a/services/marketplaceagreement/src/main/resources/codegen-resources/customization.config
+++ b/services/marketplaceagreement/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/marketplacecatalog/src/main/resources/codegen-resources/customization.config
+++ b/services/marketplacecatalog/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/marketplacecommerceanalytics/src/main/resources/codegen-resources/customization.config
+++ b/services/marketplacecommerceanalytics/src/main/resources/codegen-resources/customization.config
@@ -1,6 +1,5 @@
 {
     "renameShapes": {
         "MarketplaceCommerceAnalyticsException": "MarketplaceCommerceAnalyticsServiceException"
-    },
-    "enableGenerateCompiledEndpointRules": true
+    }
 }

--- a/services/marketplacedeployment/src/main/resources/codegen-resources/customization.config
+++ b/services/marketplacedeployment/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/marketplaceentitlement/src/main/resources/codegen-resources/customization.config
+++ b/services/marketplaceentitlement/src/main/resources/codegen-resources/customization.config
@@ -3,6 +3,5 @@
         "EntitlementValue": {
             "union": true
         }
-    },
-    "enableGenerateCompiledEndpointRules": true
+    }
 }

--- a/services/marketplacemetering/src/main/resources/codegen-resources/customization.config
+++ b/services/marketplacemetering/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/mediaconnect/src/main/resources/codegen-resources/customization.config
+++ b/services/mediaconnect/src/main/resources/codegen-resources/customization.config
@@ -2,6 +2,5 @@
     "verifiedSimpleMethods": [
         "listEntitlements",
         "listFlows"
-    ],
-    "enableGenerateCompiledEndpointRules": true
+    ]
 }

--- a/services/mediaconvert/src/main/resources/codegen-resources/customization.config
+++ b/services/mediaconvert/src/main/resources/codegen-resources/customization.config
@@ -1,6 +1,5 @@
 {
     "excludedSimpleMethods": [
         "*"
-    ],
-    "enableGenerateCompiledEndpointRules": true
+    ]
 }

--- a/services/medialive/src/main/resources/codegen-resources/customization.config
+++ b/services/medialive/src/main/resources/codegen-resources/customization.config
@@ -10,6 +10,5 @@
         "createChannel",
         "createInput",
         "createInputSecurityGroup"
-    ],
-    "enableGenerateCompiledEndpointRules": true
+    ]
 }

--- a/services/mediapackage/src/main/resources/codegen-resources/customization.config
+++ b/services/mediapackage/src/main/resources/codegen-resources/customization.config
@@ -10,6 +10,5 @@
     // Do not keep adding to this list. Require the service team to name enums like they're naming their shapes.
     "__AdTriggersElement": "AdTriggersElement",
     "__PeriodTriggersElement": "PeriodTriggersElement"
-  },
-  "enableGenerateCompiledEndpointRules": true
+  }
 }

--- a/services/mediapackagev2/src/main/resources/codegen-resources/customization.config
+++ b/services/mediapackagev2/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/mediastore/src/main/resources/codegen-resources/customization.config
+++ b/services/mediastore/src/main/resources/codegen-resources/customization.config
@@ -4,6 +4,5 @@
     ],
     "excludedSimpleMethods": [
         "describeContainer"
-    ],
-    "enableGenerateCompiledEndpointRules": true
+    ]
 }

--- a/services/mediastoredata/src/main/resources/codegen-resources/customization.config
+++ b/services/mediastoredata/src/main/resources/codegen-resources/customization.config
@@ -1,5 +1,4 @@
 {
-  "enableGenerateCompiledEndpointRules": true,
   "excludedSimpleMethods" : [
     "listItems"
   ]

--- a/services/mediatailor/src/main/resources/codegen-resources/customization.config
+++ b/services/mediatailor/src/main/resources/codegen-resources/customization.config
@@ -1,6 +1,5 @@
 {
     "verifiedSimpleMethods": [
         "listPlaybackConfigurations"
-    ],
-    "enableGenerateCompiledEndpointRules": true
+    ]
 }

--- a/services/medicalimaging/src/main/resources/codegen-resources/customization.config
+++ b/services/medicalimaging/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/memorydb/src/main/resources/codegen-resources/customization.config
+++ b/services/memorydb/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/mgn/src/main/resources/codegen-resources/customization.config
+++ b/services/mgn/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/migrationhub/src/main/resources/codegen-resources/customization.config
+++ b/services/migrationhub/src/main/resources/codegen-resources/customization.config
@@ -1,6 +1,5 @@
 {
     "excludedSimpleMethods": [
         "*"
-    ],
-    "enableGenerateCompiledEndpointRules": true
+    ]
 }

--- a/services/migrationhubconfig/src/main/resources/codegen-resources/customization.config
+++ b/services/migrationhubconfig/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/migrationhuborchestrator/src/main/resources/codegen-resources/customization.config
+++ b/services/migrationhuborchestrator/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/migrationhubrefactorspaces/src/main/resources/codegen-resources/customization.config
+++ b/services/migrationhubrefactorspaces/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/migrationhubstrategy/src/main/resources/codegen-resources/customization.config
+++ b/services/migrationhubstrategy/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/mq/src/main/resources/codegen-resources/customization.config
+++ b/services/mq/src/main/resources/codegen-resources/customization.config
@@ -6,6 +6,5 @@
     "excludedSimpleMethods": [
         "createBroker",
         "createConfiguration"
-    ],
-    "enableGenerateCompiledEndpointRules": true
+    ]
 }

--- a/services/mturk/src/main/resources/codegen-resources/customization.config
+++ b/services/mturk/src/main/resources/codegen-resources/customization.config
@@ -8,6 +8,5 @@
         "getAccountBalance",
         "listQualificationRequests",
         "listHITs"
-    ],
-    "enableGenerateCompiledEndpointRules": true
+    ]
 }

--- a/services/mwaa/src/main/resources/codegen-resources/customization.config
+++ b/services/mwaa/src/main/resources/codegen-resources/customization.config
@@ -1,4 +1,3 @@
 {
-    "generateEndpointClientTests": true,
-    "enableGenerateCompiledEndpointRules": true
+    "generateEndpointClientTests": true
 }

--- a/services/neptune/src/main/resources/codegen-resources/customization.config
+++ b/services/neptune/src/main/resources/codegen-resources/customization.config
@@ -39,8 +39,6 @@
      "interceptors": [
          "software.amazon.awssdk.services.neptune.internal.CopyDbClusterSnapshotPresignInterceptor",
          "software.amazon.awssdk.services.neptune.internal.CreateDbClusterPresignInterceptor"
-     ],
-
-    "enableGenerateCompiledEndpointRules": true
+     ]
 
 }

--- a/services/neptunedata/src/main/resources/codegen-resources/customization.config
+++ b/services/neptunedata/src/main/resources/codegen-resources/customization.config
@@ -1,4 +1,3 @@
 {
-    "customErrorCodeFieldName": "code",
-    "enableGenerateCompiledEndpointRules": true
+    "customErrorCodeFieldName": "code"
 }

--- a/services/neptunegraph/src/main/resources/codegen-resources/customization.config
+++ b/services/neptunegraph/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/networkfirewall/src/main/resources/codegen-resources/customization.config
+++ b/services/networkfirewall/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/networkmanager/src/main/resources/codegen-resources/customization.config
+++ b/services/networkmanager/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/networkmonitor/src/main/resources/codegen-resources/customization.config
+++ b/services/networkmonitor/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/oam/src/main/resources/codegen-resources/customization.config
+++ b/services/oam/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/omics/src/main/resources/codegen-resources/customization.config
+++ b/services/omics/src/main/resources/codegen-resources/customization.config
@@ -1,4 +1,3 @@
 {
-    "generateEndpointClientTests": true,
-    "enableGenerateCompiledEndpointRules": true
+    "generateEndpointClientTests": true
 }

--- a/services/opensearch/src/main/resources/codegen-resources/customization.config
+++ b/services/opensearch/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/opensearchserverless/src/main/resources/codegen-resources/customization.config
+++ b/services/opensearchserverless/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/organizations/src/main/resources/codegen-resources/customization.config
+++ b/services/organizations/src/main/resources/codegen-resources/customization.config
@@ -11,6 +11,5 @@
         "listHandshakesForAccount",
         "listRoots",
         "listAWSServiceAccessForOrganization"
-    ],
-    "enableGenerateCompiledEndpointRules": true
+    ]
 }

--- a/services/osis/src/main/resources/codegen-resources/customization.config
+++ b/services/osis/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/outposts/src/main/resources/codegen-resources/customization.config
+++ b/services/outposts/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/paymentcryptography/src/main/resources/codegen-resources/customization.config
+++ b/services/paymentcryptography/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/paymentcryptographydata/src/main/resources/codegen-resources/customization.config
+++ b/services/paymentcryptographydata/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/pcaconnectorad/src/main/resources/codegen-resources/customization.config
+++ b/services/pcaconnectorad/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/personalize/src/main/resources/codegen-resources/customization.config
+++ b/services/personalize/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/personalizeevents/src/main/resources/codegen-resources/customization.config
+++ b/services/personalizeevents/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/personalizeruntime/src/main/resources/codegen-resources/customization.config
+++ b/services/personalizeruntime/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/pi/src/main/resources/codegen-resources/customization.config
+++ b/services/pi/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/pinpoint/src/main/resources/codegen-resources/customization.config
+++ b/services/pinpoint/src/main/resources/codegen-resources/customization.config
@@ -5,6 +5,5 @@
     "renameShapes": {
         "__EndpointTypesElement": "EndpointTypesElement"
     },
-    "underscoresInNameBehavior": "ALLOW",
-    "enableGenerateCompiledEndpointRules": true
+    "underscoresInNameBehavior": "ALLOW"
 }

--- a/services/pinpointemail/src/main/resources/codegen-resources/customization.config
+++ b/services/pinpointemail/src/main/resources/codegen-resources/customization.config
@@ -9,6 +9,5 @@
         "listDedicatedIpPools",
         "listDeliverabilityTestReports",
         "listEmailIdentities"
-    ],
-    "enableGenerateCompiledEndpointRules": true
+    ]
 }

--- a/services/pinpointsmsvoice/src/main/resources/codegen-resources/customization.config
+++ b/services/pinpointsmsvoice/src/main/resources/codegen-resources/customization.config
@@ -1,6 +1,5 @@
 {
     "excludedSimpleMethods": [
         "listConfigurationSets"
-    ],
-    "enableGenerateCompiledEndpointRules": true
+    ]
 }

--- a/services/pinpointsmsvoicev2/src/main/resources/codegen-resources/customization.config
+++ b/services/pinpointsmsvoicev2/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/pipes/src/main/resources/codegen-resources/customization.config
+++ b/services/pipes/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/polly/src/main/resources/codegen-resources/customization.config
+++ b/services/polly/src/main/resources/codegen-resources/customization.config
@@ -3,6 +3,5 @@
         "describeVoices",
         "listLexicons",
         "listSpeechSynthesisTasks"
-    ],
-    "enableGenerateCompiledEndpointRules": true
+    ]
 }

--- a/services/pricing/src/main/resources/codegen-resources/customization.config
+++ b/services/pricing/src/main/resources/codegen-resources/customization.config
@@ -4,6 +4,5 @@
     ],
     "excludedSimpleMethods": [
         "getProducts"
-    ],
-    "enableGenerateCompiledEndpointRules": true
+    ]
 }

--- a/services/proton/src/main/resources/codegen-resources/customization.config
+++ b/services/proton/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/qbusiness/src/main/resources/codegen-resources/customization.config
+++ b/services/qbusiness/src/main/resources/codegen-resources/customization.config
@@ -1,4 +1,3 @@
 {
-    "enableGenerateCompiledEndpointRules": true,
     "usePriorKnowledgeForH2": true
 }

--- a/services/qconnect/src/main/resources/codegen-resources/customization.config
+++ b/services/qconnect/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/quicksight/src/main/resources/codegen-resources/customization.config
+++ b/services/quicksight/src/main/resources/codegen-resources/customization.config
@@ -144,6 +144,5 @@
         "DataSourceParameters": {
             "union": true
         }
-    },
-    "enableGenerateCompiledEndpointRules": true
+    }
 }

--- a/services/ram/src/main/resources/codegen-resources/customization.config
+++ b/services/ram/src/main/resources/codegen-resources/customization.config
@@ -2,6 +2,5 @@
     "verifiedSimpleMethods": [
         "getResourceShareInvitations",
         "enableSharingWithAwsOrganization"
-    ],
-    "enableGenerateCompiledEndpointRules": true
+    ]
 }

--- a/services/rbin/src/main/resources/codegen-resources/customization.config
+++ b/services/rbin/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/rds/src/main/resources/codegen-resources/customization.config
+++ b/services/rds/src/main/resources/codegen-resources/customization.config
@@ -1,6 +1,5 @@
 {
 
-    "enableGenerateCompiledEndpointRules": true,
     "shapeModifiers" : {
         "CopyDBSnapshotMessage" : {
             "inject" : [

--- a/services/rdsdata/src/main/resources/codegen-resources/customization.config
+++ b/services/rdsdata/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/redshift/src/main/resources/codegen-resources/customization.config
+++ b/services/redshift/src/main/resources/codegen-resources/customization.config
@@ -24,8 +24,6 @@
     "excludedSimpleMethods": [
         "describeTableRestoreStatus",
         "describeClusterSecurityGroups"
-    ],
-
-    "enableGenerateCompiledEndpointRules": true
+    ]
 
 }

--- a/services/redshiftdata/src/main/resources/codegen-resources/customization.config
+++ b/services/redshiftdata/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/redshiftserverless/src/main/resources/codegen-resources/customization.config
+++ b/services/redshiftserverless/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/rekognition/src/main/resources/codegen-resources/customization.config
+++ b/services/rekognition/src/main/resources/codegen-resources/customization.config
@@ -6,6 +6,5 @@
     "excludedSimpleMethods": [
         "describeTableRestoreStatus",
         "describeClusterSecurityGroups"
-    ],
-    "enableGenerateCompiledEndpointRules": true
+    ]
 }

--- a/services/repostspace/src/main/resources/codegen-resources/customization.config
+++ b/services/repostspace/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/resiliencehub/src/main/resources/codegen-resources/customization.config
+++ b/services/resiliencehub/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/resourceexplorer2/src/main/resources/codegen-resources/customization.config
+++ b/services/resourceexplorer2/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/resourcegroups/src/main/resources/codegen-resources/customization.config
+++ b/services/resourcegroups/src/main/resources/codegen-resources/customization.config
@@ -1,6 +1,5 @@
 {
     "verifiedSimpleMethods": [
         "listGroups"
-    ],
-    "enableGenerateCompiledEndpointRules": true
+    ]
 }

--- a/services/resourcegroupstaggingapi/src/main/resources/codegen-resources/customization.config
+++ b/services/resourcegroupstaggingapi/src/main/resources/codegen-resources/customization.config
@@ -2,6 +2,5 @@
     "verifiedSimpleMethods": [
         "getResources",
         "getTagKeys"
-    ],
-    "enableGenerateCompiledEndpointRules": true
+    ]
 }

--- a/services/rolesanywhere/src/main/resources/codegen-resources/customization.config
+++ b/services/rolesanywhere/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/route53/src/main/resources/codegen-resources/customization.config
+++ b/services/route53/src/main/resources/codegen-resources/customization.config
@@ -19,8 +19,6 @@
     ],
     "interceptors": [
         "software.amazon.awssdk.services.route53.internal.Route53IdInterceptor"
-    ],
-
-    "enableGenerateCompiledEndpointRules": true
+    ]
 
 }

--- a/services/route53domains/src/main/resources/codegen-resources/customization.config
+++ b/services/route53domains/src/main/resources/codegen-resources/customization.config
@@ -7,6 +7,5 @@
     "excludedSimpleMethods": [
         "viewBilling",
         "getContactReachabilityStatus"
-    ],
-    "enableGenerateCompiledEndpointRules": true
+    ]
 }

--- a/services/route53recoverycluster/src/main/resources/codegen-resources/customization.config
+++ b/services/route53recoverycluster/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/route53recoverycontrolconfig/src/main/resources/codegen-resources/customization.config
+++ b/services/route53recoverycontrolconfig/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/route53recoveryreadiness/src/main/resources/codegen-resources/customization.config
+++ b/services/route53recoveryreadiness/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/route53resolver/src/main/resources/codegen-resources/customization.config
+++ b/services/route53resolver/src/main/resources/codegen-resources/customization.config
@@ -8,6 +8,5 @@
         "listResolverEndpoints",
         "listResolverRuleAssociations",
         "listResolverRules"
-    ],
-    "enableGenerateCompiledEndpointRules": true
+    ]
 }

--- a/services/rum/src/main/resources/codegen-resources/customization.config
+++ b/services/rum/src/main/resources/codegen-resources/customization.config
@@ -1,4 +1,3 @@
 {
-    "generateEndpointClientTests": true,
-    "enableGenerateCompiledEndpointRules": true
+    "generateEndpointClientTests": true
 }

--- a/services/s3/src/main/resources/codegen-resources/customization.config
+++ b/services/s3/src/main/resources/codegen-resources/customization.config
@@ -332,7 +332,6 @@
     }
   },
 
-  "enableGenerateCompiledEndpointRules": true,
   "endpointParameters": {
     "DeleteObjectKeys": {
       "required": false,

--- a/services/s3control/src/main/resources/codegen-resources/customization.config
+++ b/services/s3control/src/main/resources/codegen-resources/customization.config
@@ -1,6 +1,5 @@
 {
 
-    "enableGenerateCompiledEndpointRules": true,
     "serviceConfig": {
       "className": "S3ControlConfiguration",
       "hasDualstackProperty": true,

--- a/services/s3outposts/src/main/resources/codegen-resources/customization.config
+++ b/services/s3outposts/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/sagemaker/src/main/resources/codegen-resources/customization.config
+++ b/services/sagemaker/src/main/resources/codegen-resources/customization.config
@@ -20,6 +20,5 @@
         "TrialComponentParameterValue": {
             "union": true
         }
-    },
-    "enableGenerateCompiledEndpointRules": true
+    }
 }

--- a/services/sagemakera2iruntime/src/main/resources/codegen-resources/customization.config
+++ b/services/sagemakera2iruntime/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/sagemakeredge/src/main/resources/codegen-resources/customization.config
+++ b/services/sagemakeredge/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/sagemakerfeaturestoreruntime/src/main/resources/codegen-resources/customization.config
+++ b/services/sagemakerfeaturestoreruntime/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/sagemakergeospatial/src/main/resources/codegen-resources/customization.config
+++ b/services/sagemakergeospatial/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/sagemakermetrics/src/main/resources/codegen-resources/customization.config
+++ b/services/sagemakermetrics/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/sagemakerruntime/src/main/resources/codegen-resources/customization.config
+++ b/services/sagemakerruntime/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/savingsplans/src/main/resources/codegen-resources/customization.config
+++ b/services/savingsplans/src/main/resources/codegen-resources/customization.config
@@ -1,6 +1,5 @@
 {
     "customServiceMetadata": {
         "contentType": "application/json"
-    },
-    "enableGenerateCompiledEndpointRules": true
+    }
 }

--- a/services/scheduler/src/main/resources/codegen-resources/customization.config
+++ b/services/scheduler/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/schemas/src/main/resources/codegen-resources/customization.config
+++ b/services/schemas/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/secretsmanager/src/main/resources/codegen-resources/customization.config
+++ b/services/secretsmanager/src/main/resources/codegen-resources/customization.config
@@ -2,6 +2,5 @@
     "verifiedSimpleMethods": [
         "getRandomPassword",
         "listSecrets"
-    ],
-    "enableGenerateCompiledEndpointRules": true
+    ]
 }

--- a/services/securityhub/src/main/resources/codegen-resources/customization.config
+++ b/services/securityhub/src/main/resources/codegen-resources/customization.config
@@ -12,6 +12,5 @@
     "excludedSimpleMethods": [
         "getEnabledStandards",
         "getInsights"
-    ],
-    "enableGenerateCompiledEndpointRules": true
+    ]
 }

--- a/services/securitylake/src/main/resources/codegen-resources/customization.config
+++ b/services/securitylake/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/serverlessapplicationrepository/src/main/resources/codegen-resources/customization.config
+++ b/services/serverlessapplicationrepository/src/main/resources/codegen-resources/customization.config
@@ -4,6 +4,5 @@
     ],
     "verifiedSimpleMethods": [
         "listApplications"
-    ],
-    "enableGenerateCompiledEndpointRules": true
+    ]
 }

--- a/services/servicecatalog/src/main/resources/codegen-resources/customization.config
+++ b/services/servicecatalog/src/main/resources/codegen-resources/customization.config
@@ -11,6 +11,5 @@
         "listTagOptions",
         "searchProvisionedProducts",
         "getAWSOrganizationsAccessStatus"
-    ],
-    "enableGenerateCompiledEndpointRules": true
+    ]
 }

--- a/services/servicecatalogappregistry/src/main/resources/codegen-resources/customization.config
+++ b/services/servicecatalogappregistry/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/servicediscovery/src/main/resources/codegen-resources/customization.config
+++ b/services/servicediscovery/src/main/resources/codegen-resources/customization.config
@@ -4,6 +4,5 @@
         "listOperations",
         "listServices"
     ],
-    "generateEndpointClientTests": true,
-    "enableGenerateCompiledEndpointRules": true
+    "generateEndpointClientTests": true
 }

--- a/services/servicequotas/src/main/resources/codegen-resources/customization.config
+++ b/services/servicequotas/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/ses/src/main/resources/codegen-resources/customization.config
+++ b/services/ses/src/main/resources/codegen-resources/customization.config
@@ -15,8 +15,6 @@
     ],
     "excludedSimpleMethods": [
         "updateAccountSendingEnabled"
-    ],
-
-    "enableGenerateCompiledEndpointRules": true
+    ]
 
 }

--- a/services/sesv2/src/main/resources/codegen-resources/customization.config
+++ b/services/sesv2/src/main/resources/codegen-resources/customization.config
@@ -1,4 +1,3 @@
 {
-    "enableGenerateCompiledEndpointRules": true,
     "enableEndpointAuthSchemeParams": true
 }

--- a/services/sfn/src/main/resources/codegen-resources/customization.config
+++ b/services/sfn/src/main/resources/codegen-resources/customization.config
@@ -4,6 +4,5 @@
         "listStateMachines"
     ],
     "serviceSpecificHttpConfig": "software.amazon.awssdk.services.sfn.internal.SfnHttpConfigurationOptions",
-    "generateEndpointClientTests": true,
-    "enableGenerateCompiledEndpointRules": true
+    "generateEndpointClientTests": true
 }

--- a/services/shield/src/main/resources/codegen-resources/customization.config
+++ b/services/shield/src/main/resources/codegen-resources/customization.config
@@ -16,6 +16,5 @@
     ],
     "deprecatedOperations": [
         "DeleteSubscription"
-    ],
-    "enableGenerateCompiledEndpointRules": true
+    ]
 }

--- a/services/signer/src/main/resources/codegen-resources/customization.config
+++ b/services/signer/src/main/resources/codegen-resources/customization.config
@@ -3,6 +3,5 @@
         "listSigningJobs",
         "listSigningPlatforms",
         "listSigningProfiles"
-    ],
-    "enableGenerateCompiledEndpointRules": true
+    ]
 }

--- a/services/snowball/src/main/resources/codegen-resources/customization.config
+++ b/services/snowball/src/main/resources/codegen-resources/customization.config
@@ -19,6 +19,5 @@
     },
     "excludedSimpleMethods": [
         "createJob"
-    ],
-    "enableGenerateCompiledEndpointRules": true
+    ]
 }

--- a/services/snowdevicemanagement/src/main/resources/codegen-resources/customization.config
+++ b/services/snowdevicemanagement/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/sns/src/main/resources/codegen-resources/customization.config
+++ b/services/sns/src/main/resources/codegen-resources/customization.config
@@ -19,8 +19,6 @@
                 }
             ]
         }
-    },
-
-    "enableGenerateCompiledEndpointRules": true
+    }
 
 }

--- a/services/sqs/src/main/resources/codegen-resources/customization.config
+++ b/services/sqs/src/main/resources/codegen-resources/customization.config
@@ -11,6 +11,5 @@
             "type": "boolean"
         }
     },
-    "enableGenerateCompiledEndpointRules": true,
     "batchManagerSupported": true
 }

--- a/services/ssm/src/main/resources/codegen-resources/customization.config
+++ b/services/ssm/src/main/resources/codegen-resources/customization.config
@@ -25,6 +25,5 @@
         "describeAssociation",
         "listComplianceItems",
         "describeMaintenanceWindowSchedule"
-    ],
-    "enableGenerateCompiledEndpointRules": true
+    ]
 }

--- a/services/ssmcontacts/src/main/resources/codegen-resources/customization.config
+++ b/services/ssmcontacts/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/ssmincidents/src/main/resources/codegen-resources/customization.config
+++ b/services/ssmincidents/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/ssmsap/src/main/resources/codegen-resources/customization.config
+++ b/services/ssmsap/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/sso/src/main/resources/codegen-resources/customization.config
+++ b/services/sso/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/ssoadmin/src/main/resources/codegen-resources/customization.config
+++ b/services/ssoadmin/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/storagegateway/src/main/resources/codegen-resources/customization.config
+++ b/services/storagegateway/src/main/resources/codegen-resources/customization.config
@@ -17,6 +17,5 @@
                 "error"
             ]
         }
-    },
-    "enableGenerateCompiledEndpointRules": true
+    }
 }

--- a/services/sts/src/main/resources/codegen-resources/customization.config
+++ b/services/sts/src/main/resources/codegen-resources/customization.config
@@ -21,6 +21,5 @@
         "UseGlobalEndpoint with legacy region `us-west-2`": "V2 does not support setting UseGlobalEndpoint. It's regional only/by default"
     },
 
-    "enableGenerateCompiledEndpointRules": true,
     "customRetryStrategy" : "software.amazon.awssdk.services.sts.internal.StsRetryStrategy"
 }

--- a/services/supplychain/src/main/resources/codegen-resources/customization.config
+++ b/services/supplychain/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/support/src/main/resources/codegen-resources/customization.config
+++ b/services/support/src/main/resources/codegen-resources/customization.config
@@ -4,6 +4,5 @@
         "describeSeverityLevels",
         "describeCases",
         "describeServices"
-    ],
-    "enableGenerateCompiledEndpointRules": true
+    ]
 }

--- a/services/supportapp/src/main/resources/codegen-resources/customization.config
+++ b/services/supportapp/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/swf/src/main/resources/codegen-resources/customization.config
+++ b/services/swf/src/main/resources/codegen-resources/customization.config
@@ -1,4 +1,3 @@
 {
-    "serviceSpecificHttpConfig": "software.amazon.awssdk.services.swf.internal.SwfHttpConfigurationOptions",
-    "enableGenerateCompiledEndpointRules": true
+    "serviceSpecificHttpConfig": "software.amazon.awssdk.services.swf.internal.SwfHttpConfigurationOptions"
 }

--- a/services/synthetics/src/main/resources/codegen-resources/customization.config
+++ b/services/synthetics/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/textract/src/main/resources/codegen-resources/customization.config
+++ b/services/textract/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/timestreamquery/src/main/resources/codegen-resources/customization.config
+++ b/services/timestreamquery/src/main/resources/codegen-resources/customization.config
@@ -1,6 +1,4 @@
 {
-    "allowEndpointOverrideForEndpointDiscoveryRequiredOperations": true,
-
-    "enableGenerateCompiledEndpointRules": true
+    "allowEndpointOverrideForEndpointDiscoveryRequiredOperations": true
 
 }

--- a/services/timestreamwrite/src/main/resources/codegen-resources/customization.config
+++ b/services/timestreamwrite/src/main/resources/codegen-resources/customization.config
@@ -1,4 +1,3 @@
 {
-    "allowEndpointOverrideForEndpointDiscoveryRequiredOperations": true,
-    "enableGenerateCompiledEndpointRules": true
+    "allowEndpointOverrideForEndpointDiscoveryRequiredOperations": true
 }

--- a/services/tnb/src/main/resources/codegen-resources/customization.config
+++ b/services/tnb/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/transcribe/src/main/resources/codegen-resources/customization.config
+++ b/services/transcribe/src/main/resources/codegen-resources/customization.config
@@ -1,5 +1,4 @@
 {
-    "enableGenerateCompiledEndpointRules": true,
     "verifiedSimpleMethods" : [
         "listTranscriptionJobs",
         "listVocabularies"

--- a/services/transcribestreaming/src/main/resources/codegen-resources/customization.config
+++ b/services/transcribestreaming/src/main/resources/codegen-resources/customization.config
@@ -1,5 +1,4 @@
 {
-    "enableGenerateCompiledEndpointRules": true,
     "serviceSpecificHttpConfig": "software.amazon.awssdk.services.transcribestreaming.internal.DefaultHttpConfigurationOptions",
     "skipSyncClientGeneration": true,
     "useLegacyEventGenerationScheme": {

--- a/services/transfer/src/main/resources/codegen-resources/customization.config
+++ b/services/transfer/src/main/resources/codegen-resources/customization.config
@@ -1,6 +1,5 @@
 {
     "verifiedSimpleMethods": [
         "listServers"
-    ],
-    "enableGenerateCompiledEndpointRules": true
+    ]
 }

--- a/services/translate/src/main/resources/codegen-resources/customization.config
+++ b/services/translate/src/main/resources/codegen-resources/customization.config
@@ -1,6 +1,5 @@
 {
     "verifiedSimpleMethods": [
         "listTerminologies"
-    ],
-    "enableGenerateCompiledEndpointRules": true
+    ]
 }

--- a/services/trustedadvisor/src/main/resources/codegen-resources/customization.config
+++ b/services/trustedadvisor/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/verifiedpermissions/src/main/resources/codegen-resources/customization.config
+++ b/services/verifiedpermissions/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/voiceid/src/main/resources/codegen-resources/customization.config
+++ b/services/voiceid/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/vpclattice/src/main/resources/codegen-resources/customization.config
+++ b/services/vpclattice/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/waf/src/main/resources/codegen-resources/customization.config
+++ b/services/waf/src/main/resources/codegen-resources/customization.config
@@ -1,5 +1,3 @@
 {
 
-    "enableGenerateCompiledEndpointRules": true
-
 }

--- a/services/wafv2/src/main/resources/codegen-resources/customization.config
+++ b/services/wafv2/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/wellarchitected/src/main/resources/codegen-resources/customization.config
+++ b/services/wellarchitected/src/main/resources/codegen-resources/customization.config
@@ -1,6 +1,5 @@
 {
     "customServiceMetadata": {
         "contentType": "application/json"
-    },
-    "enableGenerateCompiledEndpointRules": true
+    }
 }

--- a/services/wisdom/src/main/resources/codegen-resources/customization.config
+++ b/services/wisdom/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/workdocs/src/main/resources/codegen-resources/customization.config
+++ b/services/workdocs/src/main/resources/codegen-resources/customization.config
@@ -3,6 +3,5 @@
         "describeUsers",
         "describeActivities",
         "getResources"
-    ],
-    "enableGenerateCompiledEndpointRules": true
+    ]
 }

--- a/services/workmail/src/main/resources/codegen-resources/customization.config
+++ b/services/workmail/src/main/resources/codegen-resources/customization.config
@@ -1,6 +1,5 @@
 {
     "verifiedSimpleMethods": [
         "listOrganizations"
-    ],
-    "enableGenerateCompiledEndpointRules": true
+    ]
 }

--- a/services/workmailmessageflow/src/main/resources/codegen-resources/customization.config
+++ b/services/workmailmessageflow/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/workspaces/src/main/resources/codegen-resources/customization.config
+++ b/services/workspaces/src/main/resources/codegen-resources/customization.config
@@ -10,6 +10,5 @@
     "excludedSimpleMethods": [
         "describeAccountModifications",
         "describeAccount"
-    ],
-    "enableGenerateCompiledEndpointRules": true
+    ]
 }

--- a/services/workspacesthinclient/src/main/resources/codegen-resources/customization.config
+++ b/services/workspacesthinclient/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/workspacesweb/src/main/resources/codegen-resources/customization.config
+++ b/services/workspacesweb/src/main/resources/codegen-resources/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/services/xray/src/main/resources/codegen-resources/customization.config
+++ b/services/xray/src/main/resources/codegen-resources/customization.config
@@ -13,6 +13,5 @@
         "AnnotationValue": {
             "union": true
         }
-    },
-    "enableGenerateCompiledEndpointRules": true
+    }
 }

--- a/test/codegen-generated-classes-test/src/main/resources/codegen-resources/compiledrules/customization.config
+++ b/test/codegen-generated-classes-test/src/main/resources/codegen-resources/compiledrules/customization.config
@@ -1,3 +1,2 @@
 {
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/test/codegen-generated-classes-test/src/main/resources/codegen-resources/defaultretrymode/customization.config
+++ b/test/codegen-generated-classes-test/src/main/resources/codegen-resources/defaultretrymode/customization.config
@@ -1,6 +1,4 @@
 {
-    "defaultRetryMode": "STANDARD",
+    "defaultRetryMode": "STANDARD"
 
-
-    "enableGenerateCompiledEndpointRules": true
 }

--- a/test/codegen-generated-classes-test/src/main/resources/codegen-resources/endpointproviders/customization.config
+++ b/test/codegen-generated-classes-test/src/main/resources/codegen-resources/endpointproviders/customization.config
@@ -1,7 +1,6 @@
 {
     "skipEndpointTestGeneration": true,
 
-    "enableGenerateCompiledEndpointRules": false,
     "endpointParameters": {
         "PojoString": {
             "required": false,

--- a/test/codegen-generated-classes-test/src/main/resources/codegen-resources/sdkrpcv2/customization.config
+++ b/test/codegen-generated-classes-test/src/main/resources/codegen-resources/sdkrpcv2/customization.config
@@ -1,4 +1,3 @@
 {
-  "enableGenerateCompiledEndpointRules": true,
   "skipEndpointTestGeneration": true	 
 }

--- a/test/codegen-generated-classes-test/src/main/resources/codegen-resources/stringarray/customization.config
+++ b/test/codegen-generated-classes-test/src/main/resources/codegen-resources/stringarray/customization.config
@@ -1,4 +1,3 @@
 {
-    "skipEndpointTestGeneration": true,
-    "enableGenerateCompiledEndpointRules": true
+    "skipEndpointTestGeneration": true
 }

--- a/test/protocol-tests/src/main/resources/codegen-resources/json10/customization.config
+++ b/test/protocol-tests/src/main/resources/codegen-resources/json10/customization.config
@@ -1,4 +1,3 @@
 {
-    "skipEndpointTestGeneration": true,
-    "enableGenerateCompiledEndpointRules": true
+    "skipEndpointTestGeneration": true
 }

--- a/test/protocol-tests/src/main/resources/codegen-resources/sdkrpcv2/customization.config
+++ b/test/protocol-tests/src/main/resources/codegen-resources/sdkrpcv2/customization.config
@@ -1,4 +1,3 @@
 {
-  "enableGenerateCompiledEndpointRules": true,
   "skipEndpointTestGeneration": true	 
 }

--- a/test/protocol-tests/src/main/resources/codegen-resources/smithy-query/customization.config
+++ b/test/protocol-tests/src/main/resources/codegen-resources/smithy-query/customization.config
@@ -1,4 +1,3 @@
 {
-    "skipEndpointTestGeneration": true,
-    "enableGenerateCompiledEndpointRules": true
+    "skipEndpointTestGeneration": true
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
This PR is part of a series to enable compiled endpoint rules for all services. Compiled endpoint rules are already enabled for 344 services via explicit "enableGenerateCompiledEndpointRules": true entries in their customization.config files. Once the default is flipped to true (in a follow-up PR), these entries become redundant. This PR removes them proactively to clean up the configs.

This PR is part of 3 cleanup PRs, other followup PRs:


   - [Cleanup PR](https://github.com/aws/aws-sdk-java-v2/pull/7269): Removes the flag entirely from codegen, deletes the old interpreted code path, and merges the rules2 package into rules
   - [Service changes PR](https://github.com/aws/aws-sdk-java-v2/pull/7270): Migrates STS/S3 source code off deprecated internal classes
   
## Modifications

- Removed "enableGenerateCompiledEndpointRules": true from 344 service customization.config files under services/


## Testing

   - Verified zero remaining references to enableGenerateCompiledEndpointRules in service configs
 

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
