### PR TITLE
Pin maven-dependency-submission-action to commit SHA

### DIFF
--- a/.github/workflows/dependency-cve-monitor.yml
+++ b/.github/workflows/dependency-cve-monitor.yml
@@ -16,7 +16,7 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v6
-      - uses: advanced-security/maven-dependency-submission-action@v5
+      - uses: advanced-security/maven-dependency-submission-action@b275d12641ac2d2108b2cbb7598b154ad2f2cee8 # v5
         with:
           maven-args: >-
             -DtransitiveExcludes=*:*


### PR DESCRIPTION
Pin `advanced-security/maven-dependency-submission-action` to full commit SHA to prevent unintended code changes from tag updates.