### PR TITLE
Move Kerberos proxy auth off the Netty event loop

### DIFF
--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/AwaitCloseChannelPoolMap.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/AwaitCloseChannelPoolMap.java
@@ -32,6 +32,9 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
@@ -47,6 +50,7 @@ import software.amazon.awssdk.http.nio.netty.SdkEventLoopGroup;
 import software.amazon.awssdk.http.nio.netty.internal.http2.HttpOrHttp2ChannelPool;
 import software.amazon.awssdk.http.nio.netty.internal.utils.NettyClientLogger;
 import software.amazon.awssdk.utils.StringUtils;
+import software.amazon.awssdk.utils.ThreadFactoryBuilder;
 
 /**
  * Implementation of {@link SdkChannelPoolMap} that awaits channel pools to be closed upon closing.
@@ -91,6 +95,8 @@ public final class AwaitCloseChannelPoolMap extends SdkChannelPoolMap<URI, Simpl
     private final Boolean useNonBlockingDnsResolver;
 
     private final Configuration negotiateAuthConfig;
+    private final ProxyAuthGenerator proxyAuthGenerator;
+    private final ExecutorService proxyAuthExecutor;
 
     private AwaitCloseChannelPoolMap(Builder builder, Function<Builder, BootstrapProvider> createBootStrapProvider) {
         this.configuration = builder.configuration;
@@ -105,6 +111,10 @@ public final class AwaitCloseChannelPoolMap extends SdkChannelPoolMap<URI, Simpl
         this.sslContextProvider = new SslContextProvider(configuration, protocol, protocolNegotiation, sslProvider);
         this.useNonBlockingDnsResolver = builder.useNonBlockingDnsResolver;
         this.negotiateAuthConfig = builder.negotiateAuthConfig;
+        // Both are resolved once per client rather than per pool: the proxy configuration is fixed for the life of the client,
+        // so there is no reason to duplicate the generator, or its executor, for every remote host.
+        this.proxyAuthExecutor = needsProxyAuthExecutor(proxyConfiguration) ? createProxyAuthExecutor() : null;
+        this.proxyAuthGenerator = resolveProxyAuthGenerator(proxyConfiguration, negotiateAuthConfig, proxyAuthExecutor);
     }
 
     private AwaitCloseChannelPoolMap(Builder builder) {
@@ -149,7 +159,7 @@ public final class AwaitCloseChannelPoolMap extends SdkChannelPoolMap<URI, Simpl
         if (shouldUseProxyForHost(key)) {
             tcpChannelPool = new BetterSimpleChannelPool(bootstrap, NOOP_HANDLER);
             baseChannelPool = new Http1TunnelConnectionPool(bootstrap.config().group().next(), tcpChannelPool, sslContext,
-                                            proxyAddress(key), resolveProxyAuthGenerator(proxyConfiguration),
+                                            proxyAddress(key), proxyAuthGenerator,
                                             key, pipelineInitializer, configuration);
         } else {
             tcpChannelPool = new BetterSimpleChannelPool(bootstrap, pipelineInitializer);
@@ -162,13 +172,34 @@ public final class AwaitCloseChannelPoolMap extends SdkChannelPoolMap<URI, Simpl
         return new SimpleChannelPoolAwareChannelPool(wrappedPool, tcpChannelPool);
     }
 
-    private ProxyAuthGenerator resolveProxyAuthGenerator(ProxyConfiguration proxyConfiguration) {
+    private static boolean needsProxyAuthExecutor(ProxyConfiguration proxyConfiguration) {
+        return proxyConfiguration != null && proxyConfiguration.proxyAuthScheme() == ProxyAuthScheme.NEGOTIATE;
+    }
+
+    /**
+     * Executor for auth schemes whose params are expensive to generate. A single thread, so generation is serialized: the
+     * point is only to keep the blocking work off the event loops, not to parallelize it. Daemon threaded so it never keeps
+     * the JVM alive, and shut down when this pool map is closed.
+     */
+    private static ExecutorService createProxyAuthExecutor() {
+        return Executors.newSingleThreadExecutor(new ThreadFactoryBuilder().threadNamePrefix("sdk-netty-proxy-auth")
+                                                                          .daemonThreads(true)
+                                                                          .build());
+    }
+
+    private static ProxyAuthGenerator resolveProxyAuthGenerator(ProxyConfiguration proxyConfiguration,
+                                                                Configuration negotiateAuthConfig,
+                                                                Executor proxyAuthExecutor) {
+        if (proxyConfiguration == null) {
+            return null;
+        }
+
         ProxyAuthScheme proxyAuthScheme = proxyConfiguration.proxyAuthScheme();
 
         if (proxyAuthScheme != null) {
             switch (proxyAuthScheme) {
                 case NEGOTIATE:
-                    return new NegotiateProxyAuthGenerator(negotiateAuthConfig);
+                    return new NegotiateProxyAuthGenerator(negotiateAuthConfig, proxyAuthExecutor);
                 case BASIC: {
                     String username = proxyConfiguration.username();
                     String password = proxyConfiguration.password();
@@ -203,6 +234,10 @@ public final class AwaitCloseChannelPoolMap extends SdkChannelPoolMap<URI, Simpl
         // operations. See https://github.com/aws/aws-sdk-java-v2/pull/1200#discussion_r277906715
         Collection<SimpleChannelPoolAwareChannelPool> channelPools = pools().values();
         super.close();
+
+        if (proxyAuthExecutor != null) {
+            proxyAuthExecutor.shutdownNow();
+        }
 
         try {
             CompletableFuture.allOf(channelPools.stream()

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/BasicProxyAuthGenerator.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/BasicProxyAuthGenerator.java
@@ -18,6 +18,7 @@ package software.amazon.awssdk.http.nio.netty.internal;
 import io.netty.util.CharsetUtil;
 import java.net.URI;
 import java.util.Base64;
+import java.util.concurrent.CompletableFuture;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.http.nio.netty.ProxyAuthScheme;
 import software.amazon.awssdk.utils.Validate;
@@ -43,8 +44,9 @@ public class BasicProxyAuthGenerator implements ProxyAuthGenerator {
     }
 
     @Override
-    public String generateAuthParams(URI proxyEndpoint) {
+    public CompletableFuture<String> generateAuthParams(URI proxyEndpoint) {
+        // Purely local and cheap, so this completes inline rather than hopping to another thread.
         String authToken = String.format("%s:%s", this.username, this.password);
-        return Base64.getEncoder().encodeToString(authToken.getBytes(CharsetUtil.UTF_8));
+        return CompletableFuture.completedFuture(Base64.getEncoder().encodeToString(authToken.getBytes(CharsetUtil.UTF_8)));
     }
 }

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/NegotiateProxyAuthGenerator.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/NegotiateProxyAuthGenerator.java
@@ -21,6 +21,8 @@ import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 import javax.security.auth.Subject;
 import javax.security.auth.login.AppConfigurationEntry;
 import javax.security.auth.login.Configuration;
@@ -34,6 +36,7 @@ import org.ietf.jgss.Oid;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.http.nio.netty.ProxyAuthScheme;
 import software.amazon.awssdk.utils.BinaryUtils;
+import software.amazon.awssdk.utils.Validate;
 
 /**
  * Auth generator for Kerberos. This does not login/authentication to Kerberos. It expects the ticket cache to be present and
@@ -46,17 +49,20 @@ public class NegotiateProxyAuthGenerator implements ProxyAuthGenerator {
     private static final String OID = "1.3.6.1.5.5.2";
     private static final String SERVICE_NAME = "HTTP";
     private final Configuration config;
+    private final Executor executor;
 
-    public NegotiateProxyAuthGenerator() {
-        this(createDefaultConfig());
-    }
-
-    public NegotiateProxyAuthGenerator(Configuration config) {
+    /**
+     * @param config The JAAS configuration to log in with, or null to use the default ticket-cache-only configuration.
+     * @param executor Executor to run the blocking Kerberos work on. Must not be a Netty event loop; see
+     * {@link #generateAuthParams(URI)}. Its lifecycle is owned by the caller.
+     */
+    public NegotiateProxyAuthGenerator(Configuration config, Executor executor) {
         if (config != null) {
             this.config = config;
         } else {
             this.config = createDefaultConfig();
         }
+        this.executor = Validate.paramNotNull(executor, "executor");
     }
 
     @Override
@@ -65,7 +71,14 @@ public class NegotiateProxyAuthGenerator implements ProxyAuthGenerator {
     }
 
     @Override
-    public String generateAuthParams(URI proxyEndpoint) {
+    public CompletableFuture<String> generateAuthParams(URI proxyEndpoint) {
+        // Must not run on the caller's thread: the caller is a Netty event loop thread, and the work below reads the ticket
+        // cache from disk and may make a blocking TGS request to the KDC. Blocking the loop would stall every other channel
+        // assigned to it.
+        return CompletableFuture.supplyAsync(() -> generateAuthParamsBlocking(proxyEndpoint), executor);
+    }
+
+    private String generateAuthParamsBlocking(URI proxyEndpoint) {
         try {
             Subject subject = getSubject();
 

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/ProxyAuthGenerator.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/ProxyAuthGenerator.java
@@ -16,6 +16,7 @@
 package software.amazon.awssdk.http.nio.netty.internal;
 
 import java.net.URI;
+import java.util.concurrent.CompletableFuture;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.http.nio.netty.ProxyAuthScheme;
 
@@ -31,6 +32,10 @@ public interface ProxyAuthGenerator {
 
     /**
      * Generate the auth params for this request.
+     * <p>
+     * This is asynchronous because generating the params may block - Kerberos, for example, may need to read the ticket cache
+     * from disk and contact the KDC. Implementations that block MUST complete the returned future from a thread other than the
+     * caller's; the caller is a Netty event loop thread, and blocking it would stall every other channel assigned to that loop.
      */
-    String generateAuthParams(URI proxyEndpoint);
+    CompletableFuture<String> generateAuthParams(URI proxyEndpoint);
 }

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/ProxyTunnelInitHandler.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/ProxyTunnelInitHandler.java
@@ -31,6 +31,8 @@ import io.netty.handler.codec.http.HttpVersion;
 import io.netty.util.concurrent.Promise;
 import java.io.IOException;
 import java.net.URI;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.function.Supplier;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.annotations.SdkTestInternalApi;
@@ -95,9 +97,50 @@ public final class ProxyTunnelInitHandler extends ChannelDuplexHandler {
         ChannelPipeline pipeline = ctx.pipeline();
         pipeline.addBefore(ctx.name(), null, httpCodecSupplier.get());
 
+        if (authGenerator == null) {
+            sendConnectRequest(ctx, null);
+            return;
+        }
+
+        CompletableFuture<String> authParams;
+        try {
+            authParams = authGenerator.generateAuthParams(proxyAddress);
+        } catch (Throwable t) {
+            handleConnectRequestFailure(ctx, t);
+            return;
+        }
+
+        // Basic auth completes inline, so only pay for a thread hop when the generator is actually asynchronous. When it is,
+        // the future completes on another thread, so hop back to the event loop before touching the channel or this
+        // handler's state.
+        boolean completesInline = authParams.isDone();
+        authParams.whenComplete((params, error) -> {
+            if (completesInline) {
+                sendConnectRequestWithAuth(ctx, params, error);
+            } else {
+                ctx.executor().execute(() -> sendConnectRequestWithAuth(ctx, params, error));
+            }
+        });
+    }
+
+    private void sendConnectRequestWithAuth(ChannelHandlerContext ctx, String authParams, Throwable error) {
+        // The channel may have gone away while we were waiting; whoever completed the promise has already cleaned up.
+        if (initPromise.isDone()) {
+            return;
+        }
+
+        if (error != null) {
+            handleConnectRequestFailure(ctx, unwrap(error));
+            return;
+        }
+
+        sendConnectRequest(ctx, String.format("%s %s", authGenerator.scheme().value(), authParams));
+    }
+
+    private void sendConnectRequest(ChannelHandlerContext ctx, String proxyAuthorization) {
         HttpRequest connectRequest;
         try {
-            connectRequest = connectRequest();
+            connectRequest = connectRequest(proxyAuthorization);
         } catch (Throwable t) {
             handleConnectRequestFailure(ctx, t);
             return;
@@ -108,6 +151,10 @@ public final class ProxyTunnelInitHandler extends ChannelDuplexHandler {
                 handleConnectRequestFailure(ctx, f.cause());
             }
         });
+    }
+
+    private static Throwable unwrap(Throwable t) {
+        return t instanceof CompletionException && t.getCause() != null ? t.getCause() : t;
     }
 
     @Override
@@ -170,15 +217,14 @@ public final class ProxyTunnelInitHandler extends ChannelDuplexHandler {
         sourcePool.release(ctx.channel());
     }
 
-    private HttpRequest connectRequest() {
+    private HttpRequest connectRequest(String proxyAuthorization) {
         String uri = getUri();
         HttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.CONNECT, uri,
                                                          Unpooled.EMPTY_BUFFER);
         request.headers().add(HttpHeaderNames.HOST, uri);
 
-        if (authGenerator != null) {
-            String auth = String.format("%s %s", authGenerator.scheme().value(), authGenerator.generateAuthParams(proxyAddress));
-            request.headers().add(HttpHeaderNames.PROXY_AUTHORIZATION, auth);
+        if (proxyAuthorization != null) {
+            request.headers().add(HttpHeaderNames.PROXY_AUTHORIZATION, proxyAuthorization);
         }
         
         return request;

--- a/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/BasicProxyAuthGeneratorTest.java
+++ b/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/BasicProxyAuthGeneratorTest.java
@@ -52,7 +52,7 @@ public class BasicProxyAuthGeneratorTest {
                                 .encodeToString(String.format("%s:%s", USERNAME, PASSWORD)
                                                       .getBytes(StandardCharsets.UTF_8));
 
-        assertThat(authGenerator.generateAuthParams(URI.create("http://amazon.com"))).isEqualTo(expected);
+        assertThat(authGenerator.generateAuthParams(URI.create("http://amazon.com")).join()).isEqualTo(expected);
     }
 
     private static Stream<Arguments> invalidCtorParams() {

--- a/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/Http1TunnelConnectionPoolTest.java
+++ b/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/Http1TunnelConnectionPoolTest.java
@@ -264,7 +264,7 @@ public class Http1TunnelConnectionPoolTest {
         Http1TunnelConnectionPool.InitHandlerSupplier supplier =
             (srcPool, proxyEndpoint, proxyAuthGenerator, remoteAddr, initFuture) -> {
             initFuture.setSuccess(mockChannel);
-            data.authHeader = proxyAuthGenerator.generateAuthParams(proxyEndpoint);
+            data.authHeader = proxyAuthGenerator.generateAuthParams(proxyEndpoint).join();
             return mock(ChannelHandler.class);
         };
 

--- a/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/NegotiateProxyAuthGeneratorTest.java
+++ b/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/NegotiateProxyAuthGeneratorTest.java
@@ -26,6 +26,10 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicReference;
 import javax.security.auth.login.AppConfigurationEntry;
 import javax.security.auth.login.Configuration;
 import org.apache.kerby.kerberos.kerb.KrbException;
@@ -39,6 +43,9 @@ import software.amazon.awssdk.testutils.FileUtils;
 
 public class NegotiateProxyAuthGeneratorTest {
     private static final String KRB5_PROP = "java.security.krb5.conf";
+    private static final String EXECUTOR_THREAD_NAME = "test-proxy-auth";
+    private static final ExecutorService executor =
+        Executors.newSingleThreadExecutor(r -> new Thread(r, EXECUTOR_THREAD_NAME));
     private static Path tempDir;
     private static Path keytabFile;
     private static Path ccacheFile;
@@ -104,6 +111,7 @@ public class NegotiateProxyAuthGeneratorTest {
 
     @AfterAll
     static void teardown() throws KrbException {
+        executor.shutdownNow();
         if (krb5PropSave != null) {
             System.setProperty(KRB5_PROP, krb5PropSave);
         } else {
@@ -115,11 +123,11 @@ public class NegotiateProxyAuthGeneratorTest {
 
     @Test
     void generateAuthParams_configValid_successfullyGeneratesToken() {
-        NegotiateProxyAuthGenerator authGenerator = new NegotiateProxyAuthGenerator(config);
+        NegotiateProxyAuthGenerator authGenerator = new NegotiateProxyAuthGenerator(config, executor);
 
         URI proxyEndpoint = URI.create("https://localhost:8192");
 
-        assertThat(authGenerator.generateAuthParams(proxyEndpoint)).startsWith("YII");
+        assertThat(authGenerator.generateAuthParams(proxyEndpoint).join()).startsWith("YII");
     }
 
     @Test
@@ -140,12 +148,39 @@ public class NegotiateProxyAuthGeneratorTest {
             }
         };
 
-        NegotiateProxyAuthGenerator authGenerator = new NegotiateProxyAuthGenerator(missingCacheConfig);
+        NegotiateProxyAuthGenerator authGenerator = new NegotiateProxyAuthGenerator(missingCacheConfig, executor);
 
-        assertThatThrownBy(() -> authGenerator.generateAuthParams(URI.create("https://localhost:8192")))
-            .isInstanceOf(RuntimeException.class)
+        assertThatThrownBy(() -> authGenerator.generateAuthParams(URI.create("https://localhost:8192")).join())
+            .isInstanceOf(CompletionException.class)
+            .hasCauseInstanceOf(RuntimeException.class)
             .hasMessageContaining("kinit")
             .hasMessageContaining("ticket cache");
+    }
+
+    @Test
+    void generateAuthParams_runsOnSuppliedExecutor() {
+        AtomicReference<Thread> loginThread = new AtomicReference<>();
+        Configuration recordingConfig = new Configuration() {
+            @Override
+            public AppConfigurationEntry[] getAppConfigurationEntry(String name) {
+                loginThread.set(Thread.currentThread());
+                return config.getAppConfigurationEntry(name);
+            }
+        };
+
+        new NegotiateProxyAuthGenerator(recordingConfig, executor).generateAuthParams(URI.create("https://localhost:8192"))
+                                                                 .join();
+
+        // The blocking Kerberos work must never run on the caller's thread, which in production is a Netty event loop.
+        assertThat(loginThread.get()).isNotSameAs(Thread.currentThread());
+        assertThat(loginThread.get().getName()).isEqualTo(EXECUTOR_THREAD_NAME);
+    }
+
+    @Test
+    void constructor_nullExecutor_throws() {
+        assertThatThrownBy(() -> new NegotiateProxyAuthGenerator(config, null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("executor");
     }
 
 }

--- a/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/ProxyTunnelInitHandlerTest.java
+++ b/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/ProxyTunnelInitHandlerTest.java
@@ -42,10 +42,12 @@ import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.ssl.SslCloseCompletionEvent;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.util.CharsetUtil;
+import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.Promise;
 import java.io.IOException;
 import java.net.URI;
 import java.util.Base64;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Supplier;
 import org.junit.AfterClass;
@@ -245,7 +247,6 @@ public class ProxyTunnelInitHandlerTest {
     @Test
     public void handlerAdded_authParamsGeneratorThrows_failsFuture() {
         ProxyAuthGenerator authGenerator = mock(ProxyAuthGenerator.class);
-        when(authGenerator.scheme()).thenReturn(ProxyAuthScheme.BASIC);
         when(authGenerator.generateAuthParams(any(URI.class))).thenThrow(new RuntimeException("auth generator error"));
 
         Promise<Channel> promise = GROUP.next().newPromise();
@@ -255,6 +256,55 @@ public class ProxyTunnelInitHandlerTest {
                                                                     promise);
         handler.handlerAdded(mockCtx);
 
+        assertThatThrownBy(promise::get).hasMessageContaining("Unable to send CONNECT request to proxy")
+                                        .hasRootCauseMessage("auth generator error");
+    }
+
+    @Test
+    public void handlerAdded_authParamsCompleteAsynchronously_writesRequestOnceParamsAvailable() throws Exception {
+        CompletableFuture<String> authParams = new CompletableFuture<>();
+        ProxyAuthGenerator authGenerator = mock(ProxyAuthGenerator.class);
+        when(authGenerator.scheme()).thenReturn(ProxyAuthScheme.NEGOTIATE);
+        when(authGenerator.generateAuthParams(any(URI.class))).thenReturn(authParams);
+
+        EventExecutor executor = GROUP.next();
+        when(mockCtx.executor()).thenReturn(executor);
+
+        Promise<Channel> promise = GROUP.next().newPromise();
+        ProxyTunnelInitHandler handler = new ProxyTunnelInitHandler(mockChannelPool, URI.create("https://proxy.com"),
+                                                                    authGenerator, REMOTE_HOST, promise);
+        handler.handlerAdded(mockCtx);
+
+        // The calling thread must not have waited for the auth params, so nothing is written yet.
+        verify(mockChannel, never()).writeAndFlush(any());
+
+        authParams.complete("token");
+        // Drain the executor so the queued continuation has run.
+        executor.submit(() -> { }).get();
+
+        ArgumentCaptor<HttpRequest> requestCaptor = ArgumentCaptor.forClass(HttpRequest.class);
+        verify(mockChannel).writeAndFlush(requestCaptor.capture());
+        assertThat(requestCaptor.getValue().headers().get(HttpHeaderNames.PROXY_AUTHORIZATION)).isEqualTo("Negotiate token");
+    }
+
+    @Test
+    public void handlerAdded_authParamsFailAsynchronously_failsFuture() throws Exception {
+        CompletableFuture<String> authParams = new CompletableFuture<>();
+        ProxyAuthGenerator authGenerator = mock(ProxyAuthGenerator.class);
+        when(authGenerator.generateAuthParams(any(URI.class))).thenReturn(authParams);
+
+        EventExecutor executor = GROUP.next();
+        when(mockCtx.executor()).thenReturn(executor);
+
+        Promise<Channel> promise = GROUP.next().newPromise();
+        ProxyTunnelInitHandler handler = new ProxyTunnelInitHandler(mockChannelPool, URI.create("https://proxy.com"),
+                                                                    authGenerator, REMOTE_HOST, promise);
+        handler.handlerAdded(mockCtx);
+
+        authParams.completeExceptionally(new RuntimeException("auth generator error"));
+        executor.submit(() -> { }).get();
+
+        verify(mockChannel, never()).writeAndFlush(any());
         assertThatThrownBy(promise::get).hasMessageContaining("Unable to send CONNECT request to proxy")
                                         .hasRootCauseMessage("auth generator error");
     }


### PR DESCRIPTION
Generating a SPNEGO token performs a JAAS login and may make a blocking TGS request to the KDC. That ran on the Netty event loop during proxy tunnel setup, so a slow or unreachable KDC stalled every other channel assigned to that loop, and SDK timeouts could not unpark the thread.

ProxyAuthGenerator now returns a CompletableFuture, so the contract states that generating params may be slow and must not complete on the caller's thread. Basic auth completes inline and stays on the existing synchronous path; the handler only hops threads when the future is not already done.

AwaitCloseChannelPoolMap creates the executor the Negotiate generator runs on, and shuts it down when it closes, so the resource is created and released in the same place. It is a single daemon thread, created only when NEGOTIATE is configured: the goal is to keep blocking work off the event loops, not to parallelize it. The generator itself is resolved once per client rather than once per remote host.

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Modifications
<!--- Describe your changes in detail -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
