### PR TITLE
fix(sdk-core): avoid duplicate concurrent endpoint-discovery refresh calls

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-08fe1ef1.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-08fe1ef1.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "AWS SDK for Java v2",
+  "description": "Fixed a race condition in `EndpointDiscoveryRefreshCache` where multiple concurrent threads reading the same expired cache entry could each independently trigger a background endpoint-discovery refresh call for the same key, instead of only one."
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/endpointdiscovery/EndpointDiscoveryRefreshCache.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/endpointdiscovery/EndpointDiscoveryRefreshCache.java
@@ -136,8 +136,17 @@ public final class EndpointDiscoveryRefreshCache {
         }
 
         if (endpoint.expirationTime().isBefore(Instant.now())) {
-            cache.put(key, endpoint.toBuilder().expirationTime(Instant.now().plusSeconds(60)).build());
-            refreshCacheAsync(request, key);
+            EndpointDiscoveryEndpoint refreshedEndpoint =
+                endpoint.toBuilder().expirationTime(Instant.now().plusSeconds(60)).build();
+            // CAS on the stale value each caller read: only the thread that actually wins the
+            // race to replace it kicks off a background refresh. Without this, every thread that
+            // reads the same expired entry before any of them writes back would independently
+            // decide it's expired and each fire its own refreshCacheAsync call, causing a
+            // thundering herd of duplicate endpoint-discovery requests right when the cache entry
+            // expires under concurrent load.
+            if (cache.replace(key, endpoint, refreshedEndpoint)) {
+                refreshCacheAsync(request, key);
+            }
         }
 
         return endpoint.endpoint();

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/endpointdiscovery/EndpointDiscoveryRefreshCacheTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/endpointdiscovery/EndpointDiscoveryRefreshCacheTest.java
@@ -22,10 +22,18 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.lang.reflect.Field;
 import java.net.URI;
+import java.time.Instant;
+import java.util.Map;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -87,6 +95,67 @@ public class EndpointDiscoveryRefreshCacheTest {
         assertThat(future.isCancelled()).isEqualTo(true);
         assertThatThrownBy(future::get).isInstanceOf(CancellationException.class);
 
+    }
+
+    @Test
+    public void get_concurrentCallsOnExpiredEntry_onlyRefreshesOnce() throws Exception {
+        // Regression test: returnCachedOrDefaultEndpoint used to check-then-act on an expired
+        // cache entry (isBefore(now) followed by an unguarded cache.put) with no synchronization,
+        // unlike the sibling "no cached entry yet" branch a few lines above it, which correctly
+        // uses cache.putIfAbsent as a compare-and-swap. Every thread that read the same expired
+        // entry before any of them wrote back independently decided to kick off a background
+        // refresh, causing duplicate discoverEndpoint calls under concurrent load right when an
+        // entry expires. There should only ever be exactly one refresh call per expiration.
+        AtomicInteger discoveryCalls = new AtomicInteger(0);
+        when(mockClient.discoverEndpoint(any())).thenAnswer(invocation -> {
+            discoveryCalls.incrementAndGet();
+            return CompletableFuture.completedFuture(
+                EndpointDiscoveryEndpoint.builder()
+                                          .endpoint(testURI)
+                                          .expirationTime(Instant.now().plusSeconds(60))
+                                          .build());
+        });
+
+        EndpointDiscoveryRequest request = EndpointDiscoveryRequest.builder()
+                                                                     .required(false)
+                                                                     .cacheKey(requestCacheKey)
+                                                                     .defaultEndpoint(testURI)
+                                                                     .build();
+
+        // Prime the cache with an already-expired entry, simulating the moment right after a
+        // real cache entry expires under concurrent load.
+        Field cacheField = EndpointDiscoveryRefreshCache.class.getDeclaredField("cache");
+        cacheField.setAccessible(true);
+        @SuppressWarnings("unchecked")
+        Map<String, EndpointDiscoveryEndpoint> internalCache =
+            (Map<String, EndpointDiscoveryEndpoint>) cacheField.get(endpointDiscoveryRefreshCache);
+        internalCache.put(accessKey + ":" + requestCacheKey,
+                           EndpointDiscoveryEndpoint.builder()
+                                                     .endpoint(URI.create("stale_endpoint"))
+                                                     .expirationTime(Instant.now().minusSeconds(1))
+                                                     .build());
+
+        int threadCount = 50;
+        ExecutorService pool = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch ready = new CountDownLatch(threadCount);
+        CountDownLatch go = new CountDownLatch(1);
+        for (int i = 0; i < threadCount; i++) {
+            pool.submit(() -> {
+                ready.countDown();
+                try {
+                    go.await();
+                } catch (InterruptedException ignored) {
+                    Thread.currentThread().interrupt();
+                }
+                endpointDiscoveryRefreshCache.get(accessKey, request);
+            });
+        }
+        ready.await();
+        go.countDown();
+        pool.shutdown();
+        assertThat(pool.awaitTermination(10, TimeUnit.SECONDS)).isTrue();
+
+        assertThat(discoveryCalls.get()).isEqualTo(1);
     }
 
 }


### PR DESCRIPTION
### Motivation and Context

fixes #7283

`EndpointDiscoveryRefreshCache#returnCachedOrDefaultEndpoint` decides whether to refresh an expired cached endpoint with an unguarded check-then-act:

```java
if (endpoint.expirationTime().isBefore(Instant.now())) {
    cache.put(key, endpoint.toBuilder().expirationTime(Instant.now().plusSeconds(60)).build());
    refreshCacheAsync(request, key);
}
```

Every thread that reads the same expired entry before any of them writes back independently decides to refresh, firing duplicate `refreshCacheAsync` calls against the real endpoint-discovery API for the same key. The sibling "no cached entry yet" branch a few lines above already handles this correctly with `cache.putIfAbsent` as a compare-and-swap; this branch never got the equivalent treatment.

### Modifications

Guard the refresh decision with `cache.replace(key, oldValue, newValue)`, a CAS against the exact stale `endpoint` value the caller read from `cache.get(key)`. Only the thread whose CAS succeeds — i.e. the entry hasn't already been replaced by a racing thread — proceeds to call `refreshCacheAsync`:

```java
if (endpoint.expirationTime().isBefore(Instant.now())) {
    EndpointDiscoveryEndpoint refreshedEndpoint =
        endpoint.toBuilder().expirationTime(Instant.now().plusSeconds(60)).build();
    if (cache.replace(key, endpoint, refreshedEndpoint)) {
        refreshCacheAsync(request, key);
    }
}
```

`EndpointDiscoveryEndpoint` doesn't override `equals()`, so `ConcurrentHashMap#replace(key, oldValue, newValue)`'s equality check falls back to reference identity — which is exactly right here, since all racing threads observe the same object reference from the earlier `cache.get(key)` read in `get()`/`getAsync()`.

### Testing

Added `get_concurrentCallsOnExpiredEntry_onlyRefreshesOnce` to `EndpointDiscoveryRefreshCacheTest`: primes the cache with an already-expired entry (via reflection into the private `cache` field, simulating the exact moment an entry expires), then fires 50 threads at `get()` simultaneously and asserts the mocked loader's `discoverEndpoint` is invoked exactly once.

I don't have `mvn`/a Maven-resolvable environment available locally, so I wasn't able to run this exact test file through the project's normal build. Instead I verified the underlying fix independently: I extracted a byte-for-byte faithful copy of the real `EndpointDiscoveryRefreshCache.java` and `EndpointDiscoveryEndpoint.java` (only the auxiliary `EndpointDiscoveryRequest`/`EndpointDiscoveryCacheLoader`/`EndpointDiscoveryFailedException` types were replaced with minimal stand-ins matching their real signatures, to avoid pulling in the rest of `sdk-core`'s dependency graph) into a standalone harness, compiled with plain `javac` (Java 21), and ran the same 50-thread concurrent-`get()`-on-expired-entry scenario as the new test:

- Against the original code: 1–2 duplicate `discoverEndpoint` calls across 5 runs (expected: 1).
- Against the fixed code: exactly 1 call, consistently across repeated runs.

I'm flagging this explicitly so a maintainer/CI can confirm the added test file itself compiles and passes cleanly in the real build — the fix's correctness is verified, but the exact test file hasn't been run through the project's own toolchain by me.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] I have read the **CONTRIBUTING** document
- [x] Local run of `./mvnw package` succeeds -- **not verified locally (no `mvn` available in my environment); verified the underlying fix via an independent standalone harness instead, see Testing section**
- [x] I have added tests to exercise the new behavior
- [x] My change is not breaking the existing public API