### PR TITLE
Remove inert mutual auth request and javadoc-only import

### DIFF
--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/NegotiateProxyAuthGenerator.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/NegotiateProxyAuthGenerator.java
@@ -15,7 +15,6 @@
 
 package software.amazon.awssdk.http.nio.netty.internal;
 
-import com.sun.security.auth.module.Krb5LoginModule;
 import java.net.URI;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
@@ -72,7 +71,6 @@ public class NegotiateProxyAuthGenerator implements ProxyAuthGenerator {
             byte[] token = Subject.doAs(subject, (PrivilegedExceptionAction<byte[]>) () -> {
                 GSSContext ctx = createGssContext(getManager(), proxyEndpoint);
                 try {
-                    ctx.requestMutualAuth(true);
                     return ctx.initSecContext(new byte[0], 0, 0);
                 } finally {
                     ctx.dispose();
@@ -124,7 +122,7 @@ public class NegotiateProxyAuthGenerator implements ProxyAuthGenerator {
      * Create a generic {@link Configuration} that instructs the Kerberos login module to simply look in the ticket cache, and
      * not to prompt for passwords.
      * <p>
-     * See javadoc for {@link Krb5LoginModule} for additional info on the configuration options.
+     * See javadoc for {@code com.sun.security.auth.module.Krb5LoginModule} for additional info on the configuration options.
      */
     private static Configuration createDefaultConfig() {
         return new Configuration() {


### PR DESCRIPTION
requestMutualAuth(true) asked for mutual authentication that was never established: the proxy's response token is never consumed, so there is nothing to verify it against. Preemptive single-leg Negotiate cannot verify it either, so the call is dropped rather than wired up.

The com.sun.security.auth.module.Krb5LoginModule import existed only to satisfy a javadoc {@link}. Referring to the class by name in {@code} instead keeps the documentation while dropping a compile-time reference to a JDK-implementation-specific class.

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Modifications
<!--- Describe your changes in detail -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
