### PR TITLE
Cache auth scheme resolution

### DIFF
--- a/.changes/next-release/feature-AWSSDKforJavav2-301f836.json
+++ b/.changes/next-release/feature-AWSSDKforJavav2-301f836.json
@@ -1,0 +1,6 @@
+{
+    "type": "feature",
+    "category": "AWS SDK for Java v2",
+    "contributor": "",
+    "description": "Cache auth scheme resolution results per operation"
+}

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/auth/scheme/AuthSchemeSpecUtils.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/auth/scheme/AuthSchemeSpecUtils.java
@@ -162,6 +162,10 @@ public final class AuthSchemeSpecUtils {
         return usesSigV4a() || generateEndpointBasedParams();
     }
 
+    public boolean hasPerOperationAuthOverrides() {
+        return AuthSchemeCodegenKnowledgeIndex.of(intermediateModel).hasPerOperationAuthSchemesOverrides();
+    }
+
     private static Set<String> setOf(String val1, String val2) {
         Set<String> result = new HashSet<>();
         result.add(val1);

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/AsyncClientClass.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/AsyncClientClass.java
@@ -166,7 +166,7 @@ public final class AsyncClientClass extends AsyncClientInterface {
         model.getEndpointOperation().ifPresent(
             o -> type.addField(EndpointDiscoveryRefreshCache.class, "endpointDiscoveryCache", PRIVATE));
 
-        ClientClassUtils.authSchemeCacheField(authSchemeSpecUtils, endpointRulesSpecUtils).ifPresent(type::addField);
+        ClientClassUtils.authSchemeCacheField(authSchemeSpecUtils).ifPresent(type::addField);
     }
 
     @Override

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/AsyncClientClass.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/AsyncClientClass.java
@@ -119,24 +119,24 @@ public final class AsyncClientClass extends AsyncClientInterface {
     }
 
     @Override
-    protected TypeSpec.Builder createTypeSpec() {
+    protected Builder createTypeSpec() {
         return PoetUtils.createClassBuilder(className);
     }
 
     @Override
-    protected void addInterfaceClass(TypeSpec.Builder type) {
+    protected void addInterfaceClass(Builder type) {
         ClassName interfaceClass = poetExtensions.getClientClass(model.getMetadata().getAsyncInterface());
         type.addSuperinterface(interfaceClass)
             .addJavadoc("Internal implementation of {@link $1T}.\n\n@see $1T#builder()", interfaceClass);
     }
 
     @Override
-    protected void addAnnotations(TypeSpec.Builder type) {
+    protected void addAnnotations(Builder type) {
         type.addAnnotation(SdkInternalApi.class);
     }
 
     @Override
-    protected void addModifiers(TypeSpec.Builder type) {
+    protected void addModifiers(Builder type) {
         type.addModifiers(FINAL);
     }
 
@@ -165,6 +165,8 @@ public final class AsyncClientClass extends AsyncClientInterface {
 
         model.getEndpointOperation().ifPresent(
             o -> type.addField(EndpointDiscoveryRefreshCache.class, "endpointDiscoveryCache", PRIVATE));
+
+        ClientClassUtils.authSchemeCacheField(authSchemeSpecUtils, endpointRulesSpecUtils).ifPresent(type::addField);
     }
 
     @Override

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/ClientClassUtils.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/ClientClassUtils.java
@@ -480,6 +480,8 @@ public final class ClientClassUtils {
         builder.endControlFlow();
     }
 
+    // Any AwsExecutionAttribute added here must also be added to addAuthSchemeCacheLookup().
+    // Enforced by AuthSchemeCacheKeyConsistencyTest.
     private static void addSimpleAuthSchemeResolution(MethodSpec.Builder builder,
                                                       AuthSchemeSpecUtils authSchemeSpecUtils) {
         ClassName paramsInterface = authSchemeSpecUtils.parametersInterfaceName();

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/ClientClassUtils.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/ClientClassUtils.java
@@ -28,6 +28,8 @@ import com.squareup.javapoet.ParameterizedTypeName;
 import com.squareup.javapoet.TypeName;
 import com.squareup.javapoet.TypeVariableName;
 import com.squareup.javapoet.WildcardTypeName;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -395,19 +397,9 @@ public final class ClientClassUtils {
                              SdkInternalExecutionAttribute.class,
                              "Expected an instance of " + authSchemeSpecUtils.providerInterfaceName().simpleName());
 
-        // Use cache for simple (non-endpoint-based, non-S3) auth scheme resolution when using the default provider
-        boolean canCache = !authSchemeSpecUtils.useEndpointBasedAuthProvider() && !endpointRulesSpecUtils.isS3();
+        boolean canCache = !authSchemeSpecUtils.useEndpointBasedAuthProvider();
         if (canCache) {
-            ClassName defaultProviderClass = authSchemeSpecUtils.defaultAuthSchemeProviderName();
-            builder.addStatement("boolean useCache = requestAuthSchemeProvider == null "
-                                 + "&& authSchemeProvider instanceof $T", defaultProviderClass);
-            builder.beginControlFlow("if (useCache)");
-            builder.addStatement("$T<$T> cached = authSchemeCache.get(operationName)",
-                                 List.class, AuthSchemeOption.class);
-            builder.beginControlFlow("if (cached != null)");
-            builder.addStatement("return cached");
-            builder.endControlFlow();
-            builder.endControlFlow();
+            addAuthSchemeCacheLookup(builder, authSchemeSpecUtils);
         }
 
         if (authSchemeSpecUtils.useEndpointBasedAuthProvider()) {
@@ -418,7 +410,8 @@ public final class ClientClassUtils {
 
         if (canCache) {
             builder.beginControlFlow("if (useCache)");
-            builder.addStatement("authSchemeCache.put(operationName, options)");
+            builder.addStatement("options = $T.unmodifiableList(options)", Collections.class);
+            builder.addStatement("authSchemeCache.put(cacheKey, options)");
             builder.endControlFlow();
             builder.addStatement("return options");
         } else if (endpointRulesSpecUtils.isS3()) {
@@ -439,9 +432,8 @@ public final class ClientClassUtils {
     /**
      * Returns a field spec for the auth scheme options cache, used when simple (non-endpoint-based) auth is in effect.
      */
-    static Optional<FieldSpec> authSchemeCacheField(AuthSchemeSpecUtils authSchemeSpecUtils,
-                                                    EndpointRulesSpecUtils endpointRulesSpecUtils) {
-        if (authSchemeSpecUtils.useEndpointBasedAuthProvider() || endpointRulesSpecUtils.isS3()) {
+    static Optional<FieldSpec> authSchemeCacheField(AuthSchemeSpecUtils authSchemeSpecUtils) {
+        if (authSchemeSpecUtils.useEndpointBasedAuthProvider()) {
             return Optional.empty();
         }
         ClassName concurrentHashMap = ClassName.get("java.util.concurrent", "ConcurrentHashMap");
@@ -452,6 +444,40 @@ public final class ClientClassUtils {
         return Optional.of(FieldSpec.builder(mapType, "authSchemeCache", PRIVATE, Modifier.FINAL)
                                     .initializer("new $T<>()", concurrentHashMap)
                                     .build());
+    }
+
+    private static void addAuthSchemeCacheLookup(MethodSpec.Builder builder, AuthSchemeSpecUtils authSchemeSpecUtils) {
+        ClassName defaultProviderClass = authSchemeSpecUtils.defaultAuthSchemeProviderName();
+        builder.addStatement("boolean useCache = requestAuthSchemeProvider == null "
+                             + "&& authSchemeProvider instanceof $T", defaultProviderClass);
+
+        ClassName awsExecAttr = ClassName.get("software.amazon.awssdk.awscore", "AwsExecutionAttribute");
+        List<CodeBlock> parts = new ArrayList<>();
+        if (authSchemeSpecUtils.hasPerOperationAuthOverrides()) {
+            parts.add(CodeBlock.of("operationName"));
+        }
+        if (authSchemeSpecUtils.usesSigV4()) {
+            parts.add(CodeBlock.of("executionAttributes.getAttribute($T.AWS_REGION)", awsExecAttr));
+        }
+        if (authSchemeSpecUtils.usesSigV4a()) {
+            parts.add(CodeBlock.of("executionAttributes.getAttribute($T.AWS_SIGV4A_SIGNING_REGION_SET)", awsExecAttr));
+        }
+
+        if (parts.isEmpty()) {
+            builder.addStatement("$T cacheKey = $S", String.class, "default");
+        } else if (parts.size() == 1) {
+            builder.addStatement("$T cacheKey = $T.valueOf($L)", String.class, String.class, parts.get(0));
+        } else {
+            builder.addStatement("$T cacheKey = $L", String.class, CodeBlock.join(parts, " + \":\" + "));
+        }
+
+        builder.beginControlFlow("if (useCache)");
+        builder.addStatement("$T<$T> cached = authSchemeCache.get(cacheKey)",
+                             List.class, AuthSchemeOption.class);
+        builder.beginControlFlow("if (cached != null)");
+        builder.addStatement("return cached");
+        builder.endControlFlow();
+        builder.endControlFlow();
     }
 
     private static void addSimpleAuthSchemeResolution(MethodSpec.Builder builder,

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/ClientClassUtils.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/ClientClassUtils.java
@@ -21,6 +21,7 @@ import static software.amazon.awssdk.codegen.poet.PoetUtils.classNameFromFqcn;
 
 import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.CodeBlock;
+import com.squareup.javapoet.FieldSpec;
 import com.squareup.javapoet.MethodSpec;
 import com.squareup.javapoet.ParameterSpec;
 import com.squareup.javapoet.ParameterizedTypeName;
@@ -385,6 +386,7 @@ public final class ClientClassUtils {
                              + ".orElse(null)",
                              providerInterface, Validate.class, providerInterface,
                              "Expected an instance of " + authSchemeSpecUtils.providerInterfaceName().simpleName());
+
         builder.addStatement("$T authSchemeProvider = requestAuthSchemeProvider != null "
                              + "? requestAuthSchemeProvider "
                              + ": $T.isInstanceOf($T.class, "
@@ -393,13 +395,33 @@ public final class ClientClassUtils {
                              SdkInternalExecutionAttribute.class,
                              "Expected an instance of " + authSchemeSpecUtils.providerInterfaceName().simpleName());
 
+        // Use cache for simple (non-endpoint-based, non-S3) auth scheme resolution when using the default provider
+        boolean canCache = !authSchemeSpecUtils.useEndpointBasedAuthProvider() && !endpointRulesSpecUtils.isS3();
+        if (canCache) {
+            ClassName defaultProviderClass = authSchemeSpecUtils.defaultAuthSchemeProviderName();
+            builder.addStatement("boolean useCache = requestAuthSchemeProvider == null "
+                                 + "&& authSchemeProvider instanceof $T", defaultProviderClass);
+            builder.beginControlFlow("if (useCache)");
+            builder.addStatement("$T<$T> cached = authSchemeCache.get(operationName)",
+                                 List.class, AuthSchemeOption.class);
+            builder.beginControlFlow("if (cached != null)");
+            builder.addStatement("return cached");
+            builder.endControlFlow();
+            builder.endControlFlow();
+        }
+
         if (authSchemeSpecUtils.useEndpointBasedAuthProvider()) {
             addEndpointBasedAuthSchemeResolution(builder, authSchemeSpecUtils, endpointRulesSpecUtils);
         } else {
             addSimpleAuthSchemeResolution(builder, authSchemeSpecUtils);
         }
 
-        if (endpointRulesSpecUtils.isS3()) {
+        if (canCache) {
+            builder.beginControlFlow("if (useCache)");
+            builder.addStatement("authSchemeCache.put(operationName, options)");
+            builder.endControlFlow();
+            builder.addStatement("return options");
+        } else if (endpointRulesSpecUtils.isS3()) {
             ClassName sdkIdentityProperty = ClassName.get("software.amazon.awssdk.core.identity", "SdkIdentityProperty");
             builder.addStatement("$T sdkClient = executionAttributes.getAttribute($T.SDK_CLIENT)",
                                  SdkClient.class, SdkInternalExecutionAttribute.class);
@@ -412,6 +434,24 @@ public final class ClientClassUtils {
         }
 
         return builder.build();
+    }
+
+    /**
+     * Returns a field spec for the auth scheme options cache, used when simple (non-endpoint-based) auth is in effect.
+     */
+    static Optional<FieldSpec> authSchemeCacheField(AuthSchemeSpecUtils authSchemeSpecUtils,
+                                                    EndpointRulesSpecUtils endpointRulesSpecUtils) {
+        if (authSchemeSpecUtils.useEndpointBasedAuthProvider() || endpointRulesSpecUtils.isS3()) {
+            return Optional.empty();
+        }
+        ClassName concurrentHashMap = ClassName.get("java.util.concurrent", "ConcurrentHashMap");
+        ParameterizedTypeName mapType = ParameterizedTypeName.get(
+            concurrentHashMap,
+            ClassName.get(String.class),
+            ParameterizedTypeName.get(ClassName.get(List.class), ClassName.get(AuthSchemeOption.class)));
+        return Optional.of(FieldSpec.builder(mapType, "authSchemeCache", PRIVATE, Modifier.FINAL)
+                                    .initializer("new $T<>()", concurrentHashMap)
+                                    .build());
     }
 
     private static void addSimpleAuthSchemeResolution(MethodSpec.Builder builder,

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/ClientClassUtils.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/ClientClassUtils.java
@@ -480,8 +480,7 @@ public final class ClientClassUtils {
         builder.endControlFlow();
     }
 
-    // Any AwsExecutionAttribute added here must also be added to addAuthSchemeCacheLookup().
-    // Enforced by AuthSchemeCacheKeyConsistencyTest.
+    // Any AwsExecutionAttribute added here must also be added to addAuthSchemeCacheLookup(). Enforced by AuthSchemeCacheKeyTest.
     private static void addSimpleAuthSchemeResolution(MethodSpec.Builder builder,
                                                       AuthSchemeSpecUtils authSchemeSpecUtils) {
         ClassName paramsInterface = authSchemeSpecUtils.parametersInterfaceName();

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/SyncClientClass.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/SyncClientClass.java
@@ -130,6 +130,7 @@ public class SyncClientClass extends SyncClientInterface {
             .addField(protocolSpec.protocolFactory(model))
             .addField(SdkClientConfiguration.class, "clientConfiguration", PRIVATE, FINAL);
         protocolSpec.errorResponseMapperField().ifPresent(type::addField);
+        ClientClassUtils.authSchemeCacheField(authSchemeSpecUtils, endpointRulesSpecUtils).ifPresent(type::addField);
     }
 
     @Override

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/SyncClientClass.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/SyncClientClass.java
@@ -130,7 +130,7 @@ public class SyncClientClass extends SyncClientInterface {
             .addField(protocolSpec.protocolFactory(model))
             .addField(SdkClientConfiguration.class, "clientConfiguration", PRIVATE, FINAL);
         protocolSpec.errorResponseMapperField().ifPresent(type::addField);
-        ClientClassUtils.authSchemeCacheField(authSchemeSpecUtils, endpointRulesSpecUtils).ifPresent(type::addField);
+        ClientClassUtils.authSchemeCacheField(authSchemeSpecUtils).ifPresent(type::addField);
     }
 
     @Override

--- a/codegen/src/test/java/software/amazon/awssdk/codegen/poet/client/AuthSchemeCacheKeyTest.java
+++ b/codegen/src/test/java/software/amazon/awssdk/codegen/poet/client/AuthSchemeCacheKeyTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.codegen.poet.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static software.amazon.awssdk.codegen.poet.ClientTestModels.customPackageModels;
+import static software.amazon.awssdk.codegen.poet.ClientTestModels.opsWithSigv4a;
+import static software.amazon.awssdk.codegen.poet.ClientTestModels.restJsonServiceModels;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.junit.Test;
+import software.amazon.awssdk.codegen.model.intermediate.IntermediateModel;
+import software.amazon.awssdk.codegen.poet.auth.scheme.AuthSchemeSpecUtils;
+import software.amazon.awssdk.codegen.poet.rules.EndpointRulesSpecUtils;
+
+/**
+ * Verifies that every AwsExecutionAttribute used in auth scheme params building is also present in the cache key.
+ * If a new attribute is added to the params without updating the cache key, this test will fail.
+ */
+public class AuthSchemeCacheKeyTest {
+
+    private static final Pattern AWS_EXEC_ATTR_PATTERN =
+        Pattern.compile("AwsExecutionAttribute\\.(\\w+)");
+
+    @Test
+    public void restJson_cacheKeyCoversAllParamAttributes() {
+        verifyConsistency(restJsonServiceModels());
+    }
+
+    @Test
+    public void sigv4a_cacheKeyCoversAllParamAttributes() {
+        verifyConsistency(opsWithSigv4a());
+    }
+
+    @Test
+    public void uniformAuth_cacheKeyCoversAllParamAttributes() {
+        verifyConsistency(customPackageModels());
+    }
+
+    private void verifyConsistency(IntermediateModel model) {
+        AuthSchemeSpecUtils authSchemeSpecUtils = new AuthSchemeSpecUtils(model);
+        EndpointRulesSpecUtils endpointRulesSpecUtils = new EndpointRulesSpecUtils(model);
+
+        String source = ClientClassUtils.resolveAuthSchemeOptionsMethod(authSchemeSpecUtils, endpointRulesSpecUtils)
+                                        .toString();
+
+        int resolveCallIndex = source.indexOf(".resolveAuthScheme(");
+        assertThat(resolveCallIndex).as("resolveAuthScheme call should exist in generated method").isGreaterThan(0);
+
+        int cacheKeyStart = source.indexOf("cacheKey =");
+        if (cacheKeyStart < 0) {
+            // No cache — endpoint-based service, nothing to verify
+            return;
+        }
+        int cacheKeyEnd = source.indexOf(";", cacheKeyStart);
+
+        int paramsStart = source.indexOf("paramsBuilder");
+        String paramsSection = source.substring(paramsStart, resolveCallIndex);
+
+        Set<String> paramsAttributes = extractAttributes(paramsSection);
+        assertThat(paramsAttributes).as("Expected auth params to reference AwsExecutionAttributes").isNotEmpty();
+        String cacheKeySection = source.substring(cacheKeyStart, cacheKeyEnd);
+        Set<String> cacheKeyAttributes = extractAttributes(cacheKeySection);
+
+        assertThat(cacheKeyAttributes)
+            .as("Cache key must include all AwsExecutionAttributes used in params building. "
+                + "If you added a new attribute to params, add it to addAuthSchemeCacheLookup() too.")
+            .containsAll(paramsAttributes);
+    }
+
+    private Set<String> extractAttributes(String section) {
+        Set<String> attributes = new HashSet<>();
+        Matcher matcher = AWS_EXEC_ATTR_PATTERN.matcher(section);
+        while (matcher.find()) {
+            attributes.add(matcher.group(1));
+        }
+        return attributes;
+    }
+}

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-aws-json-async-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-aws-json-async-client-class.java
@@ -1269,8 +1269,9 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
                           "Expected an instance of JsonAuthSchemeProvider");
         boolean useCache = requestAuthSchemeProvider == null
                 && authSchemeProvider instanceof DefaultJsonAuthSchemeProvider;
+        String cacheKey = operationName + ":" + executionAttributes.getAttribute(AwsExecutionAttribute.AWS_REGION);
         if (useCache) {
-            List<AuthSchemeOption> cached = authSchemeCache.get(operationName);
+            List<AuthSchemeOption> cached = authSchemeCache.get(cacheKey);
             if (cached != null) {
                 return cached;
             }
@@ -1279,7 +1280,8 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
         paramsBuilder.region(executionAttributes.getAttribute(AwsExecutionAttribute.AWS_REGION));
         List<AuthSchemeOption> options = authSchemeProvider.resolveAuthScheme(paramsBuilder.build());
         if (useCache) {
-            authSchemeCache.put(operationName, options);
+            options = Collections.unmodifiableList(options);
+            authSchemeCache.put(cacheKey, options);
         }
         return options;
     }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-aws-json-async-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-aws-json-async-client-class.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -70,6 +71,7 @@ import software.amazon.awssdk.protocols.json.JsonOperationMetadata;
 import software.amazon.awssdk.retries.api.RetryStrategy;
 import software.amazon.awssdk.services.json.auth.scheme.JsonAuthSchemeParams;
 import software.amazon.awssdk.services.json.auth.scheme.JsonAuthSchemeProvider;
+import software.amazon.awssdk.services.json.auth.scheme.internal.DefaultJsonAuthSchemeProvider;
 import software.amazon.awssdk.services.json.endpoints.JsonEndpointParams;
 import software.amazon.awssdk.services.json.endpoints.JsonEndpointProvider;
 import software.amazon.awssdk.services.json.endpoints.internal.JsonEndpointResolverUtils;
@@ -171,7 +173,10 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
         }
     };
 
+    private final ConcurrentHashMap<String, List<AuthSchemeOption>> authSchemeCache = new ConcurrentHashMap<>();
+
     private final Executor executor;
+
 
     protected DefaultJsonAsyncClient(SdkClientConfiguration clientConfiguration) {
         this.clientHandler = new AwsAsyncClientHandler(clientConfiguration);
@@ -1262,9 +1267,20 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
         JsonAuthSchemeProvider authSchemeProvider = requestAuthSchemeProvider != null ? requestAuthSchemeProvider : Validate
             .isInstanceOf(JsonAuthSchemeProvider.class, executionAttributes.getAttribute(SdkInternalExecutionAttribute.AUTH_SCHEME_RESOLVER),
                           "Expected an instance of JsonAuthSchemeProvider");
+        boolean useCache = requestAuthSchemeProvider == null
+                && authSchemeProvider instanceof DefaultJsonAuthSchemeProvider;
+        if (useCache) {
+            List<AuthSchemeOption> cached = authSchemeCache.get(operationName);
+            if (cached != null) {
+                return cached;
+            }
+        }
         JsonAuthSchemeParams.Builder paramsBuilder = JsonAuthSchemeParams.builder().operation(operationName);
         paramsBuilder.region(executionAttributes.getAttribute(AwsExecutionAttribute.AWS_REGION));
         List<AuthSchemeOption> options = authSchemeProvider.resolveAuthScheme(paramsBuilder.build());
+        if (useCache) {
+            authSchemeCache.put(operationName, options);
+        }
         return options;
     }
 

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-aws-query-compatible-json-async-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-aws-query-compatible-json-async-client-class.java
@@ -234,8 +234,9 @@ final class DefaultQueryToJsonCompatibleAsyncClient implements QueryToJsonCompat
                                                                                                                                "Expected an instance of QueryToJsonCompatibleAuthSchemeProvider");
         boolean useCache = requestAuthSchemeProvider == null
                 && authSchemeProvider instanceof DefaultQueryToJsonCompatibleAuthSchemeProvider;
+        String cacheKey = String.valueOf(executionAttributes.getAttribute(AwsExecutionAttribute.AWS_REGION));
         if (useCache) {
-            List<AuthSchemeOption> cached = authSchemeCache.get(operationName);
+            List<AuthSchemeOption> cached = authSchemeCache.get(cacheKey);
             if (cached != null) {
                 return cached;
             }
@@ -245,7 +246,8 @@ final class DefaultQueryToJsonCompatibleAsyncClient implements QueryToJsonCompat
         paramsBuilder.region(executionAttributes.getAttribute(AwsExecutionAttribute.AWS_REGION));
         List<AuthSchemeOption> options = authSchemeProvider.resolveAuthScheme(paramsBuilder.build());
         if (useCache) {
-            authSchemeCache.put(operationName, options);
+            options = Collections.unmodifiableList(options);
+            authSchemeCache.put(cacheKey, options);
         }
         return options;
     }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-aws-query-compatible-json-async-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-aws-query-compatible-json-async-client-class.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import org.slf4j.Logger;
@@ -51,6 +52,7 @@ import software.amazon.awssdk.protocols.json.JsonOperationMetadata;
 import software.amazon.awssdk.retries.api.RetryStrategy;
 import software.amazon.awssdk.services.querytojsoncompatible.auth.scheme.QueryToJsonCompatibleAuthSchemeParams;
 import software.amazon.awssdk.services.querytojsoncompatible.auth.scheme.QueryToJsonCompatibleAuthSchemeProvider;
+import software.amazon.awssdk.services.querytojsoncompatible.auth.scheme.internal.DefaultQueryToJsonCompatibleAuthSchemeProvider;
 import software.amazon.awssdk.services.querytojsoncompatible.endpoints.QueryToJsonCompatibleEndpointParams;
 import software.amazon.awssdk.services.querytojsoncompatible.endpoints.QueryToJsonCompatibleEndpointProvider;
 import software.amazon.awssdk.services.querytojsoncompatible.endpoints.internal.QueryToJsonCompatibleEndpointResolverUtils;
@@ -96,6 +98,8 @@ final class DefaultQueryToJsonCompatibleAsyncClient implements QueryToJsonCompat
                 return Optional.empty();
         }
     };
+
+    private final ConcurrentHashMap<String, List<AuthSchemeOption>> authSchemeCache = new ConcurrentHashMap<>();
 
     protected DefaultQueryToJsonCompatibleAsyncClient(SdkClientConfiguration clientConfiguration) {
         this.clientHandler = new AwsAsyncClientHandler(clientConfiguration);
@@ -228,10 +232,21 @@ final class DefaultQueryToJsonCompatibleAsyncClient implements QueryToJsonCompat
                                                                                                        : Validate.isInstanceOf(QueryToJsonCompatibleAuthSchemeProvider.class,
                                                                                                                                executionAttributes.getAttribute(SdkInternalExecutionAttribute.AUTH_SCHEME_RESOLVER),
                                                                                                                                "Expected an instance of QueryToJsonCompatibleAuthSchemeProvider");
+        boolean useCache = requestAuthSchemeProvider == null
+                && authSchemeProvider instanceof DefaultQueryToJsonCompatibleAuthSchemeProvider;
+        if (useCache) {
+            List<AuthSchemeOption> cached = authSchemeCache.get(operationName);
+            if (cached != null) {
+                return cached;
+            }
+        }
         QueryToJsonCompatibleAuthSchemeParams.Builder paramsBuilder = QueryToJsonCompatibleAuthSchemeParams.builder().operation(
             operationName);
         paramsBuilder.region(executionAttributes.getAttribute(AwsExecutionAttribute.AWS_REGION));
         List<AuthSchemeOption> options = authSchemeProvider.resolveAuthScheme(paramsBuilder.build());
+        if (useCache) {
+            authSchemeCache.put(operationName, options);
+        }
         return options;
     }
 

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-aws-query-compatible-json-sync-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-aws-query-compatible-json-sync-client-class.java
@@ -202,8 +202,9 @@ final class DefaultQueryToJsonCompatibleClient implements QueryToJsonCompatibleC
                                                                                                                                "Expected an instance of QueryToJsonCompatibleAuthSchemeProvider");
         boolean useCache = requestAuthSchemeProvider == null
                 && authSchemeProvider instanceof DefaultQueryToJsonCompatibleAuthSchemeProvider;
+        String cacheKey = String.valueOf(executionAttributes.getAttribute(AwsExecutionAttribute.AWS_REGION));
         if (useCache) {
-            List<AuthSchemeOption> cached = authSchemeCache.get(operationName);
+            List<AuthSchemeOption> cached = authSchemeCache.get(cacheKey);
             if (cached != null) {
                 return cached;
             }
@@ -213,7 +214,8 @@ final class DefaultQueryToJsonCompatibleClient implements QueryToJsonCompatibleC
         paramsBuilder.region(executionAttributes.getAttribute(AwsExecutionAttribute.AWS_REGION));
         List<AuthSchemeOption> options = authSchemeProvider.resolveAuthScheme(paramsBuilder.build());
         if (useCache) {
-            authSchemeCache.put(operationName, options);
+            options = Collections.unmodifiableList(options);
+            authSchemeCache.put(cacheKey, options);
         }
         return options;
     }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-aws-query-compatible-json-sync-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-aws-query-compatible-json-sync-client-class.java
@@ -4,6 +4,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import software.amazon.awssdk.annotations.Generated;
@@ -46,6 +47,7 @@ import software.amazon.awssdk.protocols.json.JsonOperationMetadata;
 import software.amazon.awssdk.retries.api.RetryStrategy;
 import software.amazon.awssdk.services.querytojsoncompatible.auth.scheme.QueryToJsonCompatibleAuthSchemeParams;
 import software.amazon.awssdk.services.querytojsoncompatible.auth.scheme.QueryToJsonCompatibleAuthSchemeProvider;
+import software.amazon.awssdk.services.querytojsoncompatible.auth.scheme.internal.DefaultQueryToJsonCompatibleAuthSchemeProvider;
 import software.amazon.awssdk.services.querytojsoncompatible.endpoints.QueryToJsonCompatibleEndpointParams;
 import software.amazon.awssdk.services.querytojsoncompatible.endpoints.QueryToJsonCompatibleEndpointProvider;
 import software.amazon.awssdk.services.querytojsoncompatible.endpoints.internal.QueryToJsonCompatibleEndpointResolverUtils;
@@ -91,6 +93,8 @@ final class DefaultQueryToJsonCompatibleClient implements QueryToJsonCompatibleC
                 return Optional.empty();
         }
     };
+
+    private final ConcurrentHashMap<String, List<AuthSchemeOption>> authSchemeCache = new ConcurrentHashMap<>();
 
     protected DefaultQueryToJsonCompatibleClient(SdkClientConfiguration clientConfiguration) {
         this.clientHandler = new AwsSyncClientHandler(clientConfiguration);
@@ -196,10 +200,21 @@ final class DefaultQueryToJsonCompatibleClient implements QueryToJsonCompatibleC
                                                                                                        : Validate.isInstanceOf(QueryToJsonCompatibleAuthSchemeProvider.class,
                                                                                                                                executionAttributes.getAttribute(SdkInternalExecutionAttribute.AUTH_SCHEME_RESOLVER),
                                                                                                                                "Expected an instance of QueryToJsonCompatibleAuthSchemeProvider");
+        boolean useCache = requestAuthSchemeProvider == null
+                && authSchemeProvider instanceof DefaultQueryToJsonCompatibleAuthSchemeProvider;
+        if (useCache) {
+            List<AuthSchemeOption> cached = authSchemeCache.get(operationName);
+            if (cached != null) {
+                return cached;
+            }
+        }
         QueryToJsonCompatibleAuthSchemeParams.Builder paramsBuilder = QueryToJsonCompatibleAuthSchemeParams.builder().operation(
             operationName);
         paramsBuilder.region(executionAttributes.getAttribute(AwsExecutionAttribute.AWS_REGION));
         List<AuthSchemeOption> options = authSchemeProvider.resolveAuthScheme(paramsBuilder.build());
+        if (useCache) {
+            authSchemeCache.put(operationName, options);
+        }
         return options;
     }
 

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-batchmanager-async.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-batchmanager-async.java
@@ -230,8 +230,9 @@ final class DefaultBatchManagerTestAsyncClient implements BatchManagerTestAsyncC
                                                                                                                           "Expected an instance of BatchManagerTestAuthSchemeProvider");
         boolean useCache = requestAuthSchemeProvider == null
                 && authSchemeProvider instanceof DefaultBatchManagerTestAuthSchemeProvider;
+        String cacheKey = String.valueOf(executionAttributes.getAttribute(AwsExecutionAttribute.AWS_REGION));
         if (useCache) {
-            List<AuthSchemeOption> cached = authSchemeCache.get(operationName);
+            List<AuthSchemeOption> cached = authSchemeCache.get(cacheKey);
             if (cached != null) {
                 return cached;
             }
@@ -241,7 +242,8 @@ final class DefaultBatchManagerTestAsyncClient implements BatchManagerTestAsyncC
         paramsBuilder.region(executionAttributes.getAttribute(AwsExecutionAttribute.AWS_REGION));
         List<AuthSchemeOption> options = authSchemeProvider.resolveAuthScheme(paramsBuilder.build());
         if (useCache) {
-            authSchemeCache.put(operationName, options);
+            options = Collections.unmodifiableList(options);
+            authSchemeCache.put(cacheKey, options);
         }
         return options;
     }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-batchmanager-async.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-batchmanager-async.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -52,6 +53,7 @@ import software.amazon.awssdk.protocols.json.JsonOperationMetadata;
 import software.amazon.awssdk.retries.api.RetryStrategy;
 import software.amazon.awssdk.services.batchmanagertest.auth.scheme.BatchManagerTestAuthSchemeParams;
 import software.amazon.awssdk.services.batchmanagertest.auth.scheme.BatchManagerTestAuthSchemeProvider;
+import software.amazon.awssdk.services.batchmanagertest.auth.scheme.internal.DefaultBatchManagerTestAuthSchemeProvider;
 import software.amazon.awssdk.services.batchmanagertest.batchmanager.BatchManagerTestAsyncBatchManager;
 import software.amazon.awssdk.services.batchmanagertest.endpoints.BatchManagerTestEndpointParams;
 import software.amazon.awssdk.services.batchmanagertest.endpoints.BatchManagerTestEndpointProvider;
@@ -95,6 +97,8 @@ final class DefaultBatchManagerTestAsyncClient implements BatchManagerTestAsyncC
     };
 
     private final ScheduledExecutorService executorService;
+
+    private final ConcurrentHashMap<String, List<AuthSchemeOption>> authSchemeCache = new ConcurrentHashMap<>();
 
     protected DefaultBatchManagerTestAsyncClient(SdkClientConfiguration clientConfiguration) {
         this.clientHandler = new AwsAsyncClientHandler(clientConfiguration);
@@ -224,10 +228,21 @@ final class DefaultBatchManagerTestAsyncClient implements BatchManagerTestAsyncC
                                                                                                   : Validate.isInstanceOf(BatchManagerTestAuthSchemeProvider.class,
                                                                                                                           executionAttributes.getAttribute(SdkInternalExecutionAttribute.AUTH_SCHEME_RESOLVER),
                                                                                                                           "Expected an instance of BatchManagerTestAuthSchemeProvider");
+        boolean useCache = requestAuthSchemeProvider == null
+                && authSchemeProvider instanceof DefaultBatchManagerTestAuthSchemeProvider;
+        if (useCache) {
+            List<AuthSchemeOption> cached = authSchemeCache.get(operationName);
+            if (cached != null) {
+                return cached;
+            }
+        }
         BatchManagerTestAuthSchemeParams.Builder paramsBuilder = BatchManagerTestAuthSchemeParams.builder().operation(
             operationName);
         paramsBuilder.region(executionAttributes.getAttribute(AwsExecutionAttribute.AWS_REGION));
         List<AuthSchemeOption> options = authSchemeProvider.resolveAuthScheme(paramsBuilder.build());
+        if (useCache) {
+            authSchemeCache.put(operationName, options);
+        }
         return options;
     }
 

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-cbor-async-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-cbor-async-client-class.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -71,6 +72,7 @@ import software.amazon.awssdk.protocols.json.JsonOperationMetadata;
 import software.amazon.awssdk.retries.api.RetryStrategy;
 import software.amazon.awssdk.services.json.auth.scheme.JsonAuthSchemeParams;
 import software.amazon.awssdk.services.json.auth.scheme.JsonAuthSchemeProvider;
+import software.amazon.awssdk.services.json.auth.scheme.internal.DefaultJsonAuthSchemeProvider;
 import software.amazon.awssdk.services.json.endpoints.JsonEndpointParams;
 import software.amazon.awssdk.services.json.endpoints.JsonEndpointProvider;
 import software.amazon.awssdk.services.json.endpoints.internal.JsonEndpointResolverUtils;
@@ -174,7 +176,10 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
 
     private final AwsJsonProtocolFactory jsonProtocolFactory;
 
+    private final ConcurrentHashMap<String, List<AuthSchemeOption>> authSchemeCache = new ConcurrentHashMap<>();
+
     private final Executor executor;
+
 
     protected DefaultJsonAsyncClient(SdkClientConfiguration clientConfiguration) {
         this.clientHandler = new AwsAsyncClientHandler(clientConfiguration);
@@ -1266,9 +1271,20 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
         JsonAuthSchemeProvider authSchemeProvider = requestAuthSchemeProvider != null ? requestAuthSchemeProvider : Validate
             .isInstanceOf(JsonAuthSchemeProvider.class, executionAttributes.getAttribute(SdkInternalExecutionAttribute.AUTH_SCHEME_RESOLVER),
                           "Expected an instance of JsonAuthSchemeProvider");
+        boolean useCache = requestAuthSchemeProvider == null
+                && authSchemeProvider instanceof DefaultJsonAuthSchemeProvider;
+        if (useCache) {
+            List<AuthSchemeOption> cached = authSchemeCache.get(operationName);
+            if (cached != null) {
+                return cached;
+            }
+        }
         JsonAuthSchemeParams.Builder paramsBuilder = JsonAuthSchemeParams.builder().operation(operationName);
         paramsBuilder.region(executionAttributes.getAttribute(AwsExecutionAttribute.AWS_REGION));
         List<AuthSchemeOption> options = authSchemeProvider.resolveAuthScheme(paramsBuilder.build());
+        if (useCache) {
+            authSchemeCache.put(operationName, options);
+        }
         return options;
     }
 

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-cbor-async-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-cbor-async-client-class.java
@@ -1273,8 +1273,9 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
                           "Expected an instance of JsonAuthSchemeProvider");
         boolean useCache = requestAuthSchemeProvider == null
                 && authSchemeProvider instanceof DefaultJsonAuthSchemeProvider;
+        String cacheKey = operationName + ":" + executionAttributes.getAttribute(AwsExecutionAttribute.AWS_REGION);
         if (useCache) {
-            List<AuthSchemeOption> cached = authSchemeCache.get(operationName);
+            List<AuthSchemeOption> cached = authSchemeCache.get(cacheKey);
             if (cached != null) {
                 return cached;
             }
@@ -1283,7 +1284,8 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
         paramsBuilder.region(executionAttributes.getAttribute(AwsExecutionAttribute.AWS_REGION));
         List<AuthSchemeOption> options = authSchemeProvider.resolveAuthScheme(paramsBuilder.build());
         if (useCache) {
-            authSchemeCache.put(operationName, options);
+            options = Collections.unmodifiableList(options);
+            authSchemeCache.put(cacheKey, options);
         }
         return options;
     }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-cbor-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-cbor-client-class.java
@@ -824,8 +824,9 @@ final class DefaultJsonClient implements JsonClient {
                           "Expected an instance of JsonAuthSchemeProvider");
         boolean useCache = requestAuthSchemeProvider == null
                 && authSchemeProvider instanceof DefaultJsonAuthSchemeProvider;
+        String cacheKey = operationName + ":" + executionAttributes.getAttribute(AwsExecutionAttribute.AWS_REGION);
         if (useCache) {
-            List<AuthSchemeOption> cached = authSchemeCache.get(operationName);
+            List<AuthSchemeOption> cached = authSchemeCache.get(cacheKey);
             if (cached != null) {
                 return cached;
             }
@@ -834,7 +835,8 @@ final class DefaultJsonClient implements JsonClient {
         paramsBuilder.region(executionAttributes.getAttribute(AwsExecutionAttribute.AWS_REGION));
         List<AuthSchemeOption> options = authSchemeProvider.resolveAuthScheme(paramsBuilder.build());
         if (useCache) {
-            authSchemeCache.put(operationName, options);
+            options = Collections.unmodifiableList(options);
+            authSchemeCache.put(cacheKey, options);
         }
         return options;
     }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-cbor-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-cbor-client-class.java
@@ -4,6 +4,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import software.amazon.awssdk.annotations.Generated;
@@ -51,6 +52,7 @@ import software.amazon.awssdk.protocols.json.JsonOperationMetadata;
 import software.amazon.awssdk.retries.api.RetryStrategy;
 import software.amazon.awssdk.services.json.auth.scheme.JsonAuthSchemeParams;
 import software.amazon.awssdk.services.json.auth.scheme.JsonAuthSchemeProvider;
+import software.amazon.awssdk.services.json.auth.scheme.internal.DefaultJsonAuthSchemeProvider;
 import software.amazon.awssdk.services.json.endpoints.JsonEndpointParams;
 import software.amazon.awssdk.services.json.endpoints.JsonEndpointProvider;
 import software.amazon.awssdk.services.json.endpoints.internal.JsonEndpointResolverUtils;
@@ -130,6 +132,8 @@ final class DefaultJsonClient implements JsonClient {
                 return Optional.empty();
         }
     };
+
+    private final ConcurrentHashMap<String, List<AuthSchemeOption>> authSchemeCache = new ConcurrentHashMap<>();
 
     protected DefaultJsonClient(SdkClientConfiguration clientConfiguration) {
         this.clientHandler = new AwsSyncClientHandler(clientConfiguration);
@@ -818,9 +822,20 @@ final class DefaultJsonClient implements JsonClient {
             .isInstanceOf(JsonAuthSchemeProvider.class,
                           executionAttributes.getAttribute(SdkInternalExecutionAttribute.AUTH_SCHEME_RESOLVER),
                           "Expected an instance of JsonAuthSchemeProvider");
+        boolean useCache = requestAuthSchemeProvider == null
+                && authSchemeProvider instanceof DefaultJsonAuthSchemeProvider;
+        if (useCache) {
+            List<AuthSchemeOption> cached = authSchemeCache.get(operationName);
+            if (cached != null) {
+                return cached;
+            }
+        }
         JsonAuthSchemeParams.Builder paramsBuilder = JsonAuthSchemeParams.builder().operation(operationName);
         paramsBuilder.region(executionAttributes.getAttribute(AwsExecutionAttribute.AWS_REGION));
         List<AuthSchemeOption> options = authSchemeProvider.resolveAuthScheme(paramsBuilder.build());
+        if (useCache) {
+            authSchemeCache.put(operationName, options);
+        }
         return options;
     }
 

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-custom-context-params-async-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-custom-context-params-async-client-class.java
@@ -224,8 +224,9 @@ final class DefaultFooBarAsyncClient implements FooBarAsyncClient {
                         "Expected an instance of FooBarAuthSchemeProvider");
         boolean useCache = requestAuthSchemeProvider == null
                 && authSchemeProvider instanceof DefaultFooBarAuthSchemeProvider;
+        String cacheKey = String.valueOf(executionAttributes.getAttribute(AwsExecutionAttribute.AWS_REGION));
         if (useCache) {
-            List<AuthSchemeOption> cached = authSchemeCache.get(operationName);
+            List<AuthSchemeOption> cached = authSchemeCache.get(cacheKey);
             if (cached != null) {
                 return cached;
             }
@@ -234,7 +235,8 @@ final class DefaultFooBarAsyncClient implements FooBarAsyncClient {
         paramsBuilder.region(executionAttributes.getAttribute(AwsExecutionAttribute.AWS_REGION));
         List<AuthSchemeOption> options = authSchemeProvider.resolveAuthScheme(paramsBuilder.build());
         if (useCache) {
-            authSchemeCache.put(operationName, options);
+            options = Collections.unmodifiableList(options);
+            authSchemeCache.put(cacheKey, options);
         }
         return options;
     }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-custom-context-params-async-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-custom-context-params-async-client-class.java
@@ -8,6 +8,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import org.slf4j.Logger;
@@ -52,6 +53,7 @@ import software.amazon.awssdk.protocols.json.JsonOperationMetadata;
 import software.amazon.awssdk.retries.api.RetryStrategy;
 import software.amazon.awssdk.services.foobar.auth.scheme.FooBarAuthSchemeParams;
 import software.amazon.awssdk.services.foobar.auth.scheme.FooBarAuthSchemeProvider;
+import software.amazon.awssdk.services.foobar.auth.scheme.internal.DefaultFooBarAuthSchemeProvider;
 import software.amazon.awssdk.services.foobar.endpoints.FooBarClientContextParams;
 import software.amazon.awssdk.services.foobar.endpoints.FooBarEndpointParams;
 import software.amazon.awssdk.services.foobar.endpoints.FooBarEndpointProvider;
@@ -94,6 +96,8 @@ final class DefaultFooBarAsyncClient implements FooBarAsyncClient {
             return Optional.empty();
         }
     };
+
+    private final ConcurrentHashMap<String, List<AuthSchemeOption>> authSchemeCache = new ConcurrentHashMap<>();
 
     protected DefaultFooBarAsyncClient(SdkClientConfiguration clientConfiguration) {
         this.clientHandler = new AwsAsyncClientHandler(clientConfiguration);
@@ -218,9 +222,20 @@ final class DefaultFooBarAsyncClient implements FooBarAsyncClient {
                 .isInstanceOf(FooBarAuthSchemeProvider.class,
                         executionAttributes.getAttribute(SdkInternalExecutionAttribute.AUTH_SCHEME_RESOLVER),
                         "Expected an instance of FooBarAuthSchemeProvider");
+        boolean useCache = requestAuthSchemeProvider == null
+                && authSchemeProvider instanceof DefaultFooBarAuthSchemeProvider;
+        if (useCache) {
+            List<AuthSchemeOption> cached = authSchemeCache.get(operationName);
+            if (cached != null) {
+                return cached;
+            }
+        }
         FooBarAuthSchemeParams.Builder paramsBuilder = FooBarAuthSchemeParams.builder().operation(operationName);
         paramsBuilder.region(executionAttributes.getAttribute(AwsExecutionAttribute.AWS_REGION));
         List<AuthSchemeOption> options = authSchemeProvider.resolveAuthScheme(paramsBuilder.build());
+        if (useCache) {
+            authSchemeCache.put(operationName, options);
+        }
         return options;
     }
 

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-custom-context-params-sync-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-custom-context-params-sync-client-class.java
@@ -194,8 +194,9 @@ final class DefaultFooBarClient implements FooBarClient {
                           "Expected an instance of FooBarAuthSchemeProvider");
         boolean useCache = requestAuthSchemeProvider == null
                 && authSchemeProvider instanceof DefaultFooBarAuthSchemeProvider;
+        String cacheKey = String.valueOf(executionAttributes.getAttribute(AwsExecutionAttribute.AWS_REGION));
         if (useCache) {
-            List<AuthSchemeOption> cached = authSchemeCache.get(operationName);
+            List<AuthSchemeOption> cached = authSchemeCache.get(cacheKey);
             if (cached != null) {
                 return cached;
             }
@@ -204,7 +205,8 @@ final class DefaultFooBarClient implements FooBarClient {
         paramsBuilder.region(executionAttributes.getAttribute(AwsExecutionAttribute.AWS_REGION));
         List<AuthSchemeOption> options = authSchemeProvider.resolveAuthScheme(paramsBuilder.build());
         if (useCache) {
-            authSchemeCache.put(operationName, options);
+            options = Collections.unmodifiableList(options);
+            authSchemeCache.put(cacheKey, options);
         }
         return options;
     }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-custom-context-params-sync-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-custom-context-params-sync-client-class.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import software.amazon.awssdk.annotations.Generated;
@@ -47,6 +48,7 @@ import software.amazon.awssdk.protocols.json.JsonOperationMetadata;
 import software.amazon.awssdk.retries.api.RetryStrategy;
 import software.amazon.awssdk.services.foobar.auth.scheme.FooBarAuthSchemeParams;
 import software.amazon.awssdk.services.foobar.auth.scheme.FooBarAuthSchemeProvider;
+import software.amazon.awssdk.services.foobar.auth.scheme.internal.DefaultFooBarAuthSchemeProvider;
 import software.amazon.awssdk.services.foobar.endpoints.FooBarClientContextParams;
 import software.amazon.awssdk.services.foobar.endpoints.FooBarEndpointParams;
 import software.amazon.awssdk.services.foobar.endpoints.FooBarEndpointProvider;
@@ -89,6 +91,8 @@ final class DefaultFooBarClient implements FooBarClient {
                 return Optional.empty();
         }
     };
+
+    private final ConcurrentHashMap<String, List<AuthSchemeOption>> authSchemeCache = new ConcurrentHashMap<>();
 
     protected DefaultFooBarClient(SdkClientConfiguration clientConfiguration) {
         this.clientHandler = new AwsSyncClientHandler(clientConfiguration);
@@ -188,9 +192,20 @@ final class DefaultFooBarClient implements FooBarClient {
         FooBarAuthSchemeProvider authSchemeProvider = requestAuthSchemeProvider != null ? requestAuthSchemeProvider : Validate
             .isInstanceOf(FooBarAuthSchemeProvider.class, executionAttributes.getAttribute(SdkInternalExecutionAttribute.AUTH_SCHEME_RESOLVER),
                           "Expected an instance of FooBarAuthSchemeProvider");
+        boolean useCache = requestAuthSchemeProvider == null
+                && authSchemeProvider instanceof DefaultFooBarAuthSchemeProvider;
+        if (useCache) {
+            List<AuthSchemeOption> cached = authSchemeCache.get(operationName);
+            if (cached != null) {
+                return cached;
+            }
+        }
         FooBarAuthSchemeParams.Builder paramsBuilder = FooBarAuthSchemeParams.builder().operation(operationName);
         paramsBuilder.region(executionAttributes.getAttribute(AwsExecutionAttribute.AWS_REGION));
         List<AuthSchemeOption> options = authSchemeProvider.resolveAuthScheme(paramsBuilder.build());
+        if (useCache) {
+            authSchemeCache.put(operationName, options);
+        }
         return options;
     }
 

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-custompackage-async.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-custompackage-async.java
@@ -4,6 +4,7 @@ import static software.amazon.awssdk.utils.FunctionalUtils.runAndLogError;
 
 import foo.bar.helloworld.auth.scheme.ProtocolRestJsonWithCustomPackageAuthSchemeParams;
 import foo.bar.helloworld.auth.scheme.ProtocolRestJsonWithCustomPackageAuthSchemeProvider;
+import foo.bar.helloworld.auth.scheme.internal.DefaultProtocolRestJsonWithCustomPackageAuthSchemeProvider;
 import foo.bar.helloworld.endpoints.ProtocolRestJsonWithCustomPackageEndpointParams;
 import foo.bar.helloworld.endpoints.ProtocolRestJsonWithCustomPackageEndpointProvider;
 import foo.bar.helloworld.endpoints.internal.ProtocolRestJsonWithCustomPackageEndpointResolverUtils;
@@ -18,6 +19,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import org.slf4j.Logger;
@@ -91,6 +93,8 @@ final class DefaultProtocolRestJsonWithCustomPackageAsyncClient implements Proto
                 return Optional.empty();
         }
     };
+
+    private final ConcurrentHashMap<String, List<AuthSchemeOption>> authSchemeCache = new ConcurrentHashMap<>();
 
     protected DefaultProtocolRestJsonWithCustomPackageAsyncClient(SdkClientConfiguration clientConfiguration) {
         this.clientHandler = new AwsAsyncClientHandler(clientConfiguration);
@@ -218,10 +222,21 @@ final class DefaultProtocolRestJsonWithCustomPackageAsyncClient implements Proto
                                                                                                                    : Validate.isInstanceOf(ProtocolRestJsonWithCustomPackageAuthSchemeProvider.class,
                                                                                                                                            executionAttributes.getAttribute(SdkInternalExecutionAttribute.AUTH_SCHEME_RESOLVER),
                                                                                                                                            "Expected an instance of ProtocolRestJsonWithCustomPackageAuthSchemeProvider");
+        boolean useCache = requestAuthSchemeProvider == null
+                && authSchemeProvider instanceof DefaultProtocolRestJsonWithCustomPackageAuthSchemeProvider;
+        if (useCache) {
+            List<AuthSchemeOption> cached = authSchemeCache.get(operationName);
+            if (cached != null) {
+                return cached;
+            }
+        }
         ProtocolRestJsonWithCustomPackageAuthSchemeParams.Builder paramsBuilder = ProtocolRestJsonWithCustomPackageAuthSchemeParams
             .builder().operation(operationName);
         paramsBuilder.region(executionAttributes.getAttribute(AwsExecutionAttribute.AWS_REGION));
         List<AuthSchemeOption> options = authSchemeProvider.resolveAuthScheme(paramsBuilder.build());
+        if (useCache) {
+            authSchemeCache.put(operationName, options);
+        }
         return options;
     }
 

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-custompackage-async.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-custompackage-async.java
@@ -224,8 +224,9 @@ final class DefaultProtocolRestJsonWithCustomPackageAsyncClient implements Proto
                                                                                                                                            "Expected an instance of ProtocolRestJsonWithCustomPackageAuthSchemeProvider");
         boolean useCache = requestAuthSchemeProvider == null
                 && authSchemeProvider instanceof DefaultProtocolRestJsonWithCustomPackageAuthSchemeProvider;
+        String cacheKey = String.valueOf(executionAttributes.getAttribute(AwsExecutionAttribute.AWS_REGION));
         if (useCache) {
-            List<AuthSchemeOption> cached = authSchemeCache.get(operationName);
+            List<AuthSchemeOption> cached = authSchemeCache.get(cacheKey);
             if (cached != null) {
                 return cached;
             }
@@ -235,7 +236,8 @@ final class DefaultProtocolRestJsonWithCustomPackageAsyncClient implements Proto
         paramsBuilder.region(executionAttributes.getAttribute(AwsExecutionAttribute.AWS_REGION));
         List<AuthSchemeOption> options = authSchemeProvider.resolveAuthScheme(paramsBuilder.build());
         if (useCache) {
-            authSchemeCache.put(operationName, options);
+            options = Collections.unmodifiableList(options);
+            authSchemeCache.put(cacheKey, options);
         }
         return options;
     }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-custompackage-sync.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-custompackage-sync.java
@@ -192,8 +192,9 @@ final class DefaultProtocolRestJsonWithCustomPackageClient implements ProtocolRe
                                                                                                                                            "Expected an instance of ProtocolRestJsonWithCustomPackageAuthSchemeProvider");
         boolean useCache = requestAuthSchemeProvider == null
                 && authSchemeProvider instanceof DefaultProtocolRestJsonWithCustomPackageAuthSchemeProvider;
+        String cacheKey = String.valueOf(executionAttributes.getAttribute(AwsExecutionAttribute.AWS_REGION));
         if (useCache) {
-            List<AuthSchemeOption> cached = authSchemeCache.get(operationName);
+            List<AuthSchemeOption> cached = authSchemeCache.get(cacheKey);
             if (cached != null) {
                 return cached;
             }
@@ -203,7 +204,8 @@ final class DefaultProtocolRestJsonWithCustomPackageClient implements ProtocolRe
         paramsBuilder.region(executionAttributes.getAttribute(AwsExecutionAttribute.AWS_REGION));
         List<AuthSchemeOption> options = authSchemeProvider.resolveAuthScheme(paramsBuilder.build());
         if (useCache) {
-            authSchemeCache.put(operationName, options);
+            options = Collections.unmodifiableList(options);
+            authSchemeCache.put(cacheKey, options);
         }
         return options;
     }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-custompackage-sync.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-custompackage-sync.java
@@ -2,6 +2,7 @@ package foo.bar.helloworld;
 
 import foo.bar.helloworld.auth.scheme.ProtocolRestJsonWithCustomPackageAuthSchemeParams;
 import foo.bar.helloworld.auth.scheme.ProtocolRestJsonWithCustomPackageAuthSchemeProvider;
+import foo.bar.helloworld.auth.scheme.internal.DefaultProtocolRestJsonWithCustomPackageAuthSchemeProvider;
 import foo.bar.helloworld.endpoints.ProtocolRestJsonWithCustomPackageEndpointParams;
 import foo.bar.helloworld.endpoints.ProtocolRestJsonWithCustomPackageEndpointProvider;
 import foo.bar.helloworld.endpoints.internal.ProtocolRestJsonWithCustomPackageEndpointResolverUtils;
@@ -15,6 +16,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import software.amazon.awssdk.annotations.Generated;
@@ -86,6 +88,8 @@ final class DefaultProtocolRestJsonWithCustomPackageClient implements ProtocolRe
                 return Optional.empty();
         }
     };
+
+    private final ConcurrentHashMap<String, List<AuthSchemeOption>> authSchemeCache = new ConcurrentHashMap<>();
 
     protected DefaultProtocolRestJsonWithCustomPackageClient(SdkClientConfiguration clientConfiguration) {
         this.clientHandler = new AwsSyncClientHandler(clientConfiguration);
@@ -186,10 +190,21 @@ final class DefaultProtocolRestJsonWithCustomPackageClient implements ProtocolRe
                                                                                                                    : Validate.isInstanceOf(ProtocolRestJsonWithCustomPackageAuthSchemeProvider.class,
                                                                                                                                            executionAttributes.getAttribute(SdkInternalExecutionAttribute.AUTH_SCHEME_RESOLVER),
                                                                                                                                            "Expected an instance of ProtocolRestJsonWithCustomPackageAuthSchemeProvider");
+        boolean useCache = requestAuthSchemeProvider == null
+                && authSchemeProvider instanceof DefaultProtocolRestJsonWithCustomPackageAuthSchemeProvider;
+        if (useCache) {
+            List<AuthSchemeOption> cached = authSchemeCache.get(operationName);
+            if (cached != null) {
+                return cached;
+            }
+        }
         ProtocolRestJsonWithCustomPackageAuthSchemeParams.Builder paramsBuilder = ProtocolRestJsonWithCustomPackageAuthSchemeParams
             .builder().operation(operationName);
         paramsBuilder.region(executionAttributes.getAttribute(AwsExecutionAttribute.AWS_REGION));
         List<AuthSchemeOption> options = authSchemeProvider.resolveAuthScheme(paramsBuilder.build());
+        if (useCache) {
+            authSchemeCache.put(operationName, options);
+        }
         return options;
     }
 

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-customservicemetadata-async.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-customservicemetadata-async.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import org.slf4j.Logger;
@@ -51,6 +52,7 @@ import software.amazon.awssdk.protocols.json.JsonOperationMetadata;
 import software.amazon.awssdk.retries.api.RetryStrategy;
 import software.amazon.awssdk.services.protocolrestjsonwithcustomcontenttype.auth.scheme.ProtocolRestJsonWithCustomContentTypeAuthSchemeParams;
 import software.amazon.awssdk.services.protocolrestjsonwithcustomcontenttype.auth.scheme.ProtocolRestJsonWithCustomContentTypeAuthSchemeProvider;
+import software.amazon.awssdk.services.protocolrestjsonwithcustomcontenttype.auth.scheme.internal.DefaultProtocolRestJsonWithCustomContentTypeAuthSchemeProvider;
 import software.amazon.awssdk.services.protocolrestjsonwithcustomcontenttype.endpoints.ProtocolRestJsonWithCustomContentTypeEndpointParams;
 import software.amazon.awssdk.services.protocolrestjsonwithcustomcontenttype.endpoints.ProtocolRestJsonWithCustomContentTypeEndpointProvider;
 import software.amazon.awssdk.services.protocolrestjsonwithcustomcontenttype.endpoints.internal.ProtocolRestJsonWithCustomContentTypeEndpointResolverUtils;
@@ -91,6 +93,8 @@ final class DefaultProtocolRestJsonWithCustomContentTypeAsyncClient implements P
                 return Optional.empty();
         }
     };
+
+    private final ConcurrentHashMap<String, List<AuthSchemeOption>> authSchemeCache = new ConcurrentHashMap<>();
 
     protected DefaultProtocolRestJsonWithCustomContentTypeAsyncClient(SdkClientConfiguration clientConfiguration) {
         this.clientHandler = new AwsAsyncClientHandler(clientConfiguration);
@@ -218,10 +222,21 @@ final class DefaultProtocolRestJsonWithCustomContentTypeAsyncClient implements P
                                                                                                                        : Validate.isInstanceOf(ProtocolRestJsonWithCustomContentTypeAuthSchemeProvider.class,
                                                                                                                                                executionAttributes.getAttribute(SdkInternalExecutionAttribute.AUTH_SCHEME_RESOLVER),
                                                                                                                                                "Expected an instance of ProtocolRestJsonWithCustomContentTypeAuthSchemeProvider");
+        boolean useCache = requestAuthSchemeProvider == null
+                && authSchemeProvider instanceof DefaultProtocolRestJsonWithCustomContentTypeAuthSchemeProvider;
+        if (useCache) {
+            List<AuthSchemeOption> cached = authSchemeCache.get(operationName);
+            if (cached != null) {
+                return cached;
+            }
+        }
         ProtocolRestJsonWithCustomContentTypeAuthSchemeParams.Builder paramsBuilder = ProtocolRestJsonWithCustomContentTypeAuthSchemeParams
             .builder().operation(operationName);
         paramsBuilder.region(executionAttributes.getAttribute(AwsExecutionAttribute.AWS_REGION));
         List<AuthSchemeOption> options = authSchemeProvider.resolveAuthScheme(paramsBuilder.build());
+        if (useCache) {
+            authSchemeCache.put(operationName, options);
+        }
         return options;
     }
 

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-customservicemetadata-async.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-customservicemetadata-async.java
@@ -224,8 +224,9 @@ final class DefaultProtocolRestJsonWithCustomContentTypeAsyncClient implements P
                                                                                                                                                "Expected an instance of ProtocolRestJsonWithCustomContentTypeAuthSchemeProvider");
         boolean useCache = requestAuthSchemeProvider == null
                 && authSchemeProvider instanceof DefaultProtocolRestJsonWithCustomContentTypeAuthSchemeProvider;
+        String cacheKey = String.valueOf(executionAttributes.getAttribute(AwsExecutionAttribute.AWS_REGION));
         if (useCache) {
-            List<AuthSchemeOption> cached = authSchemeCache.get(operationName);
+            List<AuthSchemeOption> cached = authSchemeCache.get(cacheKey);
             if (cached != null) {
                 return cached;
             }
@@ -235,7 +236,8 @@ final class DefaultProtocolRestJsonWithCustomContentTypeAsyncClient implements P
         paramsBuilder.region(executionAttributes.getAttribute(AwsExecutionAttribute.AWS_REGION));
         List<AuthSchemeOption> options = authSchemeProvider.resolveAuthScheme(paramsBuilder.build());
         if (useCache) {
-            authSchemeCache.put(operationName, options);
+            options = Collections.unmodifiableList(options);
+            authSchemeCache.put(cacheKey, options);
         }
         return options;
     }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-customservicemetadata-sync.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-customservicemetadata-sync.java
@@ -4,6 +4,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import software.amazon.awssdk.annotations.Generated;
@@ -46,6 +47,7 @@ import software.amazon.awssdk.protocols.json.JsonOperationMetadata;
 import software.amazon.awssdk.retries.api.RetryStrategy;
 import software.amazon.awssdk.services.protocolrestjsonwithcustomcontenttype.auth.scheme.ProtocolRestJsonWithCustomContentTypeAuthSchemeParams;
 import software.amazon.awssdk.services.protocolrestjsonwithcustomcontenttype.auth.scheme.ProtocolRestJsonWithCustomContentTypeAuthSchemeProvider;
+import software.amazon.awssdk.services.protocolrestjsonwithcustomcontenttype.auth.scheme.internal.DefaultProtocolRestJsonWithCustomContentTypeAuthSchemeProvider;
 import software.amazon.awssdk.services.protocolrestjsonwithcustomcontenttype.endpoints.ProtocolRestJsonWithCustomContentTypeEndpointParams;
 import software.amazon.awssdk.services.protocolrestjsonwithcustomcontenttype.endpoints.ProtocolRestJsonWithCustomContentTypeEndpointProvider;
 import software.amazon.awssdk.services.protocolrestjsonwithcustomcontenttype.endpoints.internal.ProtocolRestJsonWithCustomContentTypeEndpointResolverUtils;
@@ -86,6 +88,8 @@ final class DefaultProtocolRestJsonWithCustomContentTypeClient implements Protoc
                 return Optional.empty();
         }
     };
+
+    private final ConcurrentHashMap<String, List<AuthSchemeOption>> authSchemeCache = new ConcurrentHashMap<>();
 
     protected DefaultProtocolRestJsonWithCustomContentTypeClient(SdkClientConfiguration clientConfiguration) {
         this.clientHandler = new AwsSyncClientHandler(clientConfiguration);
@@ -186,10 +190,21 @@ final class DefaultProtocolRestJsonWithCustomContentTypeClient implements Protoc
                                                                                                                        : Validate.isInstanceOf(ProtocolRestJsonWithCustomContentTypeAuthSchemeProvider.class,
                                                                                                                                                executionAttributes.getAttribute(SdkInternalExecutionAttribute.AUTH_SCHEME_RESOLVER),
                                                                                                                                                "Expected an instance of ProtocolRestJsonWithCustomContentTypeAuthSchemeProvider");
+        boolean useCache = requestAuthSchemeProvider == null
+                && authSchemeProvider instanceof DefaultProtocolRestJsonWithCustomContentTypeAuthSchemeProvider;
+        if (useCache) {
+            List<AuthSchemeOption> cached = authSchemeCache.get(operationName);
+            if (cached != null) {
+                return cached;
+            }
+        }
         ProtocolRestJsonWithCustomContentTypeAuthSchemeParams.Builder paramsBuilder = ProtocolRestJsonWithCustomContentTypeAuthSchemeParams
             .builder().operation(operationName);
         paramsBuilder.region(executionAttributes.getAttribute(AwsExecutionAttribute.AWS_REGION));
         List<AuthSchemeOption> options = authSchemeProvider.resolveAuthScheme(paramsBuilder.build());
+        if (useCache) {
+            authSchemeCache.put(operationName, options);
+        }
         return options;
     }
 

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-customservicemetadata-sync.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-customservicemetadata-sync.java
@@ -192,8 +192,9 @@ final class DefaultProtocolRestJsonWithCustomContentTypeClient implements Protoc
                                                                                                                                                "Expected an instance of ProtocolRestJsonWithCustomContentTypeAuthSchemeProvider");
         boolean useCache = requestAuthSchemeProvider == null
                 && authSchemeProvider instanceof DefaultProtocolRestJsonWithCustomContentTypeAuthSchemeProvider;
+        String cacheKey = String.valueOf(executionAttributes.getAttribute(AwsExecutionAttribute.AWS_REGION));
         if (useCache) {
-            List<AuthSchemeOption> cached = authSchemeCache.get(operationName);
+            List<AuthSchemeOption> cached = authSchemeCache.get(cacheKey);
             if (cached != null) {
                 return cached;
             }
@@ -203,7 +204,8 @@ final class DefaultProtocolRestJsonWithCustomContentTypeClient implements Protoc
         paramsBuilder.region(executionAttributes.getAttribute(AwsExecutionAttribute.AWS_REGION));
         List<AuthSchemeOption> options = authSchemeProvider.resolveAuthScheme(paramsBuilder.build());
         if (useCache) {
-            authSchemeCache.put(operationName, options);
+            options = Collections.unmodifiableList(options);
+            authSchemeCache.put(cacheKey, options);
         }
         return options;
     }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-endpoint-discovery-async.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-endpoint-discovery-async.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import org.slf4j.Logger;
@@ -57,6 +58,7 @@ import software.amazon.awssdk.protocols.json.JsonOperationMetadata;
 import software.amazon.awssdk.retries.api.RetryStrategy;
 import software.amazon.awssdk.services.endpointdiscoverytest.auth.scheme.EndpointDiscoveryTestAuthSchemeParams;
 import software.amazon.awssdk.services.endpointdiscoverytest.auth.scheme.EndpointDiscoveryTestAuthSchemeProvider;
+import software.amazon.awssdk.services.endpointdiscoverytest.auth.scheme.internal.DefaultEndpointDiscoveryTestAuthSchemeProvider;
 import software.amazon.awssdk.services.endpointdiscoverytest.endpoints.EndpointDiscoveryTestEndpointParams;
 import software.amazon.awssdk.services.endpointdiscoverytest.endpoints.EndpointDiscoveryTestEndpointProvider;
 import software.amazon.awssdk.services.endpointdiscoverytest.endpoints.internal.EndpointDiscoveryTestEndpointResolverUtils;
@@ -108,6 +110,8 @@ final class DefaultEndpointDiscoveryTestAsyncClient implements EndpointDiscovery
     };
 
     private EndpointDiscoveryRefreshCache endpointDiscoveryCache;
+
+    private final ConcurrentHashMap<String, List<AuthSchemeOption>> authSchemeCache = new ConcurrentHashMap<>();
 
     protected DefaultEndpointDiscoveryTestAsyncClient(SdkClientConfiguration clientConfiguration) {
         this.clientHandler = new AwsAsyncClientHandler(clientConfiguration);
@@ -479,10 +483,21 @@ final class DefaultEndpointDiscoveryTestAsyncClient implements EndpointDiscovery
                                                                                                        : Validate.isInstanceOf(EndpointDiscoveryTestAuthSchemeProvider.class,
                                                                                                                                executionAttributes.getAttribute(SdkInternalExecutionAttribute.AUTH_SCHEME_RESOLVER),
                                                                                                                                "Expected an instance of EndpointDiscoveryTestAuthSchemeProvider");
+        boolean useCache = requestAuthSchemeProvider == null
+                && authSchemeProvider instanceof DefaultEndpointDiscoveryTestAuthSchemeProvider;
+        if (useCache) {
+            List<AuthSchemeOption> cached = authSchemeCache.get(operationName);
+            if (cached != null) {
+                return cached;
+            }
+        }
         EndpointDiscoveryTestAuthSchemeParams.Builder paramsBuilder = EndpointDiscoveryTestAuthSchemeParams.builder().operation(
             operationName);
         paramsBuilder.region(executionAttributes.getAttribute(AwsExecutionAttribute.AWS_REGION));
         List<AuthSchemeOption> options = authSchemeProvider.resolveAuthScheme(paramsBuilder.build());
+        if (useCache) {
+            authSchemeCache.put(operationName, options);
+        }
         return options;
     }
 

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-endpoint-discovery-async.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-endpoint-discovery-async.java
@@ -485,8 +485,9 @@ final class DefaultEndpointDiscoveryTestAsyncClient implements EndpointDiscovery
                                                                                                                                "Expected an instance of EndpointDiscoveryTestAuthSchemeProvider");
         boolean useCache = requestAuthSchemeProvider == null
                 && authSchemeProvider instanceof DefaultEndpointDiscoveryTestAuthSchemeProvider;
+        String cacheKey = String.valueOf(executionAttributes.getAttribute(AwsExecutionAttribute.AWS_REGION));
         if (useCache) {
-            List<AuthSchemeOption> cached = authSchemeCache.get(operationName);
+            List<AuthSchemeOption> cached = authSchemeCache.get(cacheKey);
             if (cached != null) {
                 return cached;
             }
@@ -496,7 +497,8 @@ final class DefaultEndpointDiscoveryTestAsyncClient implements EndpointDiscovery
         paramsBuilder.region(executionAttributes.getAttribute(AwsExecutionAttribute.AWS_REGION));
         List<AuthSchemeOption> options = authSchemeProvider.resolveAuthScheme(paramsBuilder.build());
         if (useCache) {
-            authSchemeCache.put(operationName, options);
+            options = Collections.unmodifiableList(options);
+            authSchemeCache.put(cacheKey, options);
         }
         return options;
     }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-endpoint-discovery-sync.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-endpoint-discovery-sync.java
@@ -406,8 +406,9 @@ final class DefaultEndpointDiscoveryTestClient implements EndpointDiscoveryTestC
                                                                                                                                "Expected an instance of EndpointDiscoveryTestAuthSchemeProvider");
         boolean useCache = requestAuthSchemeProvider == null
                 && authSchemeProvider instanceof DefaultEndpointDiscoveryTestAuthSchemeProvider;
+        String cacheKey = String.valueOf(executionAttributes.getAttribute(AwsExecutionAttribute.AWS_REGION));
         if (useCache) {
-            List<AuthSchemeOption> cached = authSchemeCache.get(operationName);
+            List<AuthSchemeOption> cached = authSchemeCache.get(cacheKey);
             if (cached != null) {
                 return cached;
             }
@@ -417,7 +418,8 @@ final class DefaultEndpointDiscoveryTestClient implements EndpointDiscoveryTestC
         paramsBuilder.region(executionAttributes.getAttribute(AwsExecutionAttribute.AWS_REGION));
         List<AuthSchemeOption> options = authSchemeProvider.resolveAuthScheme(paramsBuilder.build());
         if (useCache) {
-            authSchemeCache.put(operationName, options);
+            options = Collections.unmodifiableList(options);
+            authSchemeCache.put(cacheKey, options);
         }
         return options;
     }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-endpoint-discovery-sync.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-endpoint-discovery-sync.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import software.amazon.awssdk.annotations.Generated;
@@ -53,6 +54,7 @@ import software.amazon.awssdk.protocols.json.JsonOperationMetadata;
 import software.amazon.awssdk.retries.api.RetryStrategy;
 import software.amazon.awssdk.services.endpointdiscoverytest.auth.scheme.EndpointDiscoveryTestAuthSchemeParams;
 import software.amazon.awssdk.services.endpointdiscoverytest.auth.scheme.EndpointDiscoveryTestAuthSchemeProvider;
+import software.amazon.awssdk.services.endpointdiscoverytest.auth.scheme.internal.DefaultEndpointDiscoveryTestAuthSchemeProvider;
 import software.amazon.awssdk.services.endpointdiscoverytest.endpoints.EndpointDiscoveryTestEndpointParams;
 import software.amazon.awssdk.services.endpointdiscoverytest.endpoints.EndpointDiscoveryTestEndpointProvider;
 import software.amazon.awssdk.services.endpointdiscoverytest.endpoints.internal.EndpointDiscoveryTestEndpointResolverUtils;
@@ -104,7 +106,10 @@ final class DefaultEndpointDiscoveryTestClient implements EndpointDiscoveryTestC
         }
     };
 
+    private final ConcurrentHashMap<String, List<AuthSchemeOption>> authSchemeCache = new ConcurrentHashMap<>();
+
     private EndpointDiscoveryRefreshCache endpointDiscoveryCache;
+
 
     protected DefaultEndpointDiscoveryTestClient(SdkClientConfiguration clientConfiguration) {
         this.clientHandler = new AwsSyncClientHandler(clientConfiguration);
@@ -399,10 +404,21 @@ final class DefaultEndpointDiscoveryTestClient implements EndpointDiscoveryTestC
                                                                                                        : Validate.isInstanceOf(EndpointDiscoveryTestAuthSchemeProvider.class,
                                                                                                                                executionAttributes.getAttribute(SdkInternalExecutionAttribute.AUTH_SCHEME_RESOLVER),
                                                                                                                                "Expected an instance of EndpointDiscoveryTestAuthSchemeProvider");
+        boolean useCache = requestAuthSchemeProvider == null
+                && authSchemeProvider instanceof DefaultEndpointDiscoveryTestAuthSchemeProvider;
+        if (useCache) {
+            List<AuthSchemeOption> cached = authSchemeCache.get(operationName);
+            if (cached != null) {
+                return cached;
+            }
+        }
         EndpointDiscoveryTestAuthSchemeParams.Builder paramsBuilder = EndpointDiscoveryTestAuthSchemeParams.builder().operation(
             operationName);
         paramsBuilder.region(executionAttributes.getAttribute(AwsExecutionAttribute.AWS_REGION));
         List<AuthSchemeOption> options = authSchemeProvider.resolveAuthScheme(paramsBuilder.build());
+        if (useCache) {
+            authSchemeCache.put(operationName, options);
+        }
         return options;
     }
 

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-json-async-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-json-async-client-class.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Consumer;
@@ -75,6 +76,7 @@ import software.amazon.awssdk.protocols.json.JsonOperationMetadata;
 import software.amazon.awssdk.retries.api.RetryStrategy;
 import software.amazon.awssdk.services.json.auth.scheme.JsonAuthSchemeParams;
 import software.amazon.awssdk.services.json.auth.scheme.JsonAuthSchemeProvider;
+import software.amazon.awssdk.services.json.auth.scheme.internal.DefaultJsonAuthSchemeProvider;
 import software.amazon.awssdk.services.json.batchmanager.JsonAsyncBatchManager;
 import software.amazon.awssdk.services.json.endpoints.JsonEndpointParams;
 import software.amazon.awssdk.services.json.endpoints.JsonEndpointProvider;
@@ -181,7 +183,10 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
 
     private final ScheduledExecutorService executorService;
 
+    private final ConcurrentHashMap<String, List<AuthSchemeOption>> authSchemeCache = new ConcurrentHashMap<>();
+
     private final Executor executor;
+
 
     protected DefaultJsonAsyncClient(SdkClientConfiguration clientConfiguration) {
         this.clientHandler = new AwsAsyncClientHandler(clientConfiguration);
@@ -1458,9 +1463,20 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
         JsonAuthSchemeProvider authSchemeProvider = requestAuthSchemeProvider != null ? requestAuthSchemeProvider : Validate
             .isInstanceOf(JsonAuthSchemeProvider.class, executionAttributes.getAttribute(SdkInternalExecutionAttribute.AUTH_SCHEME_RESOLVER),
                           "Expected an instance of JsonAuthSchemeProvider");
+        boolean useCache = requestAuthSchemeProvider == null
+                && authSchemeProvider instanceof DefaultJsonAuthSchemeProvider;
+        if (useCache) {
+            List<AuthSchemeOption> cached = authSchemeCache.get(operationName);
+            if (cached != null) {
+                return cached;
+            }
+        }
         JsonAuthSchemeParams.Builder paramsBuilder = JsonAuthSchemeParams.builder().operation(operationName);
         paramsBuilder.region(executionAttributes.getAttribute(AwsExecutionAttribute.AWS_REGION));
         List<AuthSchemeOption> options = authSchemeProvider.resolveAuthScheme(paramsBuilder.build());
+        if (useCache) {
+            authSchemeCache.put(operationName, options);
+        }
         return options;
     }
 

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-json-async-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-json-async-client-class.java
@@ -1465,8 +1465,9 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
                           "Expected an instance of JsonAuthSchemeProvider");
         boolean useCache = requestAuthSchemeProvider == null
                 && authSchemeProvider instanceof DefaultJsonAuthSchemeProvider;
+        String cacheKey = operationName + ":" + executionAttributes.getAttribute(AwsExecutionAttribute.AWS_REGION);
         if (useCache) {
-            List<AuthSchemeOption> cached = authSchemeCache.get(operationName);
+            List<AuthSchemeOption> cached = authSchemeCache.get(cacheKey);
             if (cached != null) {
                 return cached;
             }
@@ -1475,7 +1476,8 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
         paramsBuilder.region(executionAttributes.getAttribute(AwsExecutionAttribute.AWS_REGION));
         List<AuthSchemeOption> options = authSchemeProvider.resolveAuthScheme(paramsBuilder.build());
         if (useCache) {
-            authSchemeCache.put(operationName, options);
+            options = Collections.unmodifiableList(options);
+            authSchemeCache.put(cacheKey, options);
         }
         return options;
     }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-json-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-json-client-class.java
@@ -4,6 +4,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import software.amazon.awssdk.annotations.Generated;
@@ -54,6 +55,7 @@ import software.amazon.awssdk.protocols.json.JsonOperationMetadata;
 import software.amazon.awssdk.retries.api.RetryStrategy;
 import software.amazon.awssdk.services.json.auth.scheme.JsonAuthSchemeParams;
 import software.amazon.awssdk.services.json.auth.scheme.JsonAuthSchemeProvider;
+import software.amazon.awssdk.services.json.auth.scheme.internal.DefaultJsonAuthSchemeProvider;
 import software.amazon.awssdk.services.json.endpoints.JsonEndpointParams;
 import software.amazon.awssdk.services.json.endpoints.JsonEndpointProvider;
 import software.amazon.awssdk.services.json.endpoints.internal.JsonEndpointResolverUtils;
@@ -135,6 +137,8 @@ final class DefaultJsonClient implements JsonClient {
                 return Optional.empty();
         }
     };
+
+    private final ConcurrentHashMap<String, List<AuthSchemeOption>> authSchemeCache = new ConcurrentHashMap<>();
 
     protected DefaultJsonClient(SdkClientConfiguration clientConfiguration) {
         this.clientHandler = new AwsSyncClientHandler(clientConfiguration);
@@ -979,9 +983,20 @@ final class DefaultJsonClient implements JsonClient {
             .isInstanceOf(JsonAuthSchemeProvider.class,
                           executionAttributes.getAttribute(SdkInternalExecutionAttribute.AUTH_SCHEME_RESOLVER),
                           "Expected an instance of JsonAuthSchemeProvider");
+        boolean useCache = requestAuthSchemeProvider == null
+                && authSchemeProvider instanceof DefaultJsonAuthSchemeProvider;
+        if (useCache) {
+            List<AuthSchemeOption> cached = authSchemeCache.get(operationName);
+            if (cached != null) {
+                return cached;
+            }
+        }
         JsonAuthSchemeParams.Builder paramsBuilder = JsonAuthSchemeParams.builder().operation(operationName);
         paramsBuilder.region(executionAttributes.getAttribute(AwsExecutionAttribute.AWS_REGION));
         List<AuthSchemeOption> options = authSchemeProvider.resolveAuthScheme(paramsBuilder.build());
+        if (useCache) {
+            authSchemeCache.put(operationName, options);
+        }
         return options;
     }
 

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-json-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-json-client-class.java
@@ -985,8 +985,9 @@ final class DefaultJsonClient implements JsonClient {
                           "Expected an instance of JsonAuthSchemeProvider");
         boolean useCache = requestAuthSchemeProvider == null
                 && authSchemeProvider instanceof DefaultJsonAuthSchemeProvider;
+        String cacheKey = operationName + ":" + executionAttributes.getAttribute(AwsExecutionAttribute.AWS_REGION);
         if (useCache) {
-            List<AuthSchemeOption> cached = authSchemeCache.get(operationName);
+            List<AuthSchemeOption> cached = authSchemeCache.get(cacheKey);
             if (cached != null) {
                 return cached;
             }
@@ -995,7 +996,8 @@ final class DefaultJsonClient implements JsonClient {
         paramsBuilder.region(executionAttributes.getAttribute(AwsExecutionAttribute.AWS_REGION));
         List<AuthSchemeOption> options = authSchemeProvider.resolveAuthScheme(paramsBuilder.build());
         if (useCache) {
-            authSchemeCache.put(operationName, options);
+            options = Collections.unmodifiableList(options);
+            authSchemeCache.put(cacheKey, options);
         }
         return options;
     }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-presignedurl-async.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-presignedurl-async.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import org.slf4j.Logger;
@@ -51,6 +52,7 @@ import software.amazon.awssdk.protocols.json.JsonOperationMetadata;
 import software.amazon.awssdk.retries.api.RetryStrategy;
 import software.amazon.awssdk.services.json.auth.scheme.JsonAuthSchemeParams;
 import software.amazon.awssdk.services.json.auth.scheme.JsonAuthSchemeProvider;
+import software.amazon.awssdk.services.json.auth.scheme.internal.DefaultJsonAuthSchemeProvider;
 import software.amazon.awssdk.services.json.endpoints.JsonEndpointParams;
 import software.amazon.awssdk.services.json.endpoints.JsonEndpointProvider;
 import software.amazon.awssdk.services.json.endpoints.internal.JsonEndpointResolverUtils;
@@ -97,6 +99,8 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
                 return Optional.empty();
         }
     };
+
+    private final ConcurrentHashMap<String, List<AuthSchemeOption>> authSchemeCache = new ConcurrentHashMap<>();
 
     protected DefaultJsonAsyncClient(SdkClientConfiguration clientConfiguration) {
         this.clientHandler = new AwsAsyncClientHandler(clientConfiguration);
@@ -228,9 +232,20 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
         JsonAuthSchemeProvider authSchemeProvider = requestAuthSchemeProvider != null ? requestAuthSchemeProvider : Validate
                                                                                                                     .isInstanceOf(JsonAuthSchemeProvider.class, executionAttributes.getAttribute(SdkInternalExecutionAttribute.AUTH_SCHEME_RESOLVER),
                                                                                                                                   "Expected an instance of JsonAuthSchemeProvider");
+        boolean useCache = requestAuthSchemeProvider == null
+                && authSchemeProvider instanceof DefaultJsonAuthSchemeProvider;
+        if (useCache) {
+            List<AuthSchemeOption> cached = authSchemeCache.get(operationName);
+            if (cached != null) {
+                return cached;
+            }
+        }
         JsonAuthSchemeParams.Builder paramsBuilder = JsonAuthSchemeParams.builder().operation(operationName);
         paramsBuilder.region(executionAttributes.getAttribute(AwsExecutionAttribute.AWS_REGION));
         List<AuthSchemeOption> options = authSchemeProvider.resolveAuthScheme(paramsBuilder.build());
+        if (useCache) {
+            authSchemeCache.put(operationName, options);
+        }
         return options;
     }
 

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-presignedurl-async.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-presignedurl-async.java
@@ -234,8 +234,9 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
                                                                                                                                   "Expected an instance of JsonAuthSchemeProvider");
         boolean useCache = requestAuthSchemeProvider == null
                 && authSchemeProvider instanceof DefaultJsonAuthSchemeProvider;
+        String cacheKey = String.valueOf(executionAttributes.getAttribute(AwsExecutionAttribute.AWS_REGION));
         if (useCache) {
-            List<AuthSchemeOption> cached = authSchemeCache.get(operationName);
+            List<AuthSchemeOption> cached = authSchemeCache.get(cacheKey);
             if (cached != null) {
                 return cached;
             }
@@ -244,7 +245,8 @@ final class DefaultJsonAsyncClient implements JsonAsyncClient {
         paramsBuilder.region(executionAttributes.getAttribute(AwsExecutionAttribute.AWS_REGION));
         List<AuthSchemeOption> options = authSchemeProvider.resolveAuthScheme(paramsBuilder.build());
         if (useCache) {
-            authSchemeCache.put(operationName, options);
+            options = Collections.unmodifiableList(options);
+            authSchemeCache.put(cacheKey, options);
         }
         return options;
     }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-query-async-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-query-async-client-class.java
@@ -1250,8 +1250,9 @@ final class DefaultQueryAsyncClient implements QueryAsyncClient {
                           "Expected an instance of QueryAuthSchemeProvider");
         boolean useCache = requestAuthSchemeProvider == null
                 && authSchemeProvider instanceof DefaultQueryAuthSchemeProvider;
+        String cacheKey = operationName + ":" + executionAttributes.getAttribute(AwsExecutionAttribute.AWS_REGION);
         if (useCache) {
-            List<AuthSchemeOption> cached = authSchemeCache.get(operationName);
+            List<AuthSchemeOption> cached = authSchemeCache.get(cacheKey);
             if (cached != null) {
                 return cached;
             }
@@ -1260,7 +1261,8 @@ final class DefaultQueryAsyncClient implements QueryAsyncClient {
         paramsBuilder.region(executionAttributes.getAttribute(AwsExecutionAttribute.AWS_REGION));
         List<AuthSchemeOption> options = authSchemeProvider.resolveAuthScheme(paramsBuilder.build());
         if (useCache) {
-            authSchemeCache.put(operationName, options);
+            options = Collections.unmodifiableList(options);
+            authSchemeCache.put(cacheKey, options);
         }
         return options;
     }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-query-async-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-query-async-client-class.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Consumer;
 import org.slf4j.Logger;
@@ -58,6 +59,7 @@ import software.amazon.awssdk.protocols.query.AwsQueryProtocolFactory;
 import software.amazon.awssdk.retries.api.RetryStrategy;
 import software.amazon.awssdk.services.query.auth.scheme.QueryAuthSchemeParams;
 import software.amazon.awssdk.services.query.auth.scheme.QueryAuthSchemeProvider;
+import software.amazon.awssdk.services.query.auth.scheme.internal.DefaultQueryAuthSchemeProvider;
 import software.amazon.awssdk.services.query.endpoints.QueryEndpointParams;
 import software.amazon.awssdk.services.query.endpoints.QueryEndpointProvider;
 import software.amazon.awssdk.services.query.endpoints.internal.QueryEndpointResolverUtils;
@@ -138,6 +140,8 @@ final class DefaultQueryAsyncClient implements QueryAsyncClient {
     private final SdkClientConfiguration clientConfiguration;
 
     private final ScheduledExecutorService executorService;
+
+    private final ConcurrentHashMap<String, List<AuthSchemeOption>> authSchemeCache = new ConcurrentHashMap<>();
 
     protected DefaultQueryAsyncClient(SdkClientConfiguration clientConfiguration) {
         this.clientHandler = new AwsAsyncClientHandler(clientConfiguration);
@@ -1244,9 +1248,20 @@ final class DefaultQueryAsyncClient implements QueryAsyncClient {
         QueryAuthSchemeProvider authSchemeProvider = requestAuthSchemeProvider != null ? requestAuthSchemeProvider : Validate
             .isInstanceOf(QueryAuthSchemeProvider.class, executionAttributes.getAttribute(SdkInternalExecutionAttribute.AUTH_SCHEME_RESOLVER),
                           "Expected an instance of QueryAuthSchemeProvider");
+        boolean useCache = requestAuthSchemeProvider == null
+                && authSchemeProvider instanceof DefaultQueryAuthSchemeProvider;
+        if (useCache) {
+            List<AuthSchemeOption> cached = authSchemeCache.get(operationName);
+            if (cached != null) {
+                return cached;
+            }
+        }
         QueryAuthSchemeParams.Builder paramsBuilder = QueryAuthSchemeParams.builder().operation(operationName);
         paramsBuilder.region(executionAttributes.getAttribute(AwsExecutionAttribute.AWS_REGION));
         List<AuthSchemeOption> options = authSchemeProvider.resolveAuthScheme(paramsBuilder.build());
+        if (useCache) {
+            authSchemeCache.put(operationName, options);
+        }
         return options;
     }
 

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-query-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-query-client-class.java
@@ -1068,8 +1068,9 @@ final class DefaultQueryClient implements QueryClient {
                           "Expected an instance of QueryAuthSchemeProvider");
         boolean useCache = requestAuthSchemeProvider == null
                 && authSchemeProvider instanceof DefaultQueryAuthSchemeProvider;
+        String cacheKey = operationName + ":" + executionAttributes.getAttribute(AwsExecutionAttribute.AWS_REGION);
         if (useCache) {
-            List<AuthSchemeOption> cached = authSchemeCache.get(operationName);
+            List<AuthSchemeOption> cached = authSchemeCache.get(cacheKey);
             if (cached != null) {
                 return cached;
             }
@@ -1078,7 +1079,8 @@ final class DefaultQueryClient implements QueryClient {
         paramsBuilder.region(executionAttributes.getAttribute(AwsExecutionAttribute.AWS_REGION));
         List<AuthSchemeOption> options = authSchemeProvider.resolveAuthScheme(paramsBuilder.build());
         if (useCache) {
-            authSchemeCache.put(operationName, options);
+            options = Collections.unmodifiableList(options);
+            authSchemeCache.put(cacheKey, options);
         }
         return options;
     }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-query-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-query-client-class.java
@@ -4,6 +4,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.annotations.SdkInternalApi;
@@ -51,6 +52,7 @@ import software.amazon.awssdk.protocols.query.AwsQueryProtocolFactory;
 import software.amazon.awssdk.retries.api.RetryStrategy;
 import software.amazon.awssdk.services.query.auth.scheme.QueryAuthSchemeParams;
 import software.amazon.awssdk.services.query.auth.scheme.QueryAuthSchemeProvider;
+import software.amazon.awssdk.services.query.auth.scheme.internal.DefaultQueryAuthSchemeProvider;
 import software.amazon.awssdk.services.query.endpoints.QueryEndpointParams;
 import software.amazon.awssdk.services.query.endpoints.QueryEndpointProvider;
 import software.amazon.awssdk.services.query.endpoints.internal.QueryEndpointResolverUtils;
@@ -128,6 +130,8 @@ final class DefaultQueryClient implements QueryClient {
     private final AwsQueryProtocolFactory protocolFactory;
 
     private final SdkClientConfiguration clientConfiguration;
+
+    private final ConcurrentHashMap<String, List<AuthSchemeOption>> authSchemeCache = new ConcurrentHashMap<>();
 
     protected DefaultQueryClient(SdkClientConfiguration clientConfiguration) {
         this.clientHandler = new AwsSyncClientHandler(clientConfiguration);
@@ -1062,9 +1066,20 @@ final class DefaultQueryClient implements QueryClient {
             .isInstanceOf(QueryAuthSchemeProvider.class,
                           executionAttributes.getAttribute(SdkInternalExecutionAttribute.AUTH_SCHEME_RESOLVER),
                           "Expected an instance of QueryAuthSchemeProvider");
+        boolean useCache = requestAuthSchemeProvider == null
+                && authSchemeProvider instanceof DefaultQueryAuthSchemeProvider;
+        if (useCache) {
+            List<AuthSchemeOption> cached = authSchemeCache.get(operationName);
+            if (cached != null) {
+                return cached;
+            }
+        }
         QueryAuthSchemeParams.Builder paramsBuilder = QueryAuthSchemeParams.builder().operation(operationName);
         paramsBuilder.region(executionAttributes.getAttribute(AwsExecutionAttribute.AWS_REGION));
         List<AuthSchemeOption> options = authSchemeProvider.resolveAuthScheme(paramsBuilder.build());
+        if (useCache) {
+            authSchemeCache.put(operationName, options);
+        }
         return options;
     }
 

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-rpcv2-async-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-rpcv2-async-client-class.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import org.slf4j.Logger;
@@ -51,6 +52,7 @@ import software.amazon.awssdk.protocols.rpcv2.SmithyRpcV2CborProtocolFactory;
 import software.amazon.awssdk.retries.api.RetryStrategy;
 import software.amazon.awssdk.services.smithyrpcv2protocol.auth.scheme.SmithyRpcV2ProtocolAuthSchemeParams;
 import software.amazon.awssdk.services.smithyrpcv2protocol.auth.scheme.SmithyRpcV2ProtocolAuthSchemeProvider;
+import software.amazon.awssdk.services.smithyrpcv2protocol.auth.scheme.internal.DefaultSmithyRpcV2ProtocolAuthSchemeProvider;
 import software.amazon.awssdk.services.smithyrpcv2protocol.endpoints.SmithyRpcV2ProtocolEndpointParams;
 import software.amazon.awssdk.services.smithyrpcv2protocol.endpoints.SmithyRpcV2ProtocolEndpointProvider;
 import software.amazon.awssdk.services.smithyrpcv2protocol.endpoints.internal.SmithyRpcV2ProtocolEndpointResolverUtils;
@@ -139,6 +141,8 @@ final class DefaultSmithyRpcV2ProtocolAsyncClient implements SmithyRpcV2Protocol
                 return Optional.empty();
         }
     };
+
+    private final ConcurrentHashMap<String, List<AuthSchemeOption>> authSchemeCache = new ConcurrentHashMap<>();
 
     protected DefaultSmithyRpcV2ProtocolAsyncClient(SdkClientConfiguration clientConfiguration) {
         this.clientHandler = new AwsAsyncClientHandler(clientConfiguration);
@@ -945,10 +949,21 @@ final class DefaultSmithyRpcV2ProtocolAsyncClient implements SmithyRpcV2Protocol
                                                                                                      : Validate.isInstanceOf(SmithyRpcV2ProtocolAuthSchemeProvider.class,
                                                                                                                              executionAttributes.getAttribute(SdkInternalExecutionAttribute.AUTH_SCHEME_RESOLVER),
                                                                                                                              "Expected an instance of SmithyRpcV2ProtocolAuthSchemeProvider");
+        boolean useCache = requestAuthSchemeProvider == null
+                && authSchemeProvider instanceof DefaultSmithyRpcV2ProtocolAuthSchemeProvider;
+        if (useCache) {
+            List<AuthSchemeOption> cached = authSchemeCache.get(operationName);
+            if (cached != null) {
+                return cached;
+            }
+        }
         SmithyRpcV2ProtocolAuthSchemeParams.Builder paramsBuilder = SmithyRpcV2ProtocolAuthSchemeParams.builder().operation(
             operationName);
         paramsBuilder.region(executionAttributes.getAttribute(AwsExecutionAttribute.AWS_REGION));
         List<AuthSchemeOption> options = authSchemeProvider.resolveAuthScheme(paramsBuilder.build());
+        if (useCache) {
+            authSchemeCache.put(operationName, options);
+        }
         return options;
     }
 

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-rpcv2-async-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-rpcv2-async-client-class.java
@@ -951,8 +951,9 @@ final class DefaultSmithyRpcV2ProtocolAsyncClient implements SmithyRpcV2Protocol
                                                                                                                              "Expected an instance of SmithyRpcV2ProtocolAuthSchemeProvider");
         boolean useCache = requestAuthSchemeProvider == null
                 && authSchemeProvider instanceof DefaultSmithyRpcV2ProtocolAuthSchemeProvider;
+        String cacheKey = String.valueOf(executionAttributes.getAttribute(AwsExecutionAttribute.AWS_REGION));
         if (useCache) {
-            List<AuthSchemeOption> cached = authSchemeCache.get(operationName);
+            List<AuthSchemeOption> cached = authSchemeCache.get(cacheKey);
             if (cached != null) {
                 return cached;
             }
@@ -962,7 +963,8 @@ final class DefaultSmithyRpcV2ProtocolAsyncClient implements SmithyRpcV2Protocol
         paramsBuilder.region(executionAttributes.getAttribute(AwsExecutionAttribute.AWS_REGION));
         List<AuthSchemeOption> options = authSchemeProvider.resolveAuthScheme(paramsBuilder.build());
         if (useCache) {
-            authSchemeCache.put(operationName, options);
+            options = Collections.unmodifiableList(options);
+            authSchemeCache.put(cacheKey, options);
         }
         return options;
     }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-rpcv2-sync.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-rpcv2-sync.java
@@ -4,6 +4,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import software.amazon.awssdk.annotations.Generated;
@@ -46,6 +47,7 @@ import software.amazon.awssdk.protocols.rpcv2.SmithyRpcV2CborProtocolFactory;
 import software.amazon.awssdk.retries.api.RetryStrategy;
 import software.amazon.awssdk.services.smithyrpcv2protocol.auth.scheme.SmithyRpcV2ProtocolAuthSchemeParams;
 import software.amazon.awssdk.services.smithyrpcv2protocol.auth.scheme.SmithyRpcV2ProtocolAuthSchemeProvider;
+import software.amazon.awssdk.services.smithyrpcv2protocol.auth.scheme.internal.DefaultSmithyRpcV2ProtocolAuthSchemeProvider;
 import software.amazon.awssdk.services.smithyrpcv2protocol.endpoints.SmithyRpcV2ProtocolEndpointParams;
 import software.amazon.awssdk.services.smithyrpcv2protocol.endpoints.SmithyRpcV2ProtocolEndpointProvider;
 import software.amazon.awssdk.services.smithyrpcv2protocol.endpoints.internal.SmithyRpcV2ProtocolEndpointResolverUtils;
@@ -134,6 +136,8 @@ final class DefaultSmithyRpcV2ProtocolClient implements SmithyRpcV2ProtocolClien
                 return Optional.empty();
         }
     };
+
+    private final ConcurrentHashMap<String, List<AuthSchemeOption>> authSchemeCache = new ConcurrentHashMap<>();
 
     protected DefaultSmithyRpcV2ProtocolClient(SdkClientConfiguration clientConfiguration) {
         this.clientHandler = new AwsSyncClientHandler(clientConfiguration);
@@ -824,10 +828,21 @@ final class DefaultSmithyRpcV2ProtocolClient implements SmithyRpcV2ProtocolClien
                                                                                                      : Validate.isInstanceOf(SmithyRpcV2ProtocolAuthSchemeProvider.class,
                                                                                                                              executionAttributes.getAttribute(SdkInternalExecutionAttribute.AUTH_SCHEME_RESOLVER),
                                                                                                                              "Expected an instance of SmithyRpcV2ProtocolAuthSchemeProvider");
+        boolean useCache = requestAuthSchemeProvider == null
+                && authSchemeProvider instanceof DefaultSmithyRpcV2ProtocolAuthSchemeProvider;
+        if (useCache) {
+            List<AuthSchemeOption> cached = authSchemeCache.get(operationName);
+            if (cached != null) {
+                return cached;
+            }
+        }
         SmithyRpcV2ProtocolAuthSchemeParams.Builder paramsBuilder = SmithyRpcV2ProtocolAuthSchemeParams.builder().operation(
             operationName);
         paramsBuilder.region(executionAttributes.getAttribute(AwsExecutionAttribute.AWS_REGION));
         List<AuthSchemeOption> options = authSchemeProvider.resolveAuthScheme(paramsBuilder.build());
+        if (useCache) {
+            authSchemeCache.put(operationName, options);
+        }
         return options;
     }
 

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-rpcv2-sync.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-rpcv2-sync.java
@@ -830,8 +830,9 @@ final class DefaultSmithyRpcV2ProtocolClient implements SmithyRpcV2ProtocolClien
                                                                                                                              "Expected an instance of SmithyRpcV2ProtocolAuthSchemeProvider");
         boolean useCache = requestAuthSchemeProvider == null
                 && authSchemeProvider instanceof DefaultSmithyRpcV2ProtocolAuthSchemeProvider;
+        String cacheKey = String.valueOf(executionAttributes.getAttribute(AwsExecutionAttribute.AWS_REGION));
         if (useCache) {
-            List<AuthSchemeOption> cached = authSchemeCache.get(operationName);
+            List<AuthSchemeOption> cached = authSchemeCache.get(cacheKey);
             if (cached != null) {
                 return cached;
             }
@@ -841,7 +842,8 @@ final class DefaultSmithyRpcV2ProtocolClient implements SmithyRpcV2ProtocolClien
         paramsBuilder.region(executionAttributes.getAttribute(AwsExecutionAttribute.AWS_REGION));
         List<AuthSchemeOption> options = authSchemeProvider.resolveAuthScheme(paramsBuilder.build());
         if (useCache) {
-            authSchemeCache.put(operationName, options);
+            options = Collections.unmodifiableList(options);
+            authSchemeCache.put(cacheKey, options);
         }
         return options;
     }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-unsigned-payload-trait-async-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-unsigned-payload-trait-async-client-class.java
@@ -8,6 +8,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import org.slf4j.Logger;
@@ -57,6 +58,7 @@ import software.amazon.awssdk.protocols.json.JsonOperationMetadata;
 import software.amazon.awssdk.retries.api.RetryStrategy;
 import software.amazon.awssdk.services.database.auth.scheme.DatabaseAuthSchemeParams;
 import software.amazon.awssdk.services.database.auth.scheme.DatabaseAuthSchemeProvider;
+import software.amazon.awssdk.services.database.auth.scheme.internal.DefaultDatabaseAuthSchemeProvider;
 import software.amazon.awssdk.services.database.endpoints.DatabaseEndpointParams;
 import software.amazon.awssdk.services.database.endpoints.DatabaseEndpointProvider;
 import software.amazon.awssdk.services.database.endpoints.internal.DatabaseEndpointResolverUtils;
@@ -132,6 +134,8 @@ final class DefaultDatabaseAsyncClient implements DatabaseAsyncClient {
                 return Optional.empty();
         }
     };
+
+    private final ConcurrentHashMap<String, List<AuthSchemeOption>> authSchemeCache = new ConcurrentHashMap<>();
 
     protected DefaultDatabaseAsyncClient(SdkClientConfiguration clientConfiguration) {
         this.clientHandler = new AwsAsyncClientHandler(clientConfiguration);
@@ -905,6 +909,14 @@ final class DefaultDatabaseAsyncClient implements DatabaseAsyncClient {
         DatabaseAuthSchemeProvider authSchemeProvider = requestAuthSchemeProvider != null ? requestAuthSchemeProvider : Validate
             .isInstanceOf(DatabaseAuthSchemeProvider.class, executionAttributes.getAttribute(SdkInternalExecutionAttribute.AUTH_SCHEME_RESOLVER),
                           "Expected an instance of DatabaseAuthSchemeProvider");
+        boolean useCache = requestAuthSchemeProvider == null
+                && authSchemeProvider instanceof DefaultDatabaseAuthSchemeProvider;
+        if (useCache) {
+            List<AuthSchemeOption> cached = authSchemeCache.get(operationName);
+            if (cached != null) {
+                return cached;
+            }
+        }
         DatabaseAuthSchemeParams.Builder paramsBuilder = DatabaseAuthSchemeParams.builder().operation(operationName);
         paramsBuilder.region(executionAttributes.getAttribute(AwsExecutionAttribute.AWS_REGION));
         Set<String> sigv4aRegionSet = executionAttributes.getAttribute(AwsExecutionAttribute.AWS_SIGV4A_SIGNING_REGION_SET);
@@ -912,6 +924,9 @@ final class DefaultDatabaseAsyncClient implements DatabaseAsyncClient {
             paramsBuilder.regionSet(RegionSet.create(sigv4aRegionSet));
         }
         List<AuthSchemeOption> options = authSchemeProvider.resolveAuthScheme(paramsBuilder.build());
+        if (useCache) {
+            authSchemeCache.put(operationName, options);
+        }
         return options;
     }
 

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-unsigned-payload-trait-async-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-unsigned-payload-trait-async-client-class.java
@@ -911,8 +911,10 @@ final class DefaultDatabaseAsyncClient implements DatabaseAsyncClient {
                           "Expected an instance of DatabaseAuthSchemeProvider");
         boolean useCache = requestAuthSchemeProvider == null
                 && authSchemeProvider instanceof DefaultDatabaseAuthSchemeProvider;
+        String cacheKey = operationName + ":" + executionAttributes.getAttribute(AwsExecutionAttribute.AWS_REGION) + ":"
+                + executionAttributes.getAttribute(AwsExecutionAttribute.AWS_SIGV4A_SIGNING_REGION_SET);
         if (useCache) {
-            List<AuthSchemeOption> cached = authSchemeCache.get(operationName);
+            List<AuthSchemeOption> cached = authSchemeCache.get(cacheKey);
             if (cached != null) {
                 return cached;
             }
@@ -925,7 +927,8 @@ final class DefaultDatabaseAsyncClient implements DatabaseAsyncClient {
         }
         List<AuthSchemeOption> options = authSchemeProvider.resolveAuthScheme(paramsBuilder.build());
         if (useCache) {
-            authSchemeCache.put(operationName, options);
+            options = Collections.unmodifiableList(options);
+            authSchemeCache.put(cacheKey, options);
         }
         return options;
     }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-unsigned-payload-trait-sync-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-unsigned-payload-trait-sync-client-class.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import software.amazon.awssdk.annotations.Generated;
@@ -52,6 +53,7 @@ import software.amazon.awssdk.protocols.json.JsonOperationMetadata;
 import software.amazon.awssdk.retries.api.RetryStrategy;
 import software.amazon.awssdk.services.database.auth.scheme.DatabaseAuthSchemeParams;
 import software.amazon.awssdk.services.database.auth.scheme.DatabaseAuthSchemeProvider;
+import software.amazon.awssdk.services.database.auth.scheme.internal.DefaultDatabaseAuthSchemeProvider;
 import software.amazon.awssdk.services.database.endpoints.DatabaseEndpointParams;
 import software.amazon.awssdk.services.database.endpoints.DatabaseEndpointProvider;
 import software.amazon.awssdk.services.database.endpoints.internal.DatabaseEndpointResolverUtils;
@@ -127,6 +129,8 @@ final class DefaultDatabaseClient implements DatabaseClient {
                 return Optional.empty();
         }
     };
+
+    private final ConcurrentHashMap<String, List<AuthSchemeOption>> authSchemeCache = new ConcurrentHashMap<>();
 
     protected DefaultDatabaseClient(SdkClientConfiguration clientConfiguration) {
         this.clientHandler = new AwsSyncClientHandler(clientConfiguration);
@@ -783,6 +787,14 @@ final class DefaultDatabaseClient implements DatabaseClient {
             .isInstanceOf(DatabaseAuthSchemeProvider.class,
                           executionAttributes.getAttribute(SdkInternalExecutionAttribute.AUTH_SCHEME_RESOLVER),
                           "Expected an instance of DatabaseAuthSchemeProvider");
+        boolean useCache = requestAuthSchemeProvider == null
+                && authSchemeProvider instanceof DefaultDatabaseAuthSchemeProvider;
+        if (useCache) {
+            List<AuthSchemeOption> cached = authSchemeCache.get(operationName);
+            if (cached != null) {
+                return cached;
+            }
+        }
         DatabaseAuthSchemeParams.Builder paramsBuilder = DatabaseAuthSchemeParams.builder().operation(operationName);
         paramsBuilder.region(executionAttributes.getAttribute(AwsExecutionAttribute.AWS_REGION));
         Set<String> sigv4aRegionSet = executionAttributes.getAttribute(AwsExecutionAttribute.AWS_SIGV4A_SIGNING_REGION_SET);
@@ -790,6 +802,9 @@ final class DefaultDatabaseClient implements DatabaseClient {
             paramsBuilder.regionSet(RegionSet.create(sigv4aRegionSet));
         }
         List<AuthSchemeOption> options = authSchemeProvider.resolveAuthScheme(paramsBuilder.build());
+        if (useCache) {
+            authSchemeCache.put(operationName, options);
+        }
         return options;
     }
 

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-unsigned-payload-trait-sync-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-unsigned-payload-trait-sync-client-class.java
@@ -789,8 +789,10 @@ final class DefaultDatabaseClient implements DatabaseClient {
                           "Expected an instance of DatabaseAuthSchemeProvider");
         boolean useCache = requestAuthSchemeProvider == null
                 && authSchemeProvider instanceof DefaultDatabaseAuthSchemeProvider;
+        String cacheKey = operationName + ":" + executionAttributes.getAttribute(AwsExecutionAttribute.AWS_REGION) + ":"
+                + executionAttributes.getAttribute(AwsExecutionAttribute.AWS_SIGV4A_SIGNING_REGION_SET);
         if (useCache) {
-            List<AuthSchemeOption> cached = authSchemeCache.get(operationName);
+            List<AuthSchemeOption> cached = authSchemeCache.get(cacheKey);
             if (cached != null) {
                 return cached;
             }
@@ -803,7 +805,8 @@ final class DefaultDatabaseClient implements DatabaseClient {
         }
         List<AuthSchemeOption> options = authSchemeProvider.resolveAuthScheme(paramsBuilder.build());
         if (useCache) {
-            authSchemeCache.put(operationName, options);
+            options = Collections.unmodifiableList(options);
+            authSchemeCache.put(cacheKey, options);
         }
         return options;
     }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-xml-async-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-xml-async-client-class.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
 import java.util.function.Consumer;
 import org.slf4j.Logger;
@@ -64,6 +65,7 @@ import software.amazon.awssdk.protocols.xml.XmlOperationMetadata;
 import software.amazon.awssdk.retries.api.RetryStrategy;
 import software.amazon.awssdk.services.xml.auth.scheme.XmlAuthSchemeParams;
 import software.amazon.awssdk.services.xml.auth.scheme.XmlAuthSchemeProvider;
+import software.amazon.awssdk.services.xml.auth.scheme.internal.DefaultXmlAuthSchemeProvider;
 import software.amazon.awssdk.services.xml.endpoints.XmlEndpointParams;
 import software.amazon.awssdk.services.xml.endpoints.XmlEndpointProvider;
 import software.amazon.awssdk.services.xml.endpoints.internal.XmlEndpointResolverUtils;
@@ -129,7 +131,10 @@ final class DefaultXmlAsyncClient implements XmlAsyncClient {
 
     private final SdkClientConfiguration clientConfiguration;
 
+    private final ConcurrentHashMap<String, List<AuthSchemeOption>> authSchemeCache = new ConcurrentHashMap<>();
+
     private final Executor executor;
+
 
     protected DefaultXmlAsyncClient(SdkClientConfiguration clientConfiguration) {
         this.clientHandler = new AwsAsyncClientHandler(clientConfiguration);
@@ -953,9 +958,20 @@ final class DefaultXmlAsyncClient implements XmlAsyncClient {
         XmlAuthSchemeProvider authSchemeProvider = requestAuthSchemeProvider != null ? requestAuthSchemeProvider : Validate
             .isInstanceOf(XmlAuthSchemeProvider.class, executionAttributes.getAttribute(SdkInternalExecutionAttribute.AUTH_SCHEME_RESOLVER),
                           "Expected an instance of XmlAuthSchemeProvider");
+        boolean useCache = requestAuthSchemeProvider == null
+                && authSchemeProvider instanceof DefaultXmlAuthSchemeProvider;
+        if (useCache) {
+            List<AuthSchemeOption> cached = authSchemeCache.get(operationName);
+            if (cached != null) {
+                return cached;
+            }
+        }
         XmlAuthSchemeParams.Builder paramsBuilder = XmlAuthSchemeParams.builder().operation(operationName);
         paramsBuilder.region(executionAttributes.getAttribute(AwsExecutionAttribute.AWS_REGION));
         List<AuthSchemeOption> options = authSchemeProvider.resolveAuthScheme(paramsBuilder.build());
+        if (useCache) {
+            authSchemeCache.put(operationName, options);
+        }
         return options;
     }
 

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-xml-async-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-xml-async-client-class.java
@@ -960,8 +960,9 @@ final class DefaultXmlAsyncClient implements XmlAsyncClient {
                           "Expected an instance of XmlAuthSchemeProvider");
         boolean useCache = requestAuthSchemeProvider == null
                 && authSchemeProvider instanceof DefaultXmlAuthSchemeProvider;
+        String cacheKey = operationName + ":" + executionAttributes.getAttribute(AwsExecutionAttribute.AWS_REGION);
         if (useCache) {
-            List<AuthSchemeOption> cached = authSchemeCache.get(operationName);
+            List<AuthSchemeOption> cached = authSchemeCache.get(cacheKey);
             if (cached != null) {
                 return cached;
             }
@@ -970,7 +971,8 @@ final class DefaultXmlAsyncClient implements XmlAsyncClient {
         paramsBuilder.region(executionAttributes.getAttribute(AwsExecutionAttribute.AWS_REGION));
         List<AuthSchemeOption> options = authSchemeProvider.resolveAuthScheme(paramsBuilder.build());
         if (useCache) {
-            authSchemeCache.put(operationName, options);
+            options = Collections.unmodifiableList(options);
+            authSchemeCache.put(cacheKey, options);
         }
         return options;
     }

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-xml-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-xml-client-class.java
@@ -4,6 +4,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 import software.amazon.awssdk.annotations.Generated;
 import software.amazon.awssdk.annotations.SdkInternalApi;
@@ -52,6 +53,7 @@ import software.amazon.awssdk.protocols.xml.XmlOperationMetadata;
 import software.amazon.awssdk.retries.api.RetryStrategy;
 import software.amazon.awssdk.services.xml.auth.scheme.XmlAuthSchemeParams;
 import software.amazon.awssdk.services.xml.auth.scheme.XmlAuthSchemeProvider;
+import software.amazon.awssdk.services.xml.auth.scheme.internal.DefaultXmlAuthSchemeProvider;
 import software.amazon.awssdk.services.xml.endpoints.XmlEndpointParams;
 import software.amazon.awssdk.services.xml.endpoints.XmlEndpointProvider;
 import software.amazon.awssdk.services.xml.endpoints.internal.XmlEndpointResolverUtils;
@@ -110,6 +112,8 @@ final class DefaultXmlClient implements XmlClient {
     private final AwsXmlProtocolFactory protocolFactory;
 
     private final SdkClientConfiguration clientConfiguration;
+
+    private final ConcurrentHashMap<String, List<AuthSchemeOption>> authSchemeCache = new ConcurrentHashMap<>();
 
     protected DefaultXmlClient(SdkClientConfiguration clientConfiguration) {
         this.clientHandler = new AwsSyncClientHandler(clientConfiguration);
@@ -722,9 +726,20 @@ final class DefaultXmlClient implements XmlClient {
             .isInstanceOf(XmlAuthSchemeProvider.class,
                           executionAttributes.getAttribute(SdkInternalExecutionAttribute.AUTH_SCHEME_RESOLVER),
                           "Expected an instance of XmlAuthSchemeProvider");
+        boolean useCache = requestAuthSchemeProvider == null
+                && authSchemeProvider instanceof DefaultXmlAuthSchemeProvider;
+        if (useCache) {
+            List<AuthSchemeOption> cached = authSchemeCache.get(operationName);
+            if (cached != null) {
+                return cached;
+            }
+        }
         XmlAuthSchemeParams.Builder paramsBuilder = XmlAuthSchemeParams.builder().operation(operationName);
         paramsBuilder.region(executionAttributes.getAttribute(AwsExecutionAttribute.AWS_REGION));
         List<AuthSchemeOption> options = authSchemeProvider.resolveAuthScheme(paramsBuilder.build());
+        if (useCache) {
+            authSchemeCache.put(operationName, options);
+        }
         return options;
     }
 

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-xml-client-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/test-xml-client-class.java
@@ -728,8 +728,9 @@ final class DefaultXmlClient implements XmlClient {
                           "Expected an instance of XmlAuthSchemeProvider");
         boolean useCache = requestAuthSchemeProvider == null
                 && authSchemeProvider instanceof DefaultXmlAuthSchemeProvider;
+        String cacheKey = operationName + ":" + executionAttributes.getAttribute(AwsExecutionAttribute.AWS_REGION);
         if (useCache) {
-            List<AuthSchemeOption> cached = authSchemeCache.get(operationName);
+            List<AuthSchemeOption> cached = authSchemeCache.get(cacheKey);
             if (cached != null) {
                 return cached;
             }
@@ -738,7 +739,8 @@ final class DefaultXmlClient implements XmlClient {
         paramsBuilder.region(executionAttributes.getAttribute(AwsExecutionAttribute.AWS_REGION));
         List<AuthSchemeOption> options = authSchemeProvider.resolveAuthScheme(paramsBuilder.build());
         if (useCache) {
-            authSchemeCache.put(operationName, options);
+            options = Collections.unmodifiableList(options);
+            authSchemeCache.put(cacheKey, options);
         }
         return options;
     }

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/auth/AuthSchemeCacheTest.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/auth/AuthSchemeCacheTest.java
@@ -20,7 +20,10 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
+import java.lang.reflect.Field;
 import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -28,19 +31,19 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.awscore.AwsExecutionAttribute;
+import software.amazon.awssdk.core.interceptor.Context;
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
 import software.amazon.awssdk.http.SdkHttpClient;
 import software.amazon.awssdk.http.auth.aws.scheme.AwsV4AuthScheme;
 import software.amazon.awssdk.http.auth.spi.scheme.AuthSchemeOption;
 import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.multiauth.MultiauthClient;
 import software.amazon.awssdk.services.protocolrestjson.ProtocolRestJsonClient;
+import software.amazon.awssdk.services.protocolrestjson.auth.scheme.ProtocolRestJsonAuthSchemeParams;
 import software.amazon.awssdk.services.protocolrestjson.auth.scheme.ProtocolRestJsonAuthSchemeProvider;
 
-/**
- * Tests verifying auth scheme options cache behavior:
- * - Custom client-level providers bypass the cache (instanceof guard)
- * - Per-request overrides bypass the cache
- * - Default provider with caching doesn't break correctness
- */
 class AuthSchemeCacheTest {
 
     @Mock
@@ -71,15 +74,11 @@ class AuthSchemeCacheTest {
             .authSchemeProvider(customProvider)
             .build();
 
-        // Custom provider is invoked on every call — instanceof guard prevents caching
         assertThatThrownBy(() -> client.allTypes(r -> {})).hasMessageContaining("stop");
         assertThat(resolveCount.get()).isEqualTo(1);
 
         assertThatThrownBy(() -> client.allTypes(r -> {})).hasMessageContaining("stop");
         assertThat(resolveCount.get()).isEqualTo(2);
-
-        assertThatThrownBy(() -> client.allTypes(r -> {})).hasMessageContaining("stop");
-        assertThat(resolveCount.get()).isEqualTo(3);
 
         client.close();
     }
@@ -94,24 +93,20 @@ class AuthSchemeCacheTest {
                 AuthSchemeOption.builder().schemeId(AwsV4AuthScheme.SCHEME_ID).build());
         };
 
-        // Use default provider on the client (cache will be active)
         ProtocolRestJsonClient client = ProtocolRestJsonClient.builder()
             .httpClient(mockHttpClient)
             .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("akid", "skid")))
             .region(Region.US_WEST_2)
             .build();
 
-        // First call with default provider — populates cache
         assertThatThrownBy(() -> client.allTypes(r -> {})).hasMessageContaining("stop");
         assertThat(requestProviderCount.get()).isEqualTo(0);
 
-        // Per-request override — must use the override, not the cache
         assertThatThrownBy(() -> client.allTypes(r -> r.overrideConfiguration(
             c -> c.authSchemeProvider(requestProvider)
         ))).hasMessageContaining("stop");
         assertThat(requestProviderCount.get()).isEqualTo(1);
 
-        // Without override — back to cache (request provider not called again)
         assertThatThrownBy(() -> client.allTypes(r -> {})).hasMessageContaining("stop");
         assertThat(requestProviderCount.get()).isEqualTo(1);
 
@@ -120,21 +115,156 @@ class AuthSchemeCacheTest {
 
     @Test
     void defaultProvider_multipleOperationsSucceed() {
-        // Smoke test: default provider with caching active doesn't break across operations
         ProtocolRestJsonClient client = ProtocolRestJsonClient.builder()
             .httpClient(mockHttpClient)
             .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("akid", "skid")))
             .region(Region.US_WEST_2)
             .build();
 
-        // Multiple calls to the same operation succeed (cache hit path)
         assertThatThrownBy(() -> client.allTypes(r -> {})).hasMessageContaining("stop");
         assertThatThrownBy(() -> client.allTypes(r -> {})).hasMessageContaining("stop");
-
-        // Different operation also succeeds (cache miss then hit)
         assertThatThrownBy(() -> client.deleteOperation(r -> {})).hasMessageContaining("stop");
         assertThatThrownBy(() -> client.deleteOperation(r -> {})).hasMessageContaining("stop");
 
         client.close();
+    }
+
+    @Test
+    void defaultProvider_returnsUnmodifiableList() {
+        List<AuthSchemeOption> options = ProtocolRestJsonAuthSchemeProvider.defaultProvider().resolveAuthScheme(
+            ProtocolRestJsonAuthSchemeParams.builder().operation("AllTypes").region(Region.US_WEST_2).build());
+
+        assertThat(options).isNotEmpty();
+        assertThatThrownBy(() -> options.add(AuthSchemeOption.builder().schemeId(AwsV4AuthScheme.SCHEME_ID).build()))
+            .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void defaultProvider_cachesUnmodifiableListAndReusesInstance() throws Exception {
+        ProtocolRestJsonClient client = ProtocolRestJsonClient.builder()
+            .httpClient(mockHttpClient)
+            .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("akid", "skid")))
+            .region(Region.US_WEST_2)
+            .build();
+
+        assertThatThrownBy(() -> client.allTypes(r -> {})).hasMessageContaining("stop");
+
+        Map<String, List<AuthSchemeOption>> cache = authSchemeCache(client);
+        assertThat(cache).isNotEmpty();
+        List<AuthSchemeOption> cached = cache.values().iterator().next();
+
+        assertThatThrownBy(() -> cached.add(AuthSchemeOption.builder().schemeId(AwsV4AuthScheme.SCHEME_ID).build()))
+            .isInstanceOf(UnsupportedOperationException.class);
+
+        assertThatThrownBy(() -> client.allTypes(r -> {})).hasMessageContaining("stop");
+        assertThat(cache.values().iterator().next()).isSameAs(cached);
+
+        client.close();
+    }
+
+    @Test
+    void perOpAuthService_differentOperationsSeparateCacheEntries() throws Exception {
+        ProtocolRestJsonClient client = ProtocolRestJsonClient.builder()
+            .httpClient(mockHttpClient)
+            .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("akid", "skid")))
+            .region(Region.US_WEST_2)
+            .build();
+
+        assertThatThrownBy(() -> client.allTypes(r -> {})).hasMessageContaining("stop");
+        Map<String, List<AuthSchemeOption>> cache = authSchemeCache(client);
+        assertThat(cache).hasSize(1);
+
+        assertThatThrownBy(() -> client.deleteOperation(r -> {})).hasMessageContaining("stop");
+        assertThat(cache).hasSize(2);
+
+        client.close();
+    }
+
+
+    @Test
+    void regionChange_causesCacheMiss() throws Exception {
+        AtomicInteger callCount = new AtomicInteger(0);
+        ExecutionInterceptor regionSwitcher = new ExecutionInterceptor() {
+            @Override
+            public void beforeExecution(Context.BeforeExecution context, ExecutionAttributes executionAttributes) {
+                if (callCount.incrementAndGet() > 1) {
+                    executionAttributes.putAttribute(AwsExecutionAttribute.AWS_REGION, Region.EU_WEST_1);
+                }
+            }
+        };
+
+        ProtocolRestJsonClient client = ProtocolRestJsonClient.builder()
+            .httpClient(mockHttpClient)
+            .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("akid", "skid")))
+            .region(Region.US_WEST_2)
+            .overrideConfiguration(c -> c.addExecutionInterceptor(regionSwitcher))
+            .build();
+
+        assertThatThrownBy(() -> client.allTypes(r -> {})).hasMessageContaining("stop");
+        Map<String, List<AuthSchemeOption>> cache = authSchemeCache(client);
+        assertThat(cache).hasSize(1);
+
+        assertThatThrownBy(() -> client.allTypes(r -> {})).hasMessageContaining("stop");
+        assertThat(cache).hasSize(2);
+
+        client.close();
+    }
+
+    @Test
+    void cacheHit_returnsSameInstanceOnRepeatedCalls() throws Exception {
+        ProtocolRestJsonClient client = ProtocolRestJsonClient.builder()
+            .httpClient(mockHttpClient)
+            .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("akid", "skid")))
+            .region(Region.US_WEST_2)
+            .build();
+
+        assertThatThrownBy(() -> client.allTypes(r -> {})).hasMessageContaining("stop");
+        Map<String, List<AuthSchemeOption>> cache = authSchemeCache(client);
+        assertThat(cache).hasSize(1);
+        List<AuthSchemeOption> firstResult = cache.values().iterator().next();
+
+        assertThatThrownBy(() -> client.allTypes(r -> {})).hasMessageContaining("stop");
+        assertThatThrownBy(() -> client.allTypes(r -> {})).hasMessageContaining("stop");
+        assertThat(cache).hasSize(1);
+        assertThat(cache.values().iterator().next()).isSameAs(firstResult);
+
+        client.close();
+    }
+
+    @Test
+    void regionSetChange_causesCacheMiss() throws Exception {
+        AtomicInteger callCount = new AtomicInteger(0);
+        ExecutionInterceptor regionSetSwitcher = new ExecutionInterceptor() {
+            @Override
+            public void beforeExecution(Context.BeforeExecution context, ExecutionAttributes executionAttributes) {
+                if (callCount.incrementAndGet() > 1) {
+                    executionAttributes.putAttribute(AwsExecutionAttribute.AWS_SIGV4A_SIGNING_REGION_SET,
+                        Collections.singleton("eu-west-1"));
+                }
+            }
+        };
+
+        MultiauthClient client = MultiauthClient.builder()
+            .httpClient(mockHttpClient)
+            .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("akid", "skid")))
+            .region(Region.US_WEST_2)
+            .overrideConfiguration(c -> c.addExecutionInterceptor(regionSetSwitcher))
+            .build();
+
+        assertThatThrownBy(() -> client.multiAuthWithOnlySigv4a(r -> {})).hasMessageContaining("stop");
+        Map<String, List<AuthSchemeOption>> cache = authSchemeCache(client);
+        assertThat(cache).hasSize(1);
+
+        assertThatThrownBy(() -> client.multiAuthWithOnlySigv4a(r -> {})).hasMessageContaining("stop");
+        assertThat(cache).hasSize(2);
+
+        client.close();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, List<AuthSchemeOption>> authSchemeCache(Object client) throws Exception {
+        Field field = client.getClass().getDeclaredField("authSchemeCache");
+        field.setAccessible(true);
+        return (Map<String, List<AuthSchemeOption>>) field.get(client);
     }
 }

--- a/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/auth/AuthSchemeCacheTest.java
+++ b/test/codegen-generated-classes-test/src/test/java/software/amazon/awssdk/services/auth/AuthSchemeCacheTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.http.SdkHttpClient;
+import software.amazon.awssdk.http.auth.aws.scheme.AwsV4AuthScheme;
+import software.amazon.awssdk.http.auth.spi.scheme.AuthSchemeOption;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.protocolrestjson.ProtocolRestJsonClient;
+import software.amazon.awssdk.services.protocolrestjson.auth.scheme.ProtocolRestJsonAuthSchemeProvider;
+
+/**
+ * Tests verifying auth scheme options cache behavior:
+ * - Custom client-level providers bypass the cache (instanceof guard)
+ * - Per-request overrides bypass the cache
+ * - Default provider with caching doesn't break correctness
+ */
+class AuthSchemeCacheTest {
+
+    @Mock
+    private SdkHttpClient mockHttpClient;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        when(mockHttpClient.clientName()).thenReturn("MockHttpClient");
+        when(mockHttpClient.prepareRequest(any()))
+            .thenThrow(new RuntimeException("stop"));
+    }
+
+    @Test
+    void customClientProvider_isNotCached() {
+        AtomicInteger resolveCount = new AtomicInteger(0);
+
+        ProtocolRestJsonAuthSchemeProvider customProvider = params -> {
+            resolveCount.incrementAndGet();
+            return Collections.singletonList(
+                AuthSchemeOption.builder().schemeId(AwsV4AuthScheme.SCHEME_ID).build());
+        };
+
+        ProtocolRestJsonClient client = ProtocolRestJsonClient.builder()
+            .httpClient(mockHttpClient)
+            .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("akid", "skid")))
+            .region(Region.US_WEST_2)
+            .authSchemeProvider(customProvider)
+            .build();
+
+        // Custom provider is invoked on every call — instanceof guard prevents caching
+        assertThatThrownBy(() -> client.allTypes(r -> {})).hasMessageContaining("stop");
+        assertThat(resolveCount.get()).isEqualTo(1);
+
+        assertThatThrownBy(() -> client.allTypes(r -> {})).hasMessageContaining("stop");
+        assertThat(resolveCount.get()).isEqualTo(2);
+
+        assertThatThrownBy(() -> client.allTypes(r -> {})).hasMessageContaining("stop");
+        assertThat(resolveCount.get()).isEqualTo(3);
+
+        client.close();
+    }
+
+    @Test
+    void perRequestOverride_usesOverrideProvider() {
+        AtomicInteger requestProviderCount = new AtomicInteger(0);
+
+        ProtocolRestJsonAuthSchemeProvider requestProvider = params -> {
+            requestProviderCount.incrementAndGet();
+            return Collections.singletonList(
+                AuthSchemeOption.builder().schemeId(AwsV4AuthScheme.SCHEME_ID).build());
+        };
+
+        // Use default provider on the client (cache will be active)
+        ProtocolRestJsonClient client = ProtocolRestJsonClient.builder()
+            .httpClient(mockHttpClient)
+            .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("akid", "skid")))
+            .region(Region.US_WEST_2)
+            .build();
+
+        // First call with default provider — populates cache
+        assertThatThrownBy(() -> client.allTypes(r -> {})).hasMessageContaining("stop");
+        assertThat(requestProviderCount.get()).isEqualTo(0);
+
+        // Per-request override — must use the override, not the cache
+        assertThatThrownBy(() -> client.allTypes(r -> r.overrideConfiguration(
+            c -> c.authSchemeProvider(requestProvider)
+        ))).hasMessageContaining("stop");
+        assertThat(requestProviderCount.get()).isEqualTo(1);
+
+        // Without override — back to cache (request provider not called again)
+        assertThatThrownBy(() -> client.allTypes(r -> {})).hasMessageContaining("stop");
+        assertThat(requestProviderCount.get()).isEqualTo(1);
+
+        client.close();
+    }
+
+    @Test
+    void defaultProvider_multipleOperationsSucceed() {
+        // Smoke test: default provider with caching active doesn't break across operations
+        ProtocolRestJsonClient client = ProtocolRestJsonClient.builder()
+            .httpClient(mockHttpClient)
+            .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("akid", "skid")))
+            .region(Region.US_WEST_2)
+            .build();
+
+        // Multiple calls to the same operation succeed (cache hit path)
+        assertThatThrownBy(() -> client.allTypes(r -> {})).hasMessageContaining("stop");
+        assertThatThrownBy(() -> client.allTypes(r -> {})).hasMessageContaining("stop");
+
+        // Different operation also succeeds (cache miss then hit)
+        assertThatThrownBy(() -> client.deleteOperation(r -> {})).hasMessageContaining("stop");
+        assertThatThrownBy(() -> client.deleteOperation(r -> {})).hasMessageContaining("stop");
+
+        client.close();
+    }
+}


### PR DESCRIPTION
## Motivation and Context

Cache deterministic auth scheme resolution results to reduce per-request CPU overhead. Auth scheme resolution is called on every request and produces the same result for a given set of inputs when using the default provider - caching avoids repeated allocation and computation.

## Modifications

- Generate `ConcurrentHashMap<String, List<AuthSchemeOption>> authSchemeCache` field on sync/async client classes
- Cache activates only when: 1) no per-request auth scheme provider override AND 2) client-level provider `instanceof DefaultXxxAuthSchemeProvider`
- Disabled for endpoint-based auth provider services (e.g. S3) where resolution depends on dynamic endpoint parameters
- Cache key composition varies by service characteristics:
  - Uniform-auth + sigv4: `region`
  - Uniform-auth + sigv4a: `region + ":" + regionSet`
  - Per-op-auth + sigv4: `operationName + ":" + region`
  - Per-op-auth + sigv4a: `operationName + ":" + region + ":" + regionSet`

## Testing

- Added unit tests
- Ran benchmarks confirming no regression on full-roundtrip workloads and significant savings on the isolated auth resolution path

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
