### PR TITLE
Remove deleted test modules from dependency-cve-monitor exclusion list

### DIFF
--- a/.github/workflows/dependency-cve-monitor.yml
+++ b/.github/workflows/dependency-cve-monitor.yml
@@ -21,7 +21,7 @@ jobs:
           maven-args: >-
             -DtransitiveExcludes=*:*
             -DclasspathScope=runtime
-            -pl !build-tools,!release-scripts,!archetypes,!test/test-utils,!test/sdk-benchmarks,!test/http-client-tests,!test/http-client-benchmarks,!test/s3-benchmarks,!test/protocol-tests-core,!test/ruleset-testing-core,!test/protocol-tests,!test/service-test-utils,!test/codegen-generated-classes-test,!test/sdk-standard-benchmarks,!test/module-path-tests,!test/tests-coverage-reporting,!test/stability-tests,!test/sdk-native-image-test,!test/auth-tests,!test/region-testing,!test/old-client-version-compatibility-test,!test/bundle-logging-bridge-binding-test,!test/v2-migration-tests,!test/bundle-shading-tests,!test/crt-unavailable-tests,!test/architecture-tests,!test/s3-tests
+            -pl !build-tools,!release-scripts,!archetypes,!test/test-utils,!test/sdk-benchmarks,!test/http-client-tests,!test/http-client-benchmarks,!test/s3-benchmarks,!test/protocol-tests-core,!test/ruleset-testing-core,!test/protocol-tests,!test/service-test-utils,!test/codegen-generated-classes-test,!test/sdk-standard-benchmarks,!test/module-path-tests,!test/tests-coverage-reporting,!test/stability-tests,!test/sdk-native-image-test,!test/auth-tests,!test/bundle-logging-bridge-binding-test,!test/v2-migration-tests,!test/bundle-shading-tests,!test/crt-unavailable-tests,!test/architecture-tests,!test/s3-tests
 
   notify-alerts:
     if: github.repository == 'aws/aws-sdk-java-v2'


### PR DESCRIPTION
Removes `test/region-testing` and `test/old-client-version-compatibility-test` from the Maven exclusion list — both modules were recently deleted and
  cause the workflow to fail with `Could not find the selected project in the reactor`.