### PR TITLE
fix: prevent NPE in netty HandlerSubscriber

### DIFF
--- a/.changes/next-release/bugfix-NettyNIOHTTPClient-b9465c8.json
+++ b/.changes/next-release/bugfix-NettyNIOHTTPClient-b9465c8.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "Netty NIO HTTP Client",
+    "contributor": "",
+    "description": "Fixed a `NullPointerException` in `HandlerSubscriber` that could intermittently fail async requests (such as S3 `PutObject`/`UploadPart`) when a channel writability change occurred during the `Expect: 100-continue` window before the request body subscription was established. See [#7271](https://github.com/aws/aws-sdk-java-v2/issues/7271)."
+}

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/nrs/HandlerSubscriber.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/internal/nrs/HandlerSubscriber.java
@@ -154,7 +154,12 @@ public class HandlerSubscriber<T> extends ChannelDuplexHandler implements Subscr
 
     @Override
     public void channelWritabilityChanged(ChannelHandlerContext ctx) throws Exception {
-        maybeRequestMore();
+        // Only request demand once RUNNING. A writability change can arrive while the subscription is still pending
+        // (the Expect: 100-continue deferral window, where the subscribe is held back until the server answers), when
+        // maybeRequestMore() would dereference a null subscription. See #7271.
+        if (state == HandlerSubscriber.State.RUNNING) {
+            maybeRequestMore();
+        }
         ctx.fireChannelWritabilityChanged();
     }
 

--- a/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/nrs/HandlerSubscriberExpectContinueTest.java
+++ b/http-clients/netty-nio-client/src/test/java/software/amazon/awssdk/http/nio/netty/internal/nrs/HandlerSubscriberExpectContinueTest.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.nio.netty.internal.nrs;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.DefaultHttpContent;
+import io.netty.handler.codec.http.HttpContent;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpUtil;
+import io.netty.handler.codec.http.HttpVersion;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+/**
+ * Regression coverage for the NPE reported in
+ * <a href="https://github.com/aws/aws-sdk-java-v2/issues/7271">#7271</a>: when a request carries
+ * {@code Expect: 100-continue}, {@link HttpStreamsClientHandler} defers subscribing the {@link HandlerSubscriber} to the
+ * body until the server answers {@code 100 Continue}. A {@code channelWritabilityChanged} event fired during that window
+ * used to dereference the still-null subscription and throw.
+ */
+public class HandlerSubscriberExpectContinueTest {
+
+    private EmbeddedChannel channel;
+    private ExceptionCapturingHandler exceptionCapture;
+
+    @BeforeEach
+    public void setup() {
+        channel = new EmbeddedChannel(new HttpStreamsClientHandler());
+        exceptionCapture = new ExceptionCapturingHandler();
+        channel.pipeline().addLast(exceptionCapture);
+    }
+
+    @AfterEach
+    public void teardown() {
+        channel.finishAndReleaseAll();
+    }
+
+    @Test
+    public void channelWritabilityChanged_whenSubscriptionPending_doesNotRouteExceptionToPipeline() {
+        writeExpectContinueRequest(new SingleChunkPublisher("body"));
+
+        channel.pipeline().fireChannelWritabilityChanged();
+
+        assertThat(exceptionCapture.captured()).isNull();
+    }
+
+    @Test
+    public void channelWritabilityChanged_whenSubscriptionPending_bodyStreamsAfter100Continue() {
+        SingleChunkPublisher body = new SingleChunkPublisher("body");
+        writeExpectContinueRequest(body);
+
+        channel.pipeline().fireChannelWritabilityChanged();
+        deliver100Continue();
+
+        assertThat(body.subscribed()).isTrue();
+        assertThat(streamedBody()).isEqualTo("body");
+        assertThat(exceptionCapture.captured()).isNull();
+    }
+
+    private void writeExpectContinueRequest(Publisher<HttpContent> body) {
+        DefaultStreamedHttpRequest request =
+            new DefaultStreamedHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.PUT, "/", body);
+        HttpUtil.set100ContinueExpected(request, true);
+        channel.writeOutbound(request);
+    }
+
+    private void deliver100Continue() {
+        HttpResponse continueResponse =
+            new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.CONTINUE);
+        channel.writeInbound(continueResponse);
+        channel.runPendingTasks();
+    }
+
+    private String streamedBody() {
+        StringBuilder body = new StringBuilder();
+        Object msg;
+        while ((msg = channel.readOutbound()) != null) {
+            if (msg instanceof HttpContent) {
+                body.append(((HttpContent) msg).content().toString(UTF_8));
+            }
+        }
+        return body.toString();
+    }
+
+    private static final class ExceptionCapturingHandler extends ChannelInboundHandlerAdapter {
+        private final AtomicReference<Throwable> captured = new AtomicReference<>();
+
+        @Override
+        public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+            captured.compareAndSet(null, cause);
+        }
+
+        Throwable captured() {
+            return captured.get();
+        }
+    }
+
+    private static final class SingleChunkPublisher implements Publisher<HttpContent> {
+        private final byte[] payload;
+        private final AtomicBoolean subscribed = new AtomicBoolean(false);
+
+        private SingleChunkPublisher(String payload) {
+            this.payload = payload.getBytes(UTF_8);
+        }
+
+        boolean subscribed() {
+            return subscribed.get();
+        }
+
+        @Override
+        public void subscribe(Subscriber<? super HttpContent> subscriber) {
+            subscribed.set(true);
+            subscriber.onSubscribe(new Subscription() {
+                private boolean delivered;
+
+                @Override
+                public void request(long n) {
+                    if (n <= 0 || delivered) {
+                        return;
+                    }
+                    delivered = true;
+                    ByteBuf buf = Unpooled.wrappedBuffer(payload);
+                    subscriber.onNext(new DefaultHttpContent(buf));
+                    subscriber.onComplete();
+                }
+
+                @Override
+                public void cancel() {
+                    delivered = true;
+                }
+            });
+        }
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

Async S3 uploads (`PutObject`, `UploadPart`) on the netty-nio-client fail
intermittently under high concurrency with a non-retryable
`NullPointerException`:

```
java.lang.NullPointerException: Cannot invoke "org.reactivestreams.Subscription.request(long)" because "this.subscription" is null
    at ...nrs.HandlerSubscriber.maybeRequestMore(HandlerSubscriber.java:303)
    at ...nrs.HandlerSubscriber.channelWritabilityChanged(HandlerSubscriber.java:157)
    at io.netty.channel.AbstractChannelHandlerContext.invokeChannelWritabilityChanged(...)
```

`HandlerSubscriber` is the reactive-streams `Subscriber` that pumps a request
body to the Netty channel. Its `subscription` field starts `null` and is only
assigned in `onSubscribe`. For `Expect: 100-continue` requests the body
subscription is deliberately deferred: `HttpStreamsClientHandler` holds the
subscriber aside until the server returns `100 Continue`, but the
`HandlerSubscriber` is already in the pipeline and keeps receiving channel
events. If `channelWritabilityChanged` fires during that window and the channel
is writable, it calls `maybeRequestMore()`, which dereferences the still-null
subscription and throws. The exception surfaces as a `SdkClientException`
classified non-retryable, so the upload fails outright.

The S3 async client sets `Expect: 100-continue` on `PutObject` /
`UploadPart`, so async S3 upload takes the deferred-subscribe path; a
writability transition during the round trip is common under high-concurrency
uploads with backpressured sockets, which is why low-volume callers rarely see
it.

Fixes #7271

## Modifications
<!--- Describe your changes in detail -->

`channelWritabilityChanged()` now calls `maybeRequestMore()` only when the
subscriber is `RUNNING`. `RUNNING` is reached only after `onSubscribe` has
assigned the subscription, so gating on it removes the null dereference while
the subscription is pending. `channelWritabilityChanged()` still propagates the
event down the pipeline via `ctx.fireChannelWritabilityChanged()` exactly as
before, and `maybeRequestMore()` is otherwise unchanged. Once the
`100 Continue` arrives and the subscribe completes, the existing
`provideSubscription -> maybeStart -> maybeRequestMore` path requests demand as
it does today, so no demand is lost and the upload streams normally.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to --
<!--- see how your change affects other areas of the code, etc. -->

Added `HandlerSubscriberExpectContinueTest`, a deterministic regression test in
the `nrs` package. It builds an `EmbeddedChannel` with a real
`HttpStreamsClientHandler`, writes a `StreamedHttpRequest` carrying
`Expect: 100-continue`, and forces a channel writability transition before the
`100 Continue` response is delivered. Two cases:

- `channelWritabilityChanged_whenSubscriptionPending_doesNotRouteExceptionToPipeline`
  asserts the writability transition raises no exception (nothing routed to
  `exceptionCaught`) while the subscription is pending.
- `channelWritabilityChanged_whenSubscriptionPending_bodyStreamsAfter100Continue`
  asserts that after `100 Continue` arrives the body is subscribed and streamed.

With the fix reverted, both cases reproduce the exact reported NPE
(`maybeRequestMore` <- `channelWritabilityChanged`); with the fix they pass.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
