### PR TITLE
feat(sdk-core): Add User-Agent header with ft/warmup marker to HTTP client warm-up calls

### DIFF
--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/loader/AsyncHttpClientWarmer.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/loader/AsyncHttpClientWarmer.java
@@ -86,9 +86,10 @@ public final class AsyncHttpClientWarmer implements HttpClientWarmer {
     @Override
     public void warmAll() {
         URI endpoint = endpointProvider.get();
+        String userAgent = HttpClientWarmer.warmUpUserAgent();
         WarmUpDiscovery.forEachDiscovered(services.iterator(), service -> {
             SdkAsyncHttpClient client = service.createAsyncHttpClientFactory().buildWithDefaults(AttributeMap.empty());
-            warmClient(client, endpoint);
+            warmClient(client, endpoint, userAgent);
         });
     }
 
@@ -97,11 +98,12 @@ public final class AsyncHttpClientWarmer implements HttpClientWarmer {
      * failure or timeout is logged and swallowed. We block on the execute future (bounded) because the bundled async
      * clients complete it only after the body is drained, so its completion implies the full path was exercised.
      */
-    private void warmClient(SdkAsyncHttpClient client, URI endpoint) {
+    private void warmClient(SdkAsyncHttpClient client, URI endpoint, String userAgent) {
         try {
             SdkHttpFullRequest httpRequest = SdkHttpFullRequest.builder()
                                                                .method(SdkHttpMethod.GET)
                                                                .uri(endpoint)
+                                                               .putHeader(HEADER_USER_AGENT, userAgent)
                                                                .build();
             AsyncExecuteRequest request = AsyncExecuteRequest.builder()
                                                              .request(httpRequest)

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/loader/HttpClientWarmer.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/loader/HttpClientWarmer.java
@@ -15,7 +15,12 @@
 
 package software.amazon.awssdk.core.internal.http.loader;
 
+import static software.amazon.awssdk.core.internal.useragent.UserAgentConstant.FEATURE_METADATA;
+import static software.amazon.awssdk.core.internal.useragent.UserAgentConstant.appendSpaceAndField;
+
 import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.core.internal.useragent.SdkUserAgentBuilder;
+import software.amazon.awssdk.core.util.SystemUserAgent;
 
 /**
  * Warms the sync or async HTTP clients on the classpath for CRaC priming.
@@ -23,8 +28,23 @@ import software.amazon.awssdk.annotations.SdkInternalApi;
 @SdkInternalApi
 public interface HttpClientWarmer {
 
+    String HEADER_USER_AGENT = "User-Agent";
+
+    String WARM_UP_FEATURE_ID = "warmup";
+
     /**
      * Warms every HTTP client found on the classpath. Best-effort; never throws.
      */
     void warmAll();
+
+    /**
+     * Builds the {@code User-Agent} header value for warm-up requests: the system user agent (SDK version, Java version, OS,
+     * etc.) plus the {@link #WARM_UP_FEATURE_ID} feature marker.
+     */
+    static String warmUpUserAgent() {
+        StringBuilder uaString =
+            new StringBuilder(SdkUserAgentBuilder.buildSystemUserAgentString(SystemUserAgent.getOrCreate()));
+        appendSpaceAndField(uaString, FEATURE_METADATA, WARM_UP_FEATURE_ID);
+        return uaString.toString();
+    }
 }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/loader/SyncHttpClientWarmer.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/loader/SyncHttpClientWarmer.java
@@ -79,9 +79,10 @@ public final class SyncHttpClientWarmer implements HttpClientWarmer {
     @Override
     public void warmAll() {
         URI endpoint = endpointProvider.get();
+        String userAgent = HttpClientWarmer.warmUpUserAgent();
         WarmUpDiscovery.forEachDiscovered(services.iterator(), service -> {
             SdkHttpClient client = service.createHttpClientBuilder().buildWithDefaults(AttributeMap.empty());
-            warmClient(client, endpoint);
+            warmClient(client, endpoint, userAgent);
         });
     }
 
@@ -89,11 +90,12 @@ public final class SyncHttpClientWarmer implements HttpClientWarmer {
      * Sends the warm-up {@code GET} to {@code endpoint}, drains the response body, and closes the client. Best-effort: the
      * goal is JIT compilation, not a successful request, so any failure is logged and swallowed.
      */
-    private void warmClient(SdkHttpClient client, URI endpoint) {
+    private void warmClient(SdkHttpClient client, URI endpoint, String userAgent) {
         try {
             SdkHttpRequest httpRequest = SdkHttpRequest.builder()
                                                        .method(SdkHttpMethod.GET)
                                                        .uri(endpoint)
+                                                       .putHeader(HEADER_USER_AGENT, userAgent)
                                                        .build();
             HttpExecuteRequest request = HttpExecuteRequest.builder()
                                                            .request(httpRequest)

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/http/loader/AsyncHttpClientWarmerTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/http/loader/AsyncHttpClientWarmerTest.java
@@ -78,6 +78,18 @@ class AsyncHttpClientWarmerTest {
     }
 
     @Test
+    void warmAll_whenInvoked_addsWarmUpUserAgentHeader() {
+        SdkAsyncHttpClient client = stubClient(emptyBody());
+        ArgumentCaptor<AsyncExecuteRequest> request = ArgumentCaptor.forClass(AsyncExecuteRequest.class);
+
+        warmer(serviceFor(client)).warmAll();
+
+        verify(client).execute(request.capture());
+        assertThat(request.getValue().request().firstMatchingHeader("User-Agent"))
+            .hasValueSatisfying(userAgent -> assertThat(userAgent).contains("aws-sdk-java/2.").contains("ft/warmup"));
+    }
+
+    @Test
     void warmAll_whenRequestFails_swallowsAndStillClosesClient() {
         SdkAsyncHttpClient client = mock(SdkAsyncHttpClient.class);
         when(client.execute(any(AsyncExecuteRequest.class))).thenThrow(new RuntimeException("offline"));

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/http/loader/SyncHttpClientWarmerTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/http/loader/SyncHttpClientWarmerTest.java
@@ -73,6 +73,18 @@ class SyncHttpClientWarmerTest {
     }
 
     @Test
+    void warmAll_whenInvoked_addsWarmUpUserAgentHeader() {
+        SdkHttpClient client = stubClient(respondingWith(403, emptyBody()));
+        ArgumentCaptor<HttpExecuteRequest> request = ArgumentCaptor.forClass(HttpExecuteRequest.class);
+
+        warmer(serviceFor(client)).warmAll();
+
+        verify(client).prepareRequest(request.capture());
+        assertThat(request.getValue().httpRequest().firstMatchingHeader("User-Agent"))
+            .hasValueSatisfying(userAgent -> assertThat(userAgent).contains("aws-sdk-java/2.").contains("ft/warmup"));
+    }
+
+    @Test
     void warmAll_whenRequestFails_swallowsAndStillClosesClient() throws IOException {
         SdkHttpClient client = mock(SdkHttpClient.class);
         ExecutableHttpRequest request = mock(ExecutableHttpRequest.class);


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->


This change adds a `User-Agent` header to warm-up requests: the system user agent (SDK
version, Java version, OS, JVM metadata) plus an `ft/warmup` feature marker. It reuses
existing user-agent construction (`SdkUserAgentBuilder`, `UserAgentConstant`) 


## Modifications
<!--- Describe your changes in detail -->

- `HttpClientWarmer`: add constants `HEADER_USER_AGENT` (`"User-Agent"`) and
  `WARM_UP_FEATURE_ID` (`"warmup"`), and a static `warmUpUserAgent()` helper. The helper
  builds the system user agent with
  `SdkUserAgentBuilder.buildSystemUserAgentString(SystemUserAgent.getOrCreate())` and appends
  `ft/warmup` with `UserAgentConstant.appendSpaceAndField`.
- `SyncHttpClientWarmer`: build the value once in `warmAll()` and set it on the warm-up
  `SdkHttpRequest`.
- `AsyncHttpClientWarmer`: build the value once in `warmAll()` and set it on the warm-up
  `SdkHttpFullRequest`.


## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran -->

- Enabled `org.apache.http.wire` debug logging and ran the warm-up. The request carried the
  header:

```
16:20:59.004 [main] DEBUG org.apache.http.wire - http-outgoing-0 >> "User-Agent: aws-sdk-java/2.51.4-SNAPSHOT os/Mac_OS_X#56.7.8 lang/java#19.0.20.1 md/OpenJDK_64-Bit_Server_VM#11.0.20.1+9-LTS md/vendor#Some.com_Inc. md/en_US ft/warmup[\r][\n]"
```

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
