### PR TITLE
Add Smithy intermediate model builder and mojo activation

### DIFF
--- a/codegen-maven-plugin/pom.xml
+++ b/codegen-maven-plugin/pom.xml
@@ -63,6 +63,11 @@
             <version>${awsjavasdk.version}</version>
         </dependency>
         <dependency>
+            <groupId>software.amazon.smithy</groupId>
+            <artifactId>smithy-model</artifactId>
+            <version>${smithy.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <scope>compile</scope>

--- a/codegen-maven-plugin/src/main/java/software/amazon/awssdk/codegen/maven/plugin/GenerationMojo.java
+++ b/codegen-maven-plugin/src/main/java/software/amazon/awssdk/codegen/maven/plugin/GenerationMojo.java
@@ -46,10 +46,13 @@ import software.amazon.awssdk.codegen.model.service.EndpointRuleSetModel;
 import software.amazon.awssdk.codegen.model.service.Paginators;
 import software.amazon.awssdk.codegen.model.service.ServiceModel;
 import software.amazon.awssdk.codegen.model.service.Waiters;
+import software.amazon.awssdk.codegen.smithy.SmithyIntermediateModelBuilder;
+import software.amazon.awssdk.codegen.smithy.SmithyModels;
 import software.amazon.awssdk.codegen.utils.ModelLoaderUtils;
 import software.amazon.awssdk.codegen.validation.ModelInvalidException;
 import software.amazon.awssdk.codegen.validation.ModelValidationReport;
 import software.amazon.awssdk.utils.StringUtils;
+import software.amazon.smithy.model.Model;
 
 /**
  * The Maven mojo to generate Java client code using software.amazon.awssdk:codegen module.
@@ -57,6 +60,7 @@ import software.amazon.awssdk.utils.StringUtils;
 @Mojo(name = "generate")
 public class GenerationMojo extends AbstractMojo {
     private static final String MODEL_FILE = "service-2.json";
+    private static final String SMITHY_MODEL_FILE = "model.json";
     private static final String CUSTOMIZATION_CONFIG_FILE = "customization.config";
     private static final String WAITERS_FILE = "waiters-2.json";
     private static final String PAGINATORS_FILE = "paginators-1.json";
@@ -138,22 +142,51 @@ public class GenerationMojo extends AbstractMojo {
         return modelRoots.stream().map(r -> {
             Path modelRootPath = r.modelRoot;
             getLog().info("Loading from: " + modelRootPath.toString());
-            C2jModels c2jModels = C2jModels.builder()
-                                           .customizationConfig(r.customizationConfig)
-                                           .serviceModel(loadServiceModel(modelRootPath))
-                                           .waitersModel(loadWaiterModel(modelRootPath))
-                                           .paginatorsModel(loadPaginatorModel(modelRootPath))
-                                           .endpointRuleSetModel(loadEndpointRuleSetModel(modelRootPath))
-                                           .endpointTestSuiteModel(loadEndpointTestSuiteModel(modelRootPath))
-                                           .build();
-            String intermediateModelFileNamePrefix = intermediateModelFileNamePrefix(c2jModels);
-            IntermediateModel intermediateModel = new IntermediateModelBuilder(c2jModels).build();
-            return new GenerationParams().withIntermediateModel(intermediateModel)
-                                         .withIntermediateModelFileNamePrefix(intermediateModelFileNamePrefix);
+            // Generate from Smithy when a model.json sits alongside service-2.json, otherwise C2J.
+            if (Files.isRegularFile(modelRootPath.resolve(SMITHY_MODEL_FILE))) {
+                return smithyGenerationParams(r);
+            }
+            return c2jGenerationParams(r);
         }).collect(Collectors.toList());
     }
 
+    private GenerationParams c2jGenerationParams(ModelRoot r) {
+        Path modelRootPath = r.modelRoot;
+        C2jModels c2jModels = C2jModels.builder()
+                                       .customizationConfig(r.customizationConfig)
+                                       .serviceModel(loadServiceModel(modelRootPath))
+                                       .waitersModel(loadWaiterModel(modelRootPath))
+                                       .paginatorsModel(loadPaginatorModel(modelRootPath))
+                                       .endpointRuleSetModel(loadEndpointRuleSetModel(modelRootPath))
+                                       .endpointTestSuiteModel(loadEndpointTestSuiteModel(modelRootPath))
+                                       .build();
+        String intermediateModelFileNamePrefix = intermediateModelFileNamePrefix(c2jModels);
+        IntermediateModel intermediateModel = new IntermediateModelBuilder(c2jModels).build();
+        return new GenerationParams().withIntermediateModel(intermediateModel)
+                                     .withIntermediateModelFileNamePrefix(intermediateModelFileNamePrefix);
+    }
 
+    private GenerationParams smithyGenerationParams(ModelRoot r) {
+        Path modelRootPath = r.modelRoot;
+        getLog().info("Detected " + SMITHY_MODEL_FILE + "; generating from the Smithy model.");
+        // The plugin's own classloader carries the Smithy trait jars; Maven's thread context
+        // classloader does not reliably point at the plugin realm.
+        ClassLoader classLoader = GenerationMojo.class.getClassLoader();
+        Model model = Model.assembler(classLoader)
+                           .discoverModels(classLoader)
+                           .addImport(modelRootPath.resolve(SMITHY_MODEL_FILE))
+                           .assemble()
+                           .unwrap();
+        SmithyModels smithyModels = SmithyModels.builder()
+                                                .model(model)
+                                                .customizationConfig(r.customizationConfig)
+                                                .endpointRuleSetModel(loadEndpointRuleSetModel(modelRootPath))
+                                                .endpointTestSuiteModel(loadEndpointTestSuiteModel(modelRootPath))
+                                                .build();
+        IntermediateModel intermediateModel = new SmithyIntermediateModelBuilder(smithyModels).build();
+        return new GenerationParams().withIntermediateModel(intermediateModel)
+                                     .withIntermediateModelFileNamePrefix(null);
+    }
 
     private Stream<ModelRoot> findModelRoots() throws MojoExecutionException {
         try {

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/RemoveUnusedShapes.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/RemoveUnusedShapes.java
@@ -33,7 +33,7 @@ import software.amazon.awssdk.codegen.model.intermediate.VariableModel;
  * re-constructing the shapes map. First add the shapes referenced by the
  * operations and then adding the shapes referenced by each shapes.
  */
-final class RemoveUnusedShapes {
+public final class RemoveUnusedShapes {
 
     private RemoveUnusedShapes() {
     }

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/smithy/SmithyIntermediateModelBuilder.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/smithy/SmithyIntermediateModelBuilder.java
@@ -1,0 +1,293 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.codegen.smithy;
+
+import static software.amazon.awssdk.codegen.RemoveUnusedShapes.removeUnusedShapes;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.codegen.IntermediateModelShapeProcessor;
+import software.amazon.awssdk.codegen.internal.Constant;
+import software.amazon.awssdk.codegen.internal.TypeUtils;
+import software.amazon.awssdk.codegen.internal.Utils;
+import software.amazon.awssdk.codegen.model.config.customization.CustomizationConfig;
+import software.amazon.awssdk.codegen.model.intermediate.IntermediateModel;
+import software.amazon.awssdk.codegen.model.intermediate.MemberModel;
+import software.amazon.awssdk.codegen.model.intermediate.OperationModel;
+import software.amazon.awssdk.codegen.model.intermediate.ShapeModel;
+import software.amazon.awssdk.codegen.model.rules.endpoints.EndpointTestSuiteModel;
+import software.amazon.awssdk.codegen.model.service.AuthType;
+import software.amazon.awssdk.codegen.model.service.ClientContextParam;
+import software.amazon.awssdk.codegen.model.service.EndpointRuleSetModel;
+import software.amazon.awssdk.codegen.naming.DefaultSmithyNamingStrategy;
+import software.amazon.awssdk.codegen.naming.NamingStrategy;
+import software.amazon.awssdk.codegen.utils.ProtocolUtils;
+import software.amazon.awssdk.codegen.validation.MemberShapeTargetValidator;
+import software.amazon.awssdk.utils.CollectionUtils;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.knowledge.ServiceIndex;
+import software.amazon.smithy.model.knowledge.TopDownIndex;
+import software.amazon.smithy.model.shapes.OperationShape;
+import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.rulesengine.traits.ClientContextParamsTrait;
+
+/**
+ * Builds an {@link IntermediateModel} from a Smithy {@link Model}. Smithy counterpart to
+ * {@link software.amazon.awssdk.codegen.IntermediateModelBuilder}.
+ *
+ * <p>Customizations, paginators, and waiters are not applied yet, so this is limited to services
+ * that need none of them.
+ */
+public final class SmithyIntermediateModelBuilder {
+
+    private static final Logger log = LoggerFactory.getLogger(SmithyIntermediateModelBuilder.class);
+    private static final ShapeId UNIT = ShapeId.from("smithy.api#Unit");
+
+    private final Model model;
+    private final ServiceShape service;
+    private final CustomizationConfig customConfig;
+    private final NamingStrategy namingStrategy;
+    private final TypeUtils typeUtils;
+    private final ServiceIndex serviceIndex;
+    private final String protocol;
+    private final EndpointRuleSetModel endpointRuleSet;
+    private final EndpointTestSuiteModel endpointTestSuiteModel;
+    private final List<IntermediateModelShapeProcessor> shapeProcessors;
+
+    public SmithyIntermediateModelBuilder(SmithyModels models) {
+        this.model = models.model();
+        this.service = resolveService(model);
+        this.customConfig = models.customizationConfig();
+        this.namingStrategy = new DefaultSmithyNamingStrategy(model, service, customConfig);
+        this.typeUtils = new TypeUtils(namingStrategy);
+        this.serviceIndex = ServiceIndex.of(model);
+        this.protocol = ProtocolUtils.resolveProtocol(serviceIndex, service);
+        this.endpointRuleSet = models.endpointRuleSetModel();
+        this.endpointTestSuiteModel = models.endpointTestSuiteModel();
+        this.shapeProcessors = createShapeProcessors();
+    }
+
+    private static ServiceShape resolveService(Model model) {
+        Set<ServiceShape> services = model.getServiceShapes();
+        if (services.size() != 1) {
+            throw new IllegalArgumentException(
+                "Expected exactly one service in the Smithy model but found " + services.size());
+        }
+        return services.iterator().next();
+    }
+
+    /**
+     * Four processors where C2J has six: the input and output processors synthesize the empty
+     * request and response shapes themselves instead of leaving them to separate passes.
+     */
+    private List<IntermediateModelShapeProcessor> createShapeProcessors() {
+        List<IntermediateModelShapeProcessor> processors = new ArrayList<>();
+        processors.add(new AddSmithyInputShapes(model, service, namingStrategy, customConfig, protocol, typeUtils));
+        processors.add(new AddSmithyOutputShapes(model, service, namingStrategy, customConfig, protocol, typeUtils));
+        processors.add(new AddSmithyExceptionShapes(model, service, namingStrategy, customConfig, protocol, typeUtils));
+        processors.add(new AddSmithyModelShapes(model, service, namingStrategy, customConfig, protocol, typeUtils));
+        return processors;
+    }
+
+    public IntermediateModel build() {
+        Map<String, OperationModel> operations =
+            new TreeMap<>(new AddSmithyOperations(model, service, namingStrategy, customConfig, protocol)
+                              .constructOperations());
+
+        OperationModel endpointOperation = null;
+        boolean endpointCacheRequired = false;
+        for (OperationModel o : operations.values()) {
+            if (o.isEndpointOperation()) {
+                endpointOperation = o;
+            }
+            if (o.getEndpointDiscovery() != null && o.getEndpointDiscovery().isRequired()) {
+                endpointCacheRequired = true;
+            }
+        }
+        if (endpointOperation != null) {
+            endpointOperation.setEndpointCacheRequired(endpointCacheRequired);
+        }
+
+        Map<String, ShapeModel> shapes = new HashMap<>();
+        for (IntermediateModelShapeProcessor processor : shapeProcessors) {
+            shapes.putAll(processor.process(Collections.unmodifiableMap(operations),
+                                            Collections.unmodifiableMap(shapes)));
+        }
+
+        operations.entrySet().removeIf(e -> customConfig.getDeprecatedOperations().contains(e.getKey()));
+
+        log.info("{} shapes found in total.", shapes.size());
+
+        Map<String, ClientContextParam> clientContextParams = clientContextParams();
+
+        IntermediateModel fullModel = new IntermediateModel(
+            AddSmithyMetadata.constructMetadata(model, service, serviceIndex, namingStrategy, customConfig),
+            operations, shapes, customConfig, endpointOperation,
+            Collections.emptyMap(), namingStrategy, Collections.emptyMap(),
+            endpointRuleSet, endpointTestSuiteModel, clientContextParams);
+
+        Map<String, ShapeModel> trimmedShapes = removeUnusedShapes(fullModel);
+        trimmedShapes.entrySet().removeIf(e -> customConfig.getDeprecatedShapes().contains(e.getKey()));
+
+        log.info("{} shapes remained after removing unused shapes.", trimmedShapes.size());
+
+        IntermediateModel trimmedModel = new IntermediateModel(fullModel.getMetadata(),
+                                                               fullModel.getOperations(),
+                                                               trimmedShapes,
+                                                               customConfig,
+                                                               endpointOperation,
+                                                               fullModel.getPaginators(),
+                                                               namingStrategy,
+                                                               fullModel.getWaiters(),
+                                                               endpointRuleSet,
+                                                               endpointTestSuiteModel,
+                                                               clientContextParams);
+
+        linkMembersToShapes(trimmedModel);
+        MemberShapeTargetValidator.validate(trimmedModel);
+        linkOperationsToInputOutputShapes(trimmedModel);
+        linkCustomAuthorizationToRequestShapes(trimmedModel);
+        setSimpleMethods(trimmedModel);
+        namingStrategy.validateCustomerVisibleNaming(trimmedModel);
+        return trimmedModel;
+    }
+
+    /**
+     * Null rather than an empty map when the trait is absent, matching C2J, whose field stays null
+     * when the key is missing. Sorted by name so the generated builder settings keep a stable
+     * order; the trait's own key order is arbitrary.
+     */
+    private Map<String, ClientContextParam> clientContextParams() {
+        if (!service.hasTrait(ClientContextParamsTrait.class)) {
+            return null;
+        }
+
+        Map<String, ClientContextParam> params = new TreeMap<>();
+        service.expectTrait(ClientContextParamsTrait.class).getParameters().forEach((name, definition) -> {
+            ClientContextParam param = new ClientContextParam();
+            param.setType(definition.getType().toString());
+            definition.getDocumentation().ifPresent(param::setDocumentation);
+            params.put(name, param);
+        });
+        return params;
+    }
+
+    private void linkMembersToShapes(IntermediateModel model) {
+        for (Map.Entry<String, ShapeModel> entry : model.getShapes().entrySet()) {
+            if (entry.getValue().getMembers() != null) {
+                for (MemberModel member : entry.getValue().getMembers()) {
+                    member.setShape(Utils.findMemberShapeModelByC2jNameIfExists(model, member.getC2jShape()));
+                }
+            }
+        }
+    }
+
+    /**
+     * Output linking is skipped for {@code smithy.api#Unit}, matching how C2J treats an operation
+     * that declares no output shape.
+     */
+    private void linkOperationsToInputOutputShapes(IntermediateModel model) {
+        Map<String, OperationShape> smithyOps = new HashMap<>();
+        for (OperationShape op : TopDownIndex.of(this.model).getContainedOperations(service)) {
+            smithyOps.put(op.getId().getName(), op);
+        }
+
+        for (Map.Entry<String, OperationModel> entry : model.getOperations().entrySet()) {
+            OperationModel operationModel = entry.getValue();
+            OperationShape op = smithyOps.get(entry.getKey());
+
+            if (operationModel.getInput() != null) {
+                operationModel.setInputShape(model.getShapes().get(operationModel.getInput().getSimpleType()));
+            }
+
+            if (op != null && !UNIT.equals(op.getOutputShape())) {
+                String outputShapeName = op.getOutputShape().getName();
+                ShapeModel outputShape =
+                    model.getShapeByNameAndC2jName(operationModel.getReturnType().getReturnType(), outputShapeName);
+                operationModel.setOutputShape(outputShape);
+            }
+        }
+    }
+
+    private void linkCustomAuthorizationToRequestShapes(IntermediateModel model) {
+        model.getOperations().values().stream()
+             .filter(OperationModel::isAuthenticated)
+             .forEach(operation -> {
+                 ShapeModel shape = operation.getInputShape();
+                 if (shape == null) {
+                     throw new RuntimeException(String.format("Operation %s has unknown input shape",
+                                                              operation.getOperationName()));
+                 }
+                 linkAuthorizationToRequestShapeForAwsProtocol(operation.getAuthType(), shape);
+             });
+    }
+
+    private void linkAuthorizationToRequestShapeForAwsProtocol(AuthType authType, ShapeModel shape) {
+        if (authType == null) {
+            return;
+        }
+
+        switch (authType) {
+            case V4:
+                shape.setRequestSignerClassFqcn("software.amazon.awssdk.auth.signer.Aws4Signer");
+                break;
+            case V4_UNSIGNED_BODY:
+                shape.setRequestSignerClassFqcn("software.amazon.awssdk.auth.signer.Aws4UnsignedPayloadSigner");
+                break;
+            case BEARER:
+                shape.setRequestSignerClassFqcn("software.amazon.awssdk.auth.token.signer.aws.BearerTokenSigner");
+                break;
+            case NONE:
+                break;
+            default:
+                throw new IllegalArgumentException("Unsupported authtype for AWS Request: " + authType);
+        }
+    }
+
+    private void setSimpleMethods(IntermediateModel model) {
+        CustomizationConfig config = model.getCustomizationConfig();
+        model.getOperations().values().forEach(operation -> {
+            ShapeModel inputShape = operation.getInputShape();
+            String methodName = operation.getMethodName();
+
+            if (config.getVerifiedSimpleMethods().contains(methodName)) {
+                inputShape.setSimpleMethod(true);
+            } else {
+                inputShape.setSimpleMethod(false);
+
+                boolean methodIsNotExcluded = !config.getExcludedSimpleMethods().contains(methodName) ||
+                                              config.getExcludedSimpleMethods().stream().noneMatch(m -> m.equals("*")) ||
+                                              !config.getBlacklistedSimpleMethods().contains(methodName) ||
+                                              config.getBlacklistedSimpleMethods().stream().noneMatch(m -> m.equals("*"));
+                boolean methodHasNoRequiredMembers = CollectionUtils.isNullOrEmpty(inputShape.getRequired());
+                boolean methodIsNotStreaming = !operation.isStreaming();
+                boolean methodHasSimpleMethodVerb = methodName.matches(Constant.APPROVED_SIMPLE_METHOD_VERBS);
+
+                if (methodIsNotExcluded && methodHasNoRequiredMembers && methodIsNotStreaming && methodHasSimpleMethodVerb) {
+                    log.warn("A potential simple method exists that isn't explicitly excluded or included: " + methodName);
+                }
+            }
+        });
+    }
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/smithy/SmithyModels.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/smithy/SmithyModels.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.codegen.smithy;
+
+import software.amazon.awssdk.codegen.model.config.customization.CustomizationConfig;
+import software.amazon.awssdk.codegen.model.rules.endpoints.EndpointTestSuiteModel;
+import software.amazon.awssdk.codegen.model.service.EndpointRuleSetModel;
+import software.amazon.awssdk.utils.builder.SdkBuilder;
+import software.amazon.smithy.model.Model;
+
+/**
+ * Inputs consumed by {@link SmithyIntermediateModelBuilder}. Smithy counterpart to
+ * {@code C2jModels}.
+ *
+ * <p>Paginators and waiters are not carried yet.
+ */
+public final class SmithyModels {
+
+    private final Model model;
+    private final CustomizationConfig customizationConfig;
+    private final EndpointRuleSetModel endpointRuleSetModel;
+    private final EndpointTestSuiteModel endpointTestSuiteModel;
+
+    private SmithyModels(Model model,
+                         CustomizationConfig customizationConfig,
+                         EndpointRuleSetModel endpointRuleSetModel,
+                         EndpointTestSuiteModel endpointTestSuiteModel) {
+        this.model = model;
+        this.customizationConfig = customizationConfig;
+        this.endpointRuleSetModel = endpointRuleSetModel;
+        this.endpointTestSuiteModel = endpointTestSuiteModel;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public Model model() {
+        return model;
+    }
+
+    public CustomizationConfig customizationConfig() {
+        return customizationConfig;
+    }
+
+    public EndpointRuleSetModel endpointRuleSetModel() {
+        return endpointRuleSetModel;
+    }
+
+    public EndpointTestSuiteModel endpointTestSuiteModel() {
+        return endpointTestSuiteModel;
+    }
+
+    public static final class Builder implements SdkBuilder<Builder, SmithyModels> {
+
+        private Model model;
+        private CustomizationConfig customizationConfig;
+        private EndpointRuleSetModel endpointRuleSetModel;
+        private EndpointTestSuiteModel endpointTestSuiteModel;
+
+        private Builder() {
+        }
+
+        public Builder model(Model model) {
+            this.model = model;
+            return this;
+        }
+
+        public Builder customizationConfig(CustomizationConfig customizationConfig) {
+            this.customizationConfig = customizationConfig;
+            return this;
+        }
+
+        public Builder endpointRuleSetModel(EndpointRuleSetModel endpointRuleSetModel) {
+            this.endpointRuleSetModel = endpointRuleSetModel;
+            return this;
+        }
+
+        public Builder endpointTestSuiteModel(EndpointTestSuiteModel endpointTestSuiteModel) {
+            this.endpointTestSuiteModel = endpointTestSuiteModel;
+            return this;
+        }
+
+        @Override
+        public SmithyModels build() {
+            CustomizationConfig config = customizationConfig != null ? customizationConfig : CustomizationConfig.create();
+            return new SmithyModels(model, config, endpointRuleSetModel, endpointTestSuiteModel);
+        }
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

This builds an `IntermediateModel` from a Smithy model, and teaches the Maven mojo to use it when a `model.json` is present. It's a port of C2J's `IntermediateModelBuilder`.

The fastest way to review it is to open `IntermediateModelBuilder` next to`SmithyIntermediateModelBuilder` and work through the phase table below. Most of it is line-for-line. Four places needed real thought, and five C2J steps are missing on purpose.

## Modifications
<!--- Describe your changes in detail -->

| File | Role | C2J counterpart |
|---|---|---|
| `smithy/SmithyIntermediateModelBuilder.java` | Smithy model → `IntermediateModel` | `IntermediateModelBuilder` |
| `smithy/SmithyModels.java` | input container | `C2jModels` |
| `maven/plugin/GenerationMojo.java` | route to Smithy when `model.json` present | same file, C2J branch |
| `codegen-maven-plugin/pom.xml` | declare `smithy-model` | — |
| `RemoveUnusedShapes.java` | `final` → `public final` | — |

There's no `codegen/pom.xml` change, because `smithy-model`, `smithy-aws-traits` and`smithy-rules-engine` are already compile dependencies there. The plugin module did need `smithy-model` declared, since it now imports `Model` directly instead of picking it up transitively from `codegen`.

The only thing that reaches this builder is the mojo, and only for a model root that contains a`model.json`. No shipped service has one, so generated output doesn't change.

### Build phases

| Phase | C2J | Here |
|---|---|---|
| Operations | `AddOperations` → `TreeMap` | `AddSmithyOperations` → `TreeMap` |
| Endpoint discovery | find op, set `endpointCacheRequired` | same (Will be changed in the follow up PR) |
| Shapes | 6 processors | 4 processors — D1 |
| Deprecated operations | `removeIf` | same |
| First `IntermediateModel` | full inputs | paginators/waiters empty |
| Trim | `removeUnusedShapes` + deprecated shapes | same |
| Linking | 5 calls | same, 2 reimplemented — D3, D4 |

**D1 — four shape processors where C2J has six.** C2J runs `AddEmptyInputShape` and `AddEmptyOutputShape` as extra passes to invent request and response shapes for operations that declare none. The Smithy input and output processors do it inline, checking for `smithy.api#Unit` and calling `synthesizeEmptyRequest` or `synthesizeEmptyResponse`. Diffing the chains looks like a dropped step; the work just happens in one pass instead of two.

**D2 — two linking methods read the built model instead of the raw one.** C2J's versions reach back into its `ServiceModel`, which doesn't exist here. `linkCustomAuthorizationToRequestShapes` reads `operation.getAuthType()` off the `OperationModel` — the same value, since `AddSmithyOperations.translateAuth` sets it from the source C2J reads. `linkOperationsToInputOutputShapes` keys on `smithy.api#Unit` rather than C2J's `getOutput() != null`, which is how Smithy expresses "no output". The `op != null` guard beside it is unreachable.

**D3 — `clientContextParams` is translated from `smithy.rules#clientContextParams`.** This is the only behaviour the PR adds beyond wiring. It's not an internal field: it generates a public builder method per param, plus the key class and the endpoint-resolution wiring, so leaving it null silently removes public API rather than producing a subtly wrong model.

Two choices worth a look. It returns null rather than an empty map when the trait is absent, matching C2J, where an empty map would serialise as `{}` and read as a diff. And it sorts by name, because this map decides generated builder-method order and the trait's key order is arbitrary where C2J's happens to be alphabetical.

### Set by C2J, not here

Five steps are missing on purpose. Taken together they're the main limit on what this builder can currently handle.

| C2J step | Here |
|---|---|
| `customization.preprocess(service)` | nothing |
| `customization.postprocess(fullModel)` | nothing |
| `paginators.getPagination()` | `Collections.emptyMap()` |
| `waiters.getWaiters()` | `Collections.emptyMap()` |
| `customizeEndpointParameters`, `customizeOperationContextParams` | nothing |

The endpoint rule set and endpoint tests still come from the sidecar JSON files, passed through `SmithyModels` untouched, even though the model carries `@smithy.rules#endpointRuleSet` and `@smithy.rules#endpointTests` inline. 
following PR will prefer the trait and fall back to the sidecar.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Implemented parity fixture test, but not in this PR to keep it clean to review. 
- All 11 parity tests pass: 6 full-fidelity and 5 translation-only, covering ec2 (ec2Query), sqs (awsJson), route53 (rest-xml), sts (awsQuery) and kendraranking (rpcv2Cbor).
- Translation-only mode empties customizations, paginators and waiters on *both* sides, so the comparison isolates pure translation. 

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
