### PR TITLE
fix(sqs): stop close() busy-loop duplicate sends

### DIFF
--- a/.changes/next-release/bugfix-AmazonSQS-9b1a920.json
+++ b/.changes/next-release/bugfix-AmazonSQS-9b1a920.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "Amazon SQS",
+    "contributor": "",
+    "description": "Fixed `SqsAsyncBatchManager.close()` re-sending the same buffered batch in a busy loop. On close, each buffered batch (including partial batches) is now flushed exactly once, and close waits a bounded grace period for in-flight batch sends to complete so their callers receive the real result instead of a cancellation."
+}

--- a/.changes/next-release/bugfix-AmazonSQS-9b1a920.json
+++ b/.changes/next-release/bugfix-AmazonSQS-9b1a920.json
@@ -2,5 +2,5 @@
     "type": "bugfix",
     "category": "Amazon SQS",
     "contributor": "",
-    "description": "Fixed `SqsAsyncBatchManager.close()` re-sending the same buffered batch in a busy loop. On close, each buffered batch (including partial batches) is now flushed exactly once, and close waits a bounded grace period for in-flight batch sends to complete so their callers receive the real result instead of a cancellation."
+    "description": "Fixed `SqsAsyncBatchManager.close()` re-sending the same buffered batch in a busy loop. On close, each buffered batch (including partial batches) is now flushed exactly once, and close waits a bounded timeout (approximately 5 seconds) for in-flight batch sends to complete so their callers receive the real result instead of a cancellation."
 }

--- a/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/batchmanager/SqsAsyncBatchManager.java
+++ b/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/batchmanager/SqsAsyncBatchManager.java
@@ -148,6 +148,13 @@ public interface SqsAsyncBatchManager extends SdkAutoCloseable {
         return receiveMessage(ReceiveMessageRequest.builder().applyMutation(request).build());
     }
 
+    /**
+     * Closes the batch manager and releases its resources. Buffered requests are first flushed to the service, then
+     * this method blocks for up to a bounded grace period waiting for the in-flight batch sends to complete so their
+     * callers receive the real service result. Requests still outstanding when the grace period expires are cancelled.
+     */
+    @Override
+    void close();
 
     interface Builder {
 

--- a/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/batchmanager/SqsAsyncBatchManager.java
+++ b/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/batchmanager/SqsAsyncBatchManager.java
@@ -150,8 +150,8 @@ public interface SqsAsyncBatchManager extends SdkAutoCloseable {
 
     /**
      * Closes the batch manager and releases its resources. Buffered requests are first flushed to the service, then
-     * this method blocks for up to a bounded grace period waiting for the in-flight batch sends to complete so their
-     * callers receive the real service result. Requests still outstanding when the grace period expires are cancelled.
+     * this method blocks for up to a bounded timeout waiting for the in-flight batch sends to complete so their
+     * callers receive the real service result. Requests still outstanding when the timeout expires are cancelled.
      */
     @Override
     void close();

--- a/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/internal/batchmanager/DefaultSqsAsyncBatchManager.java
+++ b/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/internal/batchmanager/DefaultSqsAsyncBatchManager.java
@@ -70,7 +70,7 @@ public final class DefaultSqsAsyncBatchManager implements SqsAsyncBatchManager {
             new SendMessageBatchManager(
                 RequestBatchConfiguration.builder(builder.overrideConfiguration)
                                          .maxBatchBytesSize(MAX_SEND_MESSAGE_PAYLOAD_SIZE_BYTES)
-                                         .shutdownGracePeriod(builder.shutdownGracePeriod)
+                                         .shutdownTimeout(builder.shutdownTimeout)
                                          .build(),
                 scheduledExecutor,
                 client
@@ -79,7 +79,7 @@ public final class DefaultSqsAsyncBatchManager implements SqsAsyncBatchManager {
         this.deleteMessageBatchManager =
             new DeleteMessageBatchManager(
                 RequestBatchConfiguration.builder(builder.overrideConfiguration)
-                                         .shutdownGracePeriod(builder.shutdownGracePeriod)
+                                         .shutdownTimeout(builder.shutdownTimeout)
                                          .build(),
                 scheduledExecutor,
                 client
@@ -88,7 +88,7 @@ public final class DefaultSqsAsyncBatchManager implements SqsAsyncBatchManager {
         this.changeMessageVisibilityBatchManager =
             new ChangeMessageVisibilityBatchManager(
                 RequestBatchConfiguration.builder(builder.overrideConfiguration)
-                                         .shutdownGracePeriod(builder.shutdownGracePeriod)
+                                         .shutdownTimeout(builder.shutdownTimeout)
                                          .build(),
                 scheduledExecutor,
                 client
@@ -136,19 +136,19 @@ public final class DefaultSqsAsyncBatchManager implements SqsAsyncBatchManager {
         }
 
         List<CompletableFuture<Void>> futures =
-            requestBatchManagers.stream().map(requestBatchManager -> requestBatchManager.dispatchPending())
+            requestBatchManagers.stream().map(requestBatchManager -> requestBatchManager.closeAndDispatch())
                                                                     .collect(Collectors.toList());
 
         awaitQuietly(CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])),
-                     sendMessageBatchManager.shutdownGracePeriod());
+                     sendMessageBatchManager.shutdownTimeout());
 
         requestBatchManagers.forEach(requestBatchManager -> requestBatchManager.cancelPending());
         receiveMessageBatchManager.close();
     }
 
-    private static void awaitQuietly(CompletableFuture<?> pending, Duration grace) {
+    private static void awaitQuietly(CompletableFuture<?> pending, Duration timeout) {
         try {
-            pending.get(grace.toMillis(), TimeUnit.MILLISECONDS);
+            pending.get(timeout.toMillis(), TimeUnit.MILLISECONDS);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
         } catch (TimeoutException e) {
@@ -163,14 +163,14 @@ public final class DefaultSqsAsyncBatchManager implements SqsAsyncBatchManager {
         private SqsAsyncClient client;
         private BatchOverrideConfiguration overrideConfiguration;
         private ScheduledExecutorService scheduledExecutor;
-        private Duration shutdownGracePeriod;
+        private Duration shutdownTimeout;
 
         private DefaultBuilder() {
         }
 
         @SdkTestInternalApi
-        DefaultBuilder shutdownGracePeriod(Duration shutdownGracePeriod) {
-            this.shutdownGracePeriod = shutdownGracePeriod;
+        DefaultBuilder shutdownTimeout(Duration shutdownTimeout) {
+            this.shutdownTimeout = shutdownTimeout;
             return this;
         }
 

--- a/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/internal/batchmanager/DefaultSqsAsyncBatchManager.java
+++ b/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/internal/batchmanager/DefaultSqsAsyncBatchManager.java
@@ -18,9 +18,18 @@ package software.amazon.awssdk.services.sqs.internal.batchmanager;
 
 import static software.amazon.awssdk.services.sqs.internal.batchmanager.ResponseBatchConfiguration.MAX_SEND_MESSAGE_PAYLOAD_SIZE_BYTES;
 
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
 import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.annotations.SdkTestInternalApi;
 import software.amazon.awssdk.services.sqs.SqsAsyncClient;
 import software.amazon.awssdk.services.sqs.batchmanager.BatchOverrideConfiguration;
 import software.amazon.awssdk.services.sqs.batchmanager.SqsAsyncBatchManager;
@@ -32,10 +41,13 @@ import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest;
 import software.amazon.awssdk.services.sqs.model.ReceiveMessageResponse;
 import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
 import software.amazon.awssdk.services.sqs.model.SendMessageResponse;
+import software.amazon.awssdk.utils.Logger;
 import software.amazon.awssdk.utils.Validate;
 
 @SdkInternalApi
 public final class DefaultSqsAsyncBatchManager implements SqsAsyncBatchManager {
+    private static final Logger log = Logger.loggerFor(DefaultSqsAsyncBatchManager.class);
+
     private final SqsAsyncClient client;
 
     private final SendMessageBatchManager sendMessageBatchManager;
@@ -46,6 +58,10 @@ public final class DefaultSqsAsyncBatchManager implements SqsAsyncBatchManager {
 
     private final ReceiveMessageBatchManager receiveMessageBatchManager;
 
+    private final List<RequestBatchManager<?, ?, ?>> requestBatchManagers;
+
+    private final AtomicBoolean closed = new AtomicBoolean(false);
+
     private DefaultSqsAsyncBatchManager(DefaultBuilder builder) {
         this.client = Validate.notNull(builder.client, "client cannot be null");
         ScheduledExecutorService scheduledExecutor  = Validate.notNull(builder.scheduledExecutor,
@@ -54,6 +70,7 @@ public final class DefaultSqsAsyncBatchManager implements SqsAsyncBatchManager {
             new SendMessageBatchManager(
                 RequestBatchConfiguration.builder(builder.overrideConfiguration)
                                          .maxBatchBytesSize(MAX_SEND_MESSAGE_PAYLOAD_SIZE_BYTES)
+                                         .shutdownGracePeriod(builder.shutdownGracePeriod)
                                          .build(),
                 scheduledExecutor,
                 client
@@ -61,17 +78,26 @@ public final class DefaultSqsAsyncBatchManager implements SqsAsyncBatchManager {
 
         this.deleteMessageBatchManager =
             new DeleteMessageBatchManager(
-                RequestBatchConfiguration.builder(builder.overrideConfiguration).build(),
+                RequestBatchConfiguration.builder(builder.overrideConfiguration)
+                                         .shutdownGracePeriod(builder.shutdownGracePeriod)
+                                         .build(),
                 scheduledExecutor,
                 client
             );
 
         this.changeMessageVisibilityBatchManager =
             new ChangeMessageVisibilityBatchManager(
-                RequestBatchConfiguration.builder(builder.overrideConfiguration).build(),
+                RequestBatchConfiguration.builder(builder.overrideConfiguration)
+                                         .shutdownGracePeriod(builder.shutdownGracePeriod)
+                                         .build(),
                 scheduledExecutor,
                 client
             );
+
+        requestBatchManagers = new ArrayList<>(3);
+        requestBatchManagers.add(sendMessageBatchManager);
+        requestBatchManagers.add(deleteMessageBatchManager);
+        requestBatchManagers.add(changeMessageVisibilityBatchManager);
 
         this.receiveMessageBatchManager =
             new ReceiveMessageBatchManager(client,
@@ -105,18 +131,47 @@ public final class DefaultSqsAsyncBatchManager implements SqsAsyncBatchManager {
 
     @Override
     public void close() {
-        sendMessageBatchManager.close();
-        deleteMessageBatchManager.close();
-        changeMessageVisibilityBatchManager.close();
+        if (!closed.compareAndSet(false, true)) {
+            return;
+        }
+
+        List<CompletableFuture<Void>> futures =
+            requestBatchManagers.stream().map(requestBatchManager -> requestBatchManager.dispatchPending())
+                                                                    .collect(Collectors.toList());
+
+        awaitQuietly(CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])),
+                     sendMessageBatchManager.shutdownGracePeriod());
+
+        requestBatchManagers.forEach(requestBatchManager -> requestBatchManager.cancelPending());
         receiveMessageBatchManager.close();
+    }
+
+    private static void awaitQuietly(CompletableFuture<?> pending, Duration grace) {
+        try {
+            pending.get(grace.toMillis(), TimeUnit.MILLISECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        } catch (TimeoutException e) {
+            log.debug(() -> "Timed out waiting for in-flight batch sends to complete during close; "
+                            + "cancelling outstanding requests.");
+        } catch (ExecutionException e) {
+            // A send failed; its caller future is already settled with the failure. Nothing to do here.
+        }
     }
 
     public static final class DefaultBuilder implements SqsAsyncBatchManager.Builder {
         private SqsAsyncClient client;
         private BatchOverrideConfiguration overrideConfiguration;
         private ScheduledExecutorService scheduledExecutor;
+        private Duration shutdownGracePeriod;
 
         private DefaultBuilder() {
+        }
+
+        @SdkTestInternalApi
+        DefaultBuilder shutdownGracePeriod(Duration shutdownGracePeriod) {
+            this.shutdownGracePeriod = shutdownGracePeriod;
+            return this;
         }
 
         @Override

--- a/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/internal/batchmanager/RequestBatchConfiguration.java
+++ b/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/internal/batchmanager/RequestBatchConfiguration.java
@@ -32,14 +32,14 @@ public final class RequestBatchConfiguration {
      * Time {@code close()} waits for in-flight batch sends to complete so their callers receive real results before
      * outstanding requests are cancelled.
      */
-    public static final Duration DEFAULT_SHUTDOWN_GRACE_PERIOD = Duration.ofSeconds(5);
+    public static final Duration DEFAULT_SHUTDOWN_TIMEOUT = Duration.ofSeconds(5);
 
     private final Integer maxBatchItems;
     private final Integer maxBatchKeys;
     private final Integer maxBufferSize;
     private final Duration sendRequestFrequency;
     private final Integer maxBatchBytesSize;
-    private final Duration shutdownGracePeriod;
+    private final Duration shutdownTimeout;
 
     private RequestBatchConfiguration(Builder builder) {
 
@@ -50,8 +50,8 @@ public final class RequestBatchConfiguration {
                                                   builder.sendRequestFrequency :
                                          DEFAULT_MAX_BATCH_OPEN_IN_MS;
         this.maxBatchBytesSize = builder.maxBatchBytesSize != null ? builder.maxBatchBytesSize : DEFAULT_MAX_BATCH_BYTES_SIZE;
-        this.shutdownGracePeriod = builder.shutdownGracePeriod != null ?
-                                   builder.shutdownGracePeriod : DEFAULT_SHUTDOWN_GRACE_PERIOD;
+        this.shutdownTimeout = builder.shutdownTimeout != null ?
+                                   builder.shutdownTimeout : DEFAULT_SHUTDOWN_TIMEOUT;
 
     }
 
@@ -89,8 +89,8 @@ public final class RequestBatchConfiguration {
         return maxBatchBytesSize;
     }
 
-    public Duration shutdownGracePeriod() {
-        return shutdownGracePeriod;
+    public Duration shutdownTimeout() {
+        return shutdownTimeout;
     }
 
     public static final class Builder {
@@ -100,7 +100,7 @@ public final class RequestBatchConfiguration {
         private Integer maxBufferSize;
         private Duration sendRequestFrequency;
         private Integer maxBatchBytesSize;
-        private Duration shutdownGracePeriod;
+        private Duration shutdownTimeout;
 
         private Builder() {
         }
@@ -130,8 +130,8 @@ public final class RequestBatchConfiguration {
             return this;
         }
 
-        public Builder shutdownGracePeriod(Duration shutdownGracePeriod) {
-            this.shutdownGracePeriod = shutdownGracePeriod;
+        public Builder shutdownTimeout(Duration shutdownTimeout) {
+            this.shutdownTimeout = shutdownTimeout;
             return this;
         }
 

--- a/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/internal/batchmanager/RequestBatchConfiguration.java
+++ b/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/internal/batchmanager/RequestBatchConfiguration.java
@@ -28,11 +28,18 @@ public final class RequestBatchConfiguration {
     public static final int DEFAULT_MAX_BUFFER_SIZE = 500;
     public static final Duration DEFAULT_MAX_BATCH_OPEN_IN_MS = Duration.ofMillis(200);
 
+    /**
+     * Time {@code close()} waits for in-flight batch sends to complete so their callers receive real results before
+     * outstanding requests are cancelled.
+     */
+    public static final Duration DEFAULT_SHUTDOWN_GRACE_PERIOD = Duration.ofSeconds(5);
+
     private final Integer maxBatchItems;
     private final Integer maxBatchKeys;
     private final Integer maxBufferSize;
     private final Duration sendRequestFrequency;
     private final Integer maxBatchBytesSize;
+    private final Duration shutdownGracePeriod;
 
     private RequestBatchConfiguration(Builder builder) {
 
@@ -43,6 +50,8 @@ public final class RequestBatchConfiguration {
                                                   builder.sendRequestFrequency :
                                          DEFAULT_MAX_BATCH_OPEN_IN_MS;
         this.maxBatchBytesSize = builder.maxBatchBytesSize != null ? builder.maxBatchBytesSize : DEFAULT_MAX_BATCH_BYTES_SIZE;
+        this.shutdownGracePeriod = builder.shutdownGracePeriod != null ?
+                                   builder.shutdownGracePeriod : DEFAULT_SHUTDOWN_GRACE_PERIOD;
 
     }
 
@@ -80,6 +89,10 @@ public final class RequestBatchConfiguration {
         return maxBatchBytesSize;
     }
 
+    public Duration shutdownGracePeriod() {
+        return shutdownGracePeriod;
+    }
+
     public static final class Builder {
 
         private Integer maxBatchItems;
@@ -87,6 +100,7 @@ public final class RequestBatchConfiguration {
         private Integer maxBufferSize;
         private Duration sendRequestFrequency;
         private Integer maxBatchBytesSize;
+        private Duration shutdownGracePeriod;
 
         private Builder() {
         }
@@ -113,6 +127,11 @@ public final class RequestBatchConfiguration {
 
         public Builder maxBatchBytesSize(Integer maxBatchBytesSize) {
             this.maxBatchBytesSize = maxBatchBytesSize;
+            return this;
+        }
+
+        public Builder shutdownGracePeriod(Duration shutdownGracePeriod) {
+            this.shutdownGracePeriod = shutdownGracePeriod;
             return this;
         }
 

--- a/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/internal/batchmanager/RequestBatchManager.java
+++ b/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/internal/batchmanager/RequestBatchManager.java
@@ -45,7 +45,7 @@ public abstract class RequestBatchManager<RequestT, ResponseT, BatchResponseT> {
 
     private final int maxBatchItems;
     private final Duration sendRequestFrequency;
-    private final Duration shutdownGracePeriod;
+    private final Duration shutdownTimeout;
     private final BatchingMap<RequestT, ResponseT> requestsAndResponsesMaps;
     private final ScheduledExecutorService scheduledExecutor;
     private final Set<CompletableFuture<BatchResponseT>> pendingBatchResponses ;
@@ -58,7 +58,7 @@ public abstract class RequestBatchManager<RequestT, ResponseT, BatchResponseT> {
         batchConfiguration = overrideConfiguration;
         this.maxBatchItems = batchConfiguration.maxBatchItems();
         this.sendRequestFrequency = batchConfiguration.sendRequestFrequency();
-        this.shutdownGracePeriod = batchConfiguration.shutdownGracePeriod();
+        this.shutdownTimeout = batchConfiguration.shutdownTimeout();
         this.scheduledExecutor = Validate.notNull(scheduledExecutor, "Null scheduledExecutor");
         pendingBatchResponses = ConcurrentHashMap.newKeySet();
         pendingResponses = ConcurrentHashMap.newKeySet();
@@ -173,7 +173,7 @@ public abstract class RequestBatchManager<RequestT, ResponseT, BatchResponseT> {
      * caller can wait on it. Does not block and does not cancel; a second call is a no-op that returns an
      * already-completed future.
      */
-    protected CompletableFuture<Void> dispatchPending() {
+    protected CompletableFuture<Void> closeAndDispatch() {
         if (!closed.compareAndSet(false, true)) {
             return CompletableFuture.completedFuture(null);
         }
@@ -183,7 +183,7 @@ public abstract class RequestBatchManager<RequestT, ResponseT, BatchResponseT> {
     }
 
     /**
-     * Phase 2 of shutdown. Cancels any requests still pending after the grace wait, surfacing
+     * Phase 2 of shutdown. Cancels any requests still pending after the timeout, surfacing
      * {@link java.util.concurrent.CancellationException} to their callers, and releases the buffers. Idempotent.
      */
     protected void cancelPending() {
@@ -192,8 +192,8 @@ public abstract class RequestBatchManager<RequestT, ResponseT, BatchResponseT> {
         requestsAndResponsesMaps.clear();
     }
 
-    protected Duration shutdownGracePeriod() {
-        return shutdownGracePeriod;
+    protected Duration shutdownTimeout() {
+        return shutdownTimeout;
     }
 
     private void drainBuffers() {

--- a/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/internal/batchmanager/RequestBatchManager.java
+++ b/services/sqs/src/main/java/software/amazon/awssdk/services/sqs/internal/batchmanager/RequestBatchManager.java
@@ -26,6 +26,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
@@ -36,7 +37,6 @@ import software.amazon.awssdk.utils.Validate;
 @SdkInternalApi
 public abstract class RequestBatchManager<RequestT, ResponseT, BatchResponseT> {
 
-
     // abm stands for Automatic Batching Manager
     public static final Consumer<AwsRequestOverrideConfiguration.Builder> USER_AGENT_APPLIER =
         b -> b.addApiName(ApiName.builder().version("abm").name("hll").build());
@@ -45,10 +45,12 @@ public abstract class RequestBatchManager<RequestT, ResponseT, BatchResponseT> {
 
     private final int maxBatchItems;
     private final Duration sendRequestFrequency;
+    private final Duration shutdownGracePeriod;
     private final BatchingMap<RequestT, ResponseT> requestsAndResponsesMaps;
     private final ScheduledExecutorService scheduledExecutor;
     private final Set<CompletableFuture<BatchResponseT>> pendingBatchResponses ;
     private final Set<CompletableFuture<ResponseT>> pendingResponses ;
+    private final AtomicBoolean closed = new AtomicBoolean(false);
 
 
     protected RequestBatchManager(RequestBatchConfiguration overrideConfiguration,
@@ -56,6 +58,7 @@ public abstract class RequestBatchManager<RequestT, ResponseT, BatchResponseT> {
         batchConfiguration = overrideConfiguration;
         this.maxBatchItems = batchConfiguration.maxBatchItems();
         this.sendRequestFrequency = batchConfiguration.sendRequestFrequency();
+        this.shutdownGracePeriod = batchConfiguration.shutdownGracePeriod();
         this.scheduledExecutor = Validate.notNull(scheduledExecutor, "Null scheduledExecutor");
         pendingBatchResponses = ConcurrentHashMap.newKeySet();
         pendingResponses = ConcurrentHashMap.newKeySet();
@@ -65,6 +68,10 @@ public abstract class RequestBatchManager<RequestT, ResponseT, BatchResponseT> {
 
     public CompletableFuture<ResponseT> batchRequest(RequestT request) {
         CompletableFuture<ResponseT> response = new CompletableFuture<>();
+        if (closed.get()) {
+            response.completeExceptionally(new IllegalStateException("The client has been shut down."));
+            return response;
+        }
         pendingResponses.add(response);
         response.whenComplete((r, t) -> pendingResponses.remove(response));
 
@@ -160,20 +167,45 @@ public abstract class RequestBatchManager<RequestT, ResponseT, BatchResponseT> {
         }
     }
 
-    public void close() {
+    /**
+     * Phase 1 of shutdown, non-blocking. Marks the manager closed, dispatches every buffered batch (each exactly
+     * once), and returns a future that completes when all in-flight sends dispatched here have completed, so the
+     * caller can wait on it. Does not block and does not cancel; a second call is a no-op that returns an
+     * already-completed future.
+     */
+    protected CompletableFuture<Void> dispatchPending() {
+        if (!closed.compareAndSet(false, true)) {
+            return CompletableFuture.completedFuture(null);
+        }
+        drainBuffers();
+        List<CompletableFuture<ResponseT>> snapshot = new ArrayList<>(pendingResponses);
+        return CompletableFuture.allOf(snapshot.toArray(new CompletableFuture[0]));
+    }
+
+    /**
+     * Phase 2 of shutdown. Cancels any requests still pending after the grace wait, surfacing
+     * {@link java.util.concurrent.CancellationException} to their callers, and releases the buffers. Idempotent.
+     */
+    protected void cancelPending() {
+        pendingResponses.forEach(future -> future.cancel(true));
+        pendingBatchResponses.forEach(future -> future.cancel(true));
+        requestsAndResponsesMaps.clear();
+    }
+
+    protected Duration shutdownGracePeriod() {
+        return shutdownGracePeriod;
+    }
+
+    private void drainBuffers() {
         requestsAndResponsesMaps.forEach((batchKey, batchBuffer) -> {
             requestsAndResponsesMaps.cancelScheduledFlush(batchKey);
-            Map<String, BatchingExecutionContext<RequestT, ResponseT>>
-                extractedEntries = requestsAndResponsesMaps.extractBatchIfReady(batchKey);
-
+            Map<String, BatchingExecutionContext<RequestT, ResponseT>> extractedEntries =
+                requestsAndResponsesMaps.extractEntriesForScheduledFlush(batchKey, maxBatchItems);
             while (!extractedEntries.isEmpty()) {
                 flushBuffer(batchKey, extractedEntries);
+                extractedEntries = requestsAndResponsesMaps.extractEntriesForScheduledFlush(batchKey, maxBatchItems);
             }
-
         });
-        pendingBatchResponses.forEach(future -> future.cancel(true));
-        pendingResponses.forEach(future -> future.cancel(true));
-        requestsAndResponsesMaps.clear();
     }
 
 }

--- a/services/sqs/src/test/java/software/amazon/awssdk/services/sqs/batchmanager/RequestBatchManagerTest.java
+++ b/services/sqs/src/test/java/software/amazon/awssdk/services/sqs/batchmanager/RequestBatchManagerTest.java
@@ -21,7 +21,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
@@ -151,54 +150,6 @@ class RequestBatchManagerTest {
 
         assertThrows(ExecutionException.class, () -> response.get(1, TimeUnit.SECONDS));
     }
-
-    @Test
-    void close_FlushesAllBatches() throws Exception {
-        String request1 = "testRequest:0";
-        String batchKey = "testRequest";
-        String request2 = "testRequest:1";
-        CompletableFuture<BatchResponse> batchResponseFuture = CompletableFuture.completedFuture(batchedResponse(2,
-                                                                                                                 "testResponse"));
-
-        when(mockClient.sendBatchAsync(any(), eq(batchKey))).thenReturn(batchResponseFuture);
-
-        SampleBatchManager batchManager=
-            new SampleBatchManager(BatchOverrideConfiguration.builder().maxBatchSize(2).sendRequestFrequency(Duration.ofHours(1)).build(), scheduledExecutor, mockClient);
-
-        CompletableFuture<String> response1 = batchManager.batchRequest(request1);
-        CompletableFuture<String> response2 = batchManager.batchRequest(request2);
-        // Even though the mock returns results immediately, since this is asynchronous execution, the test environment may take
-        // additional time due to the Scheduled Executors execution on that machine.
-        Thread.sleep(200);
-        batchManager.close();
-
-        assertEquals("testResponse0", response1.get(1, TimeUnit.SECONDS));
-
-        assertEquals("testResponse1", response2.get(1, TimeUnit.SECONDS));
-    }
-
-
-    @Test
-    void batchRequest_ClosedWhenWaitingForResponse() throws Exception {
-        String request = "testRequest:1";
-        String batchKey = "testRequest";
-        CompletableFuture<BatchResponse> batchResponseFuture = new CompletableFuture<>();
-
-        // Simulate successful response with delay
-        scheduledExecutor.schedule(() -> batchResponseFuture.complete(batchedResponse(1, "testResponse")),
-                                   10, TimeUnit.HOURS);
-
-        when(mockClient.sendBatchAsync(any(), eq(batchKey))).thenReturn(batchResponseFuture);
-
-        SampleBatchManager batchManager =
-            new SampleBatchManager(BatchOverrideConfiguration.builder().maxBatchSize(1).build(), scheduledExecutor, mockClient);
-        CompletableFuture<String> response = batchManager.batchRequest(request);
-
-        batchManager.close();
-        assertThrows(CancellationException.class, () -> response.join());
-
-    }
-
 
     @Test
     void batchRequest_MoreThanBufferSize_Fails() throws Exception {

--- a/services/sqs/src/test/java/software/amazon/awssdk/services/sqs/internal/batchmanager/DefaultSqsAsyncBatchManagerTest.java
+++ b/services/sqs/src/test/java/software/amazon/awssdk/services/sqs/internal/batchmanager/DefaultSqsAsyncBatchManagerTest.java
@@ -48,8 +48,8 @@ import software.amazon.awssdk.services.sqs.model.SendMessageResponse;
 /**
  * Close/shutdown behavior of the real {@link DefaultSqsAsyncBatchManager} (and, through it, the real write batch
  * managers), driven over a mock {@link SqsAsyncClient} whose batch-send futures the test controls. Lives in the
- * internal package to reach the package-private {@link DefaultSqsAsyncBatchManager.DefaultBuilder#shutdownGracePeriod}
- * test seam so a short grace can be injected.
+ * internal package to reach the package-private {@link DefaultSqsAsyncBatchManager.DefaultBuilder#shutdownTimeout}
+ * test seam so a short timeout can be injected.
  */
 class DefaultSqsAsyncBatchManagerTest {
 
@@ -68,7 +68,7 @@ class DefaultSqsAsyncBatchManagerTest {
     }
 
     private SqsAsyncBatchManager batchManager(SqsAsyncClient client, int maxBatchSize, Duration sendFrequency,
-                                              Duration shutdownGracePeriod) {
+                                              Duration shutdownTimeout) {
         DefaultSqsAsyncBatchManager.DefaultBuilder builder =
             (DefaultSqsAsyncBatchManager.DefaultBuilder) DefaultSqsAsyncBatchManager.builder();
         builder.client(client);
@@ -77,14 +77,14 @@ class DefaultSqsAsyncBatchManagerTest {
                                                                 .maxBatchSize(maxBatchSize)
                                                                 .sendRequestFrequency(sendFrequency)
                                                                 .build());
-        builder.shutdownGracePeriod(shutdownGracePeriod);
+        builder.shutdownTimeout(shutdownTimeout);
         return builder.build();
     }
 
     @Test
     @Timeout(20)
-    void close_boundsShutdownToOneSharedGracePeriod_notPerManager() {
-        Duration grace = Duration.ofMillis(400);
+    void close_boundsShutdownToOneSharedTimeout_notPerManager() {
+        Duration timeout = Duration.ofMillis(400);
         SqsAsyncClient client = mock(SqsAsyncClient.class);
         when(client.sendMessageBatch(any(SendMessageBatchRequest.class)))
             .thenReturn(new CompletableFuture<SendMessageBatchResponse>());
@@ -93,7 +93,7 @@ class DefaultSqsAsyncBatchManagerTest {
         when(client.changeMessageVisibilityBatch(any(ChangeMessageVisibilityBatchRequest.class)))
             .thenReturn(new CompletableFuture<ChangeMessageVisibilityBatchResponse>());
 
-        SqsAsyncBatchManager batchManager = batchManager(client, 10, Duration.ofHours(1), grace);
+        SqsAsyncBatchManager batchManager = batchManager(client, 10, Duration.ofHours(1), timeout);
         batchManager.sendMessage(r -> r.queueUrl(QUEUE_URL).messageBody("m"));
         batchManager.deleteMessage(r -> r.queueUrl(QUEUE_URL).receiptHandle("rh"));
         batchManager.changeMessageVisibility(r -> r.queueUrl(QUEUE_URL).receiptHandle("rh").visibilityTimeout(30));
@@ -102,11 +102,11 @@ class DefaultSqsAsyncBatchManagerTest {
         batchManager.close();
         long closeMillis = (System.nanoTime() - start) / 1_000_000;
 
-        assertThat(closeMillis).as("close() should wait about one grace period").isGreaterThanOrEqualTo(300);
+        assertThat(closeMillis).as("close() should wait about one timeout").isGreaterThanOrEqualTo(300);
         assertThat(closeMillis)
-            .as("close() must be bounded by ONE shared grace period, not one per manager (3x would be ~%d ms)",
-                3 * grace.toMillis())
-            .isLessThan(2 * grace.toMillis());
+            .as("close() must be bounded by ONE shared timeout, not one per manager (3x would be ~%d ms)",
+                3 * timeout.toMillis())
+            .isLessThan(2 * timeout.toMillis());
     }
 
     @Test
@@ -148,7 +148,7 @@ class DefaultSqsAsyncBatchManagerTest {
 
     @Test
     @Timeout(20)
-    void close_completesCallerWithRealResult_whenSendCompletesWithinGracePeriod() throws Exception {
+    void close_completesCallerWithRealResult_whenSendCompletesWithinTimeout() throws Exception {
         SqsAsyncClient client = mock(SqsAsyncClient.class);
         CompletableFuture<SendMessageBatchResponse> sendFuture = new CompletableFuture<>();
         when(client.sendMessageBatch(any(SendMessageBatchRequest.class))).thenReturn(sendFuture);
@@ -172,7 +172,7 @@ class DefaultSqsAsyncBatchManagerTest {
 
     @Test
     @Timeout(20)
-    void close_cancelsStragglerSend_thatDoesNotCompleteWithinGracePeriod() {
+    void close_cancelsStragglerSend_thatDoesNotCompleteWithinTimeout() {
         SqsAsyncClient client = mock(SqsAsyncClient.class);
         when(client.sendMessageBatch(any(SendMessageBatchRequest.class)))
             .thenReturn(new CompletableFuture<SendMessageBatchResponse>());

--- a/services/sqs/src/test/java/software/amazon/awssdk/services/sqs/internal/batchmanager/DefaultSqsAsyncBatchManagerTest.java
+++ b/services/sqs/src/test/java/software/amazon/awssdk/services/sqs/internal/batchmanager/DefaultSqsAsyncBatchManagerTest.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.sqs.internal.batchmanager;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import software.amazon.awssdk.services.sqs.SqsAsyncClient;
+import software.amazon.awssdk.services.sqs.batchmanager.BatchOverrideConfiguration;
+import software.amazon.awssdk.services.sqs.batchmanager.SqsAsyncBatchManager;
+import software.amazon.awssdk.services.sqs.model.ChangeMessageVisibilityBatchRequest;
+import software.amazon.awssdk.services.sqs.model.ChangeMessageVisibilityBatchResponse;
+import software.amazon.awssdk.services.sqs.model.DeleteMessageBatchRequest;
+import software.amazon.awssdk.services.sqs.model.DeleteMessageBatchResponse;
+import software.amazon.awssdk.services.sqs.model.SendMessageBatchRequest;
+import software.amazon.awssdk.services.sqs.model.SendMessageBatchResponse;
+import software.amazon.awssdk.services.sqs.model.SendMessageBatchResultEntry;
+import software.amazon.awssdk.services.sqs.model.SendMessageResponse;
+
+/**
+ * Close/shutdown behavior of the real {@link DefaultSqsAsyncBatchManager} (and, through it, the real write batch
+ * managers), driven over a mock {@link SqsAsyncClient} whose batch-send futures the test controls. Lives in the
+ * internal package to reach the package-private {@link DefaultSqsAsyncBatchManager.DefaultBuilder#shutdownGracePeriod}
+ * test seam so a short grace can be injected.
+ */
+class DefaultSqsAsyncBatchManagerTest {
+
+    private static final String QUEUE_URL = "https://sqs.us-east-1.amazonaws.com/123456789012/q";
+
+    private ScheduledExecutorService executor;
+
+    @BeforeEach
+    void setUp() {
+        executor = Executors.newScheduledThreadPool(2);
+    }
+
+    @AfterEach
+    void tearDown() {
+        executor.shutdownNow();
+    }
+
+    private SqsAsyncBatchManager batchManager(SqsAsyncClient client, int maxBatchSize, Duration sendFrequency,
+                                              Duration shutdownGracePeriod) {
+        DefaultSqsAsyncBatchManager.DefaultBuilder builder =
+            (DefaultSqsAsyncBatchManager.DefaultBuilder) DefaultSqsAsyncBatchManager.builder();
+        builder.client(client);
+        builder.scheduledExecutor(executor);
+        builder.overrideConfiguration(BatchOverrideConfiguration.builder()
+                                                                .maxBatchSize(maxBatchSize)
+                                                                .sendRequestFrequency(sendFrequency)
+                                                                .build());
+        builder.shutdownGracePeriod(shutdownGracePeriod);
+        return builder.build();
+    }
+
+    @Test
+    @Timeout(20)
+    void close_boundsShutdownToOneSharedGracePeriod_notPerManager() {
+        Duration grace = Duration.ofMillis(400);
+        SqsAsyncClient client = mock(SqsAsyncClient.class);
+        when(client.sendMessageBatch(any(SendMessageBatchRequest.class)))
+            .thenReturn(new CompletableFuture<SendMessageBatchResponse>());
+        when(client.deleteMessageBatch(any(DeleteMessageBatchRequest.class)))
+            .thenReturn(new CompletableFuture<DeleteMessageBatchResponse>());
+        when(client.changeMessageVisibilityBatch(any(ChangeMessageVisibilityBatchRequest.class)))
+            .thenReturn(new CompletableFuture<ChangeMessageVisibilityBatchResponse>());
+
+        SqsAsyncBatchManager batchManager = batchManager(client, 10, Duration.ofHours(1), grace);
+        batchManager.sendMessage(r -> r.queueUrl(QUEUE_URL).messageBody("m"));
+        batchManager.deleteMessage(r -> r.queueUrl(QUEUE_URL).receiptHandle("rh"));
+        batchManager.changeMessageVisibility(r -> r.queueUrl(QUEUE_URL).receiptHandle("rh").visibilityTimeout(30));
+
+        long start = System.nanoTime();
+        batchManager.close();
+        long closeMillis = (System.nanoTime() - start) / 1_000_000;
+
+        assertThat(closeMillis).as("close() should wait about one grace period").isGreaterThanOrEqualTo(300);
+        assertThat(closeMillis)
+            .as("close() must be bounded by ONE shared grace period, not one per manager (3x would be ~%d ms)",
+                3 * grace.toMillis())
+            .isLessThan(2 * grace.toMillis());
+    }
+
+    @Test
+    @Timeout(20)
+    void close_flushesBufferedPartialBatchExactlyOnce() {
+        SqsAsyncClient client = mock(SqsAsyncClient.class);
+        when(client.sendMessageBatch(any(SendMessageBatchRequest.class)))
+            .thenReturn(new CompletableFuture<SendMessageBatchResponse>());
+
+        SqsAsyncBatchManager batchManager = batchManager(client, 10, Duration.ofHours(1), Duration.ofMillis(300));
+        for (int i = 0; i < 5; i++) {
+            int n = i;
+            batchManager.sendMessage(r -> r.queueUrl(QUEUE_URL).messageBody("m" + n));
+        }
+
+        batchManager.close();
+
+        verify(client, times(1)).sendMessageBatch(any(SendMessageBatchRequest.class));
+    }
+
+    @Test
+    @Timeout(20)
+    void close_flushesFullThenResidualPartialBatch_eachExactlyOnce() {
+        SqsAsyncClient client = mock(SqsAsyncClient.class);
+        when(client.sendMessageBatch(any(SendMessageBatchRequest.class)))
+            .thenReturn(new CompletableFuture<SendMessageBatchResponse>());
+
+        SqsAsyncBatchManager batchManager = batchManager(client, 10, Duration.ofHours(1), Duration.ofMillis(300));
+        for (int i = 0; i < 15; i++) {
+            int n = i;
+            batchManager.sendMessage(r -> r.queueUrl(QUEUE_URL).messageBody("m" + n));
+        }
+
+        batchManager.close();
+
+        // 10 auto-flush a full batch during sendMessage, the residual 5 are drained on close: two sends, each once.
+        verify(client, times(2)).sendMessageBatch(any(SendMessageBatchRequest.class));
+    }
+
+    @Test
+    @Timeout(20)
+    void close_completesCallerWithRealResult_whenSendCompletesWithinGracePeriod() throws Exception {
+        SqsAsyncClient client = mock(SqsAsyncClient.class);
+        CompletableFuture<SendMessageBatchResponse> sendFuture = new CompletableFuture<>();
+        when(client.sendMessageBatch(any(SendMessageBatchRequest.class))).thenReturn(sendFuture);
+
+        SqsAsyncBatchManager batchManager = batchManager(client, 10, Duration.ofHours(1), Duration.ofSeconds(2));
+        CompletableFuture<SendMessageResponse> response = batchManager.sendMessage(r -> r.queueUrl(QUEUE_URL).messageBody("m"));
+        executor.schedule(() -> sendFuture.complete(
+            SendMessageBatchResponse.builder()
+                                    .successful(SendMessageBatchResultEntry.builder()
+                                                                           .id("0")
+                                                                           .messageId("msg-0")
+                                                                           .md5OfMessageBody("d41d8cd98f00b204e9800998ecf8427e")
+                                                                           .build())
+                                    .build()),
+                          100, TimeUnit.MILLISECONDS);
+
+        batchManager.close();
+
+        assertThat(response.get(1, TimeUnit.SECONDS).messageId()).isEqualTo("msg-0");
+    }
+
+    @Test
+    @Timeout(20)
+    void close_cancelsStragglerSend_thatDoesNotCompleteWithinGracePeriod() {
+        SqsAsyncClient client = mock(SqsAsyncClient.class);
+        when(client.sendMessageBatch(any(SendMessageBatchRequest.class)))
+            .thenReturn(new CompletableFuture<SendMessageBatchResponse>());
+
+        SqsAsyncBatchManager batchManager = batchManager(client, 10, Duration.ofHours(1), Duration.ofMillis(300));
+        CompletableFuture<SendMessageResponse> response = batchManager.sendMessage(r -> r.queueUrl(QUEUE_URL).messageBody("m"));
+
+        batchManager.close();
+
+        assertThatThrownBy(response::join).isInstanceOf(CancellationException.class);
+    }
+
+    @Test
+    @Timeout(20)
+    void sendMessageAfterClose_completesExceptionallyWithIllegalStateException() {
+        SqsAsyncClient client = mock(SqsAsyncClient.class);
+        SqsAsyncBatchManager batchManager = batchManager(client, 10, Duration.ofHours(1), Duration.ofMillis(1));
+
+        batchManager.close();
+        batchManager.close(); // idempotent: second close is a no-op
+
+        CompletableFuture<SendMessageResponse> response = batchManager.sendMessage(r -> r.queueUrl(QUEUE_URL).messageBody("m"));
+
+        assertThatThrownBy(() -> response.get(1, TimeUnit.SECONDS)).hasCauseInstanceOf(IllegalStateException.class);
+    }
+}


### PR DESCRIPTION
## Motivation and Context

This fixes two shutdown issues in `SqsAsyncBatchManager.close()`, both in the shared internal base class `RequestBatchManager` (module `services/sqs`).

1. Redundant re-sends of a buffered batch on close. When `close()` was called while other threads were still submitting on a real asynchronous client, a buffered batch could be sent more than once: `close()` waited for the in-flight response by re-sending the same batch, because the drain loop stopped only after an asynchronous completion callback cleared it rather than after draining the buffer. The effect was a bounded number of duplicate `SendMessageBatch` calls for the same messages during that single `close()`. `close()` now drains each buffered batch and sends it exactly once, stopping when the buffer is empty (partial batches included).

2. In-flight requests cancelled on shutdown. Previously `close()` cancelled in-flight batch sends immediately, so a request that had already been dispatched could complete with `CancellationException` instead of its real `SendMessageResponse`. `close()` now waits a bounded grace period for in-flight sends to finish so their callers receive the real result, and cancels only the requests still outstanding when that period expires. This mirrors the graceful bounded-await shutdown already used by `CloudWatchMetricPublisher.close()`.

## Modifications

Drain each buffered batch exactly once:

- `RequestBatchManager` now drains each buffer by re-extracting the next batch with `extractEntriesForScheduledFlush` (the drain-any-non-empty primitive `performScheduledFlush` already uses) and flushing each distinct batch exactly once, terminating when the buffer is empty. Full and partial batches are now sent exactly once (previously a residual partial batch was never sent and its callers were cancelled).

Graceful bounded-await shutdown (dispatch-all-first, then a single shared wait):

- `RequestBatchManager` exposes a two-phase internal shutdown surface: `dispatchPending()` (phase 1, non-blocking) marks the manager closed, drains/dispatches every buffered batch, and returns a `CompletableFuture<Void>` that completes when the in-flight sends it dispatched complete; `cancelPending()` (phase 2) cancels anything still pending and releases the buffers. The wait targets the caller-facing futures (`pendingResponses`), so a completing send delivers the real result rather than being cancelled.
- `DefaultSqsAsyncBatchManager.close()` orchestrates the shutdown: it calls `dispatchPending()` on all three write managers first (every buffered batch goes on the wire at once), then performs a single bounded wait via `CompletableFuture.allOf(...)` up to one shared grace period, then calls `cancelPending()` on all three, then closes the receive manager. Because all three dispatch before the single wait, the whole shutdown is bounded by ONE grace period, not one per manager. The wait helper never throws (handles `TimeoutException`/`ExecutionException`/`InterruptedException`, restoring the interrupt flag).
- The grace period is a new internal field on `RequestBatchConfiguration` (`@SdkInternalApi`), default 5 seconds. There is no public knob.
- `DefaultSqsAsyncBatchManager.close()` is guarded by an `AtomicBoolean` so it is idempotent and safe under concurrent calls: only the first caller runs the dispatch/await/cancel orchestration, and a concurrent or second call is a clean no-op (this avoids a concurrent loser cancelling the winner's still-awaited in-flight sends).
- `RequestBatchManager` gains an `AtomicBoolean` closed guard: a `sendMessage` / `deleteMessage` / `changeMessageVisibility` submitted after close returns a future completed exceptionally with `IllegalStateException`, matching the receive path.

Documentation:

- Added an `@Override void close()` Javadoc on the public `SqsAsyncBatchManager` documenting that close flushes buffered requests, blocks up to a bounded grace period for in-flight sends so callers receive real results, then cancels stragglers.

## Testing

`services/sqs` built with full static analysis (Checkstyle, SpotBugs, PMD, japicmp) - BUILD SUCCESS, no public API break. New and existing tests pass. 

Added new test cases

- `DefaultSqsAsyncBatchManagerTest`  - close/shutdown behavior against the REAL `DefaultSqsAsyncBatchManager` (and, through it, the real write batch managers) over a mock `SqsAsyncClient` with controllable batch-send futures:
- `SqsAsyncBatchManagerTest` (WireMock) - real end-to-end batching over HTTP.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

- [ ] I have read the CONTRIBUTING document
- [ ] Local run of `mvn install` succeeds (built the affected module `services/sqs`, not a full-repo `mvn install`)
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have added a changelog entry.
- [ ] My change is to implement 1.11 parity feature and I have updated LaunchChangelog

## License

- [x] I confirm that this pull request can be released under the Apache 2 license