### PR TITLE
Enable dependabot for graalvm plugin

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -56,7 +56,6 @@ updates:
       - dependency-name: "org.codehaus.mojo:build-helper-maven-plugin"
       - dependency-name: "org.codehaus.mojo:exec-maven-plugin"
       - dependency-name: "org.apache.maven.plugin-tools:maven-plugin-annotations"
-      - dependency-name: "org.graalvm.buildtools:*"
       - dependency-name: "org.jacoco:jacoco-maven-plugin"
       - dependency-name: "org.apache.commons:commons-lang3"
       - dependency-name: "org.codehaus.plexus:plexus-utils"

--- a/test/sdk-native-image-test/pom.xml
+++ b/test/sdk-native-image-test/pom.xml
@@ -33,7 +33,7 @@
         <maven.compiler.plugin.version>3.6.1</maven.compiler.plugin.version>
         <exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>
         <slf4j.version>1.7.36</slf4j.version>
-        <graalvm.native.maven.plugin.version>0.9.6</graalvm.native.maven.plugin.version>
+        <graalvm.native.maven.plugin.version>1.1.10</graalvm.native.maven.plugin.version>
     </properties>
 
     <dependencies>
@@ -148,15 +148,6 @@
                         <configuration>
                             <imageName>sdk-native-image-test</imageName>
                             <mainClass>software.amazon.awssdk.nativeimagetest.App</mainClass>
-                            <buildArgs combine.children="append">
-                                <!-- BouncyCastleAlpn issue tracked in https://github.com/netty/netty/issues/11369 -->
-                                <buildArgs>
-                                    --verbose
-                                    --no-fallback
-                                    --initialize-at-build-time=org.slf4j
-                                    --initialize-at-run-time=io.netty.handler.ssl.BouncyCastleAlpnSslUtils
-                                </buildArgs>
-                            </buildArgs>
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
Allow us to catch any incompatibilities with our native image build configs and the latest Maven graalvm plugin. See for example #7291.

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Modifications
<!--- Describe your changes in detail -->

## Testing
Verified `sdk-native-image-test` runs correctly:

```
mvn clean install -P quick -pl :bom,:bom-internal,:sdk-native-image-test -am
mvn clean package -P native-image -pl :sdk-native-image-test
test/sdk-native-image-test/target/sdk-native-image-test
```

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
