### PR TITLE
Fix dependency cve monitor list and add new workflow to verify list

### DIFF
--- a/.github/workflows/cve-monitor-list-check.yml
+++ b/.github/workflows/cve-monitor-list-check.yml
@@ -1,0 +1,54 @@
+# Ensures dependency-cve-monitor.yml stays in sync when modules are removed.
+name: "Dependency CVE Monitor Verification"
+
+on:
+  pull_request:
+  merge_group:
+
+permissions:
+  contents: read
+
+jobs:
+  verify-exclusion-list:
+    name: Verify CVE monitor exclusion list
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Validate -pl exclusion list against reactor modules
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          WORKFLOW_FILE=".github/workflows/dependency-cve-monitor.yml"
+
+          # Extract the -pl argument from the workflow file
+          PL_LINE=$(grep -oP '(?<=-pl )\S+' "$WORKFLOW_FILE")
+          if [ -z "$PL_LINE" ]; then
+            echo "Could not find -pl argument in $WORKFLOW_FILE"
+            exit 1
+          fi
+
+          # Parse individual module exclusions (remove leading '!')
+          EXCLUDED_MODULES=$(echo "$PL_LINE" | tr ',' '\n' | sed 's/^!//')
+
+          # Collect all reactor modules from root pom.xml (recursive through submodule poms)
+          REACTOR_MODULES=$(grep -ohP '(?<=<module>)[^<]+' pom.xml)
+
+          HAS_ERRORS=0
+          while IFS= read -r MODULE; do
+            if ! echo "$REACTOR_MODULES" | grep -qx "$MODULE"; then
+              echo "::error::Module '$MODULE' is excluded in $WORKFLOW_FILE but does not exist in the Maven reactor (pom.xml)"
+              HAS_ERRORS=1
+            fi
+          done <<< "$EXCLUDED_MODULES"
+
+          if [ $HAS_ERRORS -eq 1 ]; then
+            echo ""
+            echo "The -pl exclusion list in $WORKFLOW_FILE references modules that are no longer in the reactor."
+            echo "Please remove the stale entries from the exclusion list."
+            exit 1
+          fi
+
+          echo "All excluded modules are valid reactor modules."

--- a/.github/workflows/dependency-cve-monitor.yml
+++ b/.github/workflows/dependency-cve-monitor.yml
@@ -21,7 +21,7 @@ jobs:
           maven-args: >-
             -DtransitiveExcludes=*:*
             -DclasspathScope=runtime
-            -pl !build-tools,!release-scripts,!archetypes,!test/test-utils,!test/sdk-benchmarks,!test/http-client-tests,!test/http-client-benchmarks,!test/s3-benchmarks,!test/protocol-tests-core,!test/ruleset-testing-core,!test/protocol-tests,!test/service-test-utils,!test/codegen-generated-classes-test,!test/sdk-standard-benchmarks,!test/module-path-tests,!test/tests-coverage-reporting,!test/stability-tests,!test/sdk-native-image-test,!test/auth-tests,!test/region-testing,!test/old-client-version-compatibility-test,!test/bundle-logging-bridge-binding-test,!test/v2-migration-tests,!test/bundle-shading-tests,!test/crt-unavailable-tests,!test/architecture-tests,!test/s3-tests
+            -pl !build-tools,!release-scripts,!archetypes,!test/test-utils,!test/sdk-benchmarks,!test/http-client-tests,!test/http-client-benchmarks,!test/s3-benchmarks,!test/protocol-tests-core,!test/ruleset-testing-core,!test/protocol-tests,!test/service-test-utils,!test/codegen-generated-classes-test,!test/sdk-standard-benchmarks,!test/module-path-tests,!test/tests-coverage-reporting,!test/stability-tests,!test/sdk-native-image-test,!test/auth-tests,!test/service-client-backward-compat-test,!test/bundle-logging-bridge-binding-test,!test/v2-migration-tests,!test/bundle-shading-tests,!test/crt-unavailable-tests,!test/architecture-tests,!test/s3-tests
 
   notify-alerts:
     if: github.repository == 'aws/aws-sdk-java-v2'


### PR DESCRIPTION
 ## Motivation and Context
  The dependency-cve-monitor workflow started failing after #7161 removed `test/region-testing` and renamed `test/old-client-version-compatibility-test`.

  ## Modifications
  - Updated `dependency-cve-monitor.yml` to remove `test/region-testing` and fix to renamed `test/service-client-backward-compat-test`
  - Added `cve-monitor-list-check.yml` — a PR check that validates all entries in the `-pl` exclusion list still exist in the reactor, so this class of breakage is caught before merge.

  ## Testing
  Ran the validation script locally against the current pom.xml — passes with stale entries removed, fails if they're re-added.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
