### PR TITLE
fix: surface CRT request-body publisher errors

### DIFF
--- a/.changes/next-release/bugfix-AWSCRTAsyncHTTPClient-9e30665.json
+++ b/.changes/next-release/bugfix-AWSCRTAsyncHTTPClient-9e30665.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "AWS CRT Async HTTP Client",
+    "contributor": "",
+    "description": "Fixed an issue where an error signaled by a request body publisher was printed to stderr on a CRT event loop thread instead of failing the request with the original error."
+}

--- a/.changes/next-release/bugfix-AWSCRTHTTPClient-136fcd0.json
+++ b/.changes/next-release/bugfix-AWSCRTHTTPClient-136fcd0.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "AWS CRT HTTP Client",
+    "contributor": "",
+    "description": "Fixed an issue where an error thrown while reading the request body stream was printed to stderr on a CRT event loop thread instead of failing the request with the original error. See [#6715](https://github.com/aws/aws-sdk-java-v2/issues/6715)."
+}

--- a/.changes/next-release/bugfix-AWSCRTbasedS3Client-b39e255.json
+++ b/.changes/next-release/bugfix-AWSCRTbasedS3Client-b39e255.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "AWS CRT-based S3 Client",
+    "contributor": "",
+    "description": "Fixed an issue where an error signaled by a request body publisher (for example via `AsyncRequestBody.fromPublisher`) was printed to stderr on a CRT event loop thread instead of failing the operation; the operation's future now completes with the original publisher error. See [#6715](https://github.com/aws/aws-sdk-java-v2/issues/6715)."
+}

--- a/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/CrtAsyncRequestExecutor.java
+++ b/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/CrtAsyncRequestExecutor.java
@@ -63,11 +63,12 @@ public final class CrtAsyncRequestExecutor {
             acquireStartTime = System.nanoTime();
         }
 
-        HttpRequestBase crtRequest = toAsyncCrtRequest(executionContext);
         HttpStreamManager streamManager = executionContext.streamManager();
 
         CrtResponseAdapter crtResponseHandler =
             CrtResponseAdapter.toCrtResponseHandler(requestFuture, asyncRequest.responseHandler());
+
+        HttpRequestBase crtRequest = toAsyncCrtRequest(executionContext, crtResponseHandler::failRequest);
 
         CompletableFuture<HttpStreamBase> streamFuture =
             streamManager.acquireStream(crtRequest, crtResponseHandler);

--- a/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/CrtRequestExecutor.java
+++ b/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/CrtRequestExecutor.java
@@ -58,7 +58,7 @@ public final class CrtRequestExecutor {
         InputStreamAdaptingHttpStreamResponseHandler crtResponseHandler =
             new InputStreamAdaptingHttpStreamResponseHandler(requestFuture);
 
-        HttpRequest crtRequest = CrtRequestAdapter.toCrtRequest(executionContext);
+        HttpRequest crtRequest = CrtRequestAdapter.toCrtRequest(executionContext, requestFuture::completeExceptionally);
         HttpStreamManager streamManager = executionContext.streamManager();
 
         CompletableFuture<HttpStreamBase> streamFuture =

--- a/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/request/CrtRequestAdapter.java
+++ b/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/request/CrtRequestAdapter.java
@@ -19,6 +19,7 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Consumer;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.crt.http.HttpHeader;
 import software.amazon.awssdk.crt.http.HttpRequest;
@@ -36,7 +37,7 @@ public final class CrtRequestAdapter {
     private CrtRequestAdapter() {
     }
 
-    public static HttpRequestBase toAsyncCrtRequest(CrtAsyncRequestContext request) {
+    public static HttpRequestBase toAsyncCrtRequest(CrtAsyncRequestContext request, Consumer<Throwable> onBodyError) {
         AsyncExecuteRequest sdkExecuteRequest = request.sdkRequest();
         SdkHttpRequest sdkRequest = sdkExecuteRequest.request();
 
@@ -51,7 +52,8 @@ public final class CrtRequestAdapter {
                                               .orElse("");
         String path = encodedPath + encodedQueryString;
         CrtRequestBodyAdapter crtRequestBodyAdapter = new CrtRequestBodyAdapter(sdkExecuteRequest.requestContentPublisher(),
-                                                                                request.readBufferSize());
+                                                                                request.readBufferSize(),
+                                                                                onBodyError);
         HttpHeader[] crtHeaderArray = asArray(createAsyncHttpHeaderList(sdkRequest.getUri(), sdkExecuteRequest,
                                                                         request.protocol()));
         return new HttpRequest(method,

--- a/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/request/CrtRequestAdapter.java
+++ b/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/request/CrtRequestAdapter.java
@@ -62,7 +62,7 @@ public final class CrtRequestAdapter {
                                crtRequestBodyAdapter);
     }
 
-    public static HttpRequest toCrtRequest(CrtRequestContext request) {
+    public static HttpRequest toCrtRequest(CrtRequestContext request, Consumer<Throwable> onBodyError) {
 
         HttpExecuteRequest sdkExecuteRequest = request.sdkRequest();
         SdkHttpRequest sdkRequest = sdkExecuteRequest.httpRequest();
@@ -84,7 +84,7 @@ public final class CrtRequestAdapter {
                                 .map(provider -> new HttpRequest(method,
                                                                  finalEncodedPath,
                                                                  crtHeaderArray,
-                                                                 new CrtRequestInputStreamAdapter(provider)))
+                                                                 new CrtRequestInputStreamAdapter(provider, onBodyError)))
                                 .orElse(new HttpRequest(method,
                                                         finalEncodedPath,
                                                         crtHeaderArray, null));

--- a/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/request/CrtRequestBodyAdapter.java
+++ b/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/request/CrtRequestBodyAdapter.java
@@ -17,6 +17,7 @@ package software.amazon.awssdk.http.crt.internal.request;
 
 import java.nio.ByteBuffer;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.crt.http.HttpRequestBodyStream;
 import software.amazon.awssdk.http.async.SdkHttpContentPublisher;
@@ -27,11 +28,14 @@ import software.amazon.awssdk.utils.async.ByteBufferStoringSubscriber.TransferRe
 final class CrtRequestBodyAdapter implements HttpRequestBodyStream {
     private final SdkHttpContentPublisher requestPublisher;
     private final ByteBufferStoringSubscriber requestBodySubscriber;
+    private final Consumer<Throwable> onBodyError;
     private final AtomicBoolean subscribed = new AtomicBoolean(false);
+    private final AtomicBoolean errorSignaled = new AtomicBoolean(false);
 
-    CrtRequestBodyAdapter(SdkHttpContentPublisher requestPublisher, long readLimit) {
+    CrtRequestBodyAdapter(SdkHttpContentPublisher requestPublisher, long readLimit, Consumer<Throwable> onBodyError) {
         this.requestPublisher = requestPublisher;
         this.requestBodySubscriber = new ByteBufferStoringSubscriber(readLimit);
+        this.onBodyError = onBodyError;
     }
 
     @Override
@@ -40,7 +44,16 @@ final class CrtRequestBodyAdapter implements HttpRequestBodyStream {
             requestPublisher.subscribe(requestBodySubscriber);
         }
 
-        return requestBodySubscriber.transferTo(bodyBytesOut) == TransferResult.END_OF_STREAM;
+        try {
+            return requestBodySubscriber.transferTo(bodyBytesOut) == TransferResult.END_OF_STREAM;
+        } catch (RuntimeException e) {
+            // This is a native JNI upcall: an escaping exception is printed to stderr and discarded by CRT (#6715).
+            // Fail the request with the original publisher error instead of letting it propagate.
+            if (errorSignaled.compareAndSet(false, true)) {
+                onBodyError.accept(e);
+            }
+            return false;
+        }
     }
 
     @Override

--- a/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/request/CrtRequestInputStreamAdapter.java
+++ b/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/request/CrtRequestInputStreamAdapter.java
@@ -20,6 +20,8 @@ import static java.lang.Math.min;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.crt.http.HttpRequestBodyStream;
 import software.amazon.awssdk.http.ContentStreamProvider;
@@ -29,11 +31,14 @@ final class CrtRequestInputStreamAdapter implements HttpRequestBodyStream {
     private static final int READ_BUFFER_SIZE = 16 * 1024;
 
     private final ContentStreamProvider provider;
+    private final Consumer<Throwable> onBodyError;
+    private final AtomicBoolean errorSignaled = new AtomicBoolean(false);
     private volatile InputStream providerStream;
     private final byte[] readBuffer = new byte[READ_BUFFER_SIZE];
 
-    CrtRequestInputStreamAdapter(ContentStreamProvider provider) {
+    CrtRequestInputStreamAdapter(ContentStreamProvider provider, Consumer<Throwable> onBodyError) {
         this.provider = provider;
+        this.onBodyError = onBodyError;
     }
 
     @Override
@@ -51,8 +56,11 @@ final class CrtRequestInputStreamAdapter implements HttpRequestBodyStream {
             if (read > 0) {
                 bodyBytesOut.put(readBuffer, 0, read);
             }
-        } catch (IOException ioe) {
-            throw new RuntimeException(ioe);
+        } catch (IOException | RuntimeException e) {
+            // This is a native JNI call: an escaping exception is printed to stderr and discarded by CRT (#6715).
+            // Fail the request with the original error instead of letting it propagate.
+            signalError(e);
+            return false;
         }
 
         return read < 0;
@@ -62,11 +70,18 @@ final class CrtRequestInputStreamAdapter implements HttpRequestBodyStream {
     public boolean resetPosition() {
         try {
             createNewStream();
-        } catch (IOException ioe) {
-            throw new RuntimeException(ioe);
+        } catch (IOException | RuntimeException e) {
+            signalError(e);
+            return false;
         }
 
         return true;
+    }
+
+    private void signalError(Throwable error) {
+        if (errorSignaled.compareAndSet(false, true)) {
+            onBodyError.accept(error);
+        }
     }
 
     private void createNewStream() throws IOException {

--- a/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/response/CrtResponseAdapter.java
+++ b/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/response/CrtResponseAdapter.java
@@ -19,6 +19,7 @@ import static software.amazon.awssdk.http.crt.internal.CrtUtils.wrapWithIoExcept
 
 import java.nio.ByteBuffer;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.annotations.SdkTestInternalApi;
 import software.amazon.awssdk.crt.CRT;
@@ -48,6 +49,11 @@ public final class CrtResponseAdapter implements HttpStreamBaseResponseHandler {
     private final SimplePublisher<ByteBuffer> responsePublisher;
     private final SdkHttpResponse.Builder responseBuilder;
     private final ResponseHandlerHelper responseHandlerHelper;
+
+    // Guards the single terminal responseHandler.onError. A request-body error (failRequest) completes the future,
+    // which triggers closeConnection -> cancel -> a cancel-derived onResponseComplete; this guard stops that from
+    // notifying onError a second time. See #6715.
+    private final AtomicBoolean onErrorInvoked = new AtomicBoolean(false);
 
     private CrtResponseAdapter(CompletableFuture<Void> completionFuture,
                                SdkAsyncHttpResponseHandler responseHandler) {
@@ -133,12 +139,25 @@ public final class CrtResponseAdapter implements HttpStreamBaseResponseHandler {
         responseHandlerHelper.closeConnection();
     }
 
+    /**
+     * Fail the request from outside the CRT response callbacks (e.g. a request-body read error): deliver the error to
+     * the response handler and complete the request future. Completing the future triggers the executor's
+     * connection-eviction which cancels the stream; the cancel-derived {@code onResponseComplete} is suppressed by the
+     * one-shot guard in {@link #callResponseHandlerOnError}, so the handler is notified exactly once. See #6715.
+     */
+    public void failRequest(Throwable error) {
+        failResponseHandlerAndFuture(error);
+    }
+
     private void failResponseHandlerAndFuture(Throwable error) {
         callResponseHandlerOnError(error);
         completionFuture.completeExceptionally(error);
     }
 
     private void callResponseHandlerOnError(Throwable error) {
+        if (!onErrorInvoked.compareAndSet(false, true)) {
+            return;
+        }
         try {
             responseHandler.onError(error);
         } catch (RuntimeException e) {

--- a/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/AwsCrtAsyncHttpClientWireMockTest.java
+++ b/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/AwsCrtAsyncHttpClientWireMockTest.java
@@ -32,8 +32,11 @@ import static software.amazon.awssdk.http.crt.CrtHttpClientTestUtils.waitForEven
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import java.net.URI;
+import java.nio.ByteBuffer;
 import java.time.Duration;
+import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import org.apache.logging.log4j.Level;
 import org.junit.jupiter.api.BeforeAll;
@@ -42,14 +45,19 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
 import software.amazon.awssdk.crt.CrtResource;
 import software.amazon.awssdk.crt.Log;
 import software.amazon.awssdk.http.HttpMetric;
 import software.amazon.awssdk.http.RecordingResponseHandler;
 import software.amazon.awssdk.http.SdkHttpConfigurationOption;
+import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.http.SdkHttpMethod;
 import software.amazon.awssdk.http.SdkHttpRequest;
 import software.amazon.awssdk.http.async.AsyncExecuteRequest;
 import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
+import software.amazon.awssdk.http.async.SdkHttpContentPublisher;
 import software.amazon.awssdk.metrics.MetricCollection;
 import software.amazon.awssdk.testutils.LogCaptor;
 import software.amazon.awssdk.utils.AttributeMap;
@@ -188,6 +196,55 @@ public class AwsCrtAsyncHttpClientWireMockTest {
                     assertThat(event.getMessage().getFormattedMessage()).contains("numEventLoopThreads"));
             }
         }
+    }
+
+    @Test
+    public void requestBodyPublisherError_completesFutureWithOriginalError(WireMockRuntimeInfo wm) {
+        mockServer.stubFor(any(urlPathEqualTo("/")).willReturn(aResponse().withStatus(200)));
+        IllegalArgumentException bodyError = new IllegalArgumentException("test error");
+
+        try (SdkAsyncHttpClient client = AwsCrtAsyncHttpClient.create()) {
+            SdkHttpFullRequest request = SdkHttpFullRequest.builder()
+                                                          .uri(URI.create("http://localhost:" + wm.getHttpPort()))
+                                                          .method(SdkHttpMethod.PUT)
+                                                          .encodedPath("/")
+                                                          .putHeader("Host", "localhost")
+                                                          .putHeader("Content-Length", "16")
+                                                          .build();
+
+            CompletableFuture<Void> executeFuture =
+                client.execute(AsyncExecuteRequest.builder()
+                                                  .request(request)
+                                                  .requestContentPublisher(erroringPublisher(bodyError, 16))
+                                                  .responseHandler(new RecordingResponseHandler())
+                                                  .build());
+
+            assertThatThrownBy(() -> executeFuture.get(5, TimeUnit.SECONDS))
+                .hasCauseReference(bodyError);
+        }
+    }
+
+    private static SdkHttpContentPublisher erroringPublisher(Throwable error, long contentLength) {
+        return new SdkHttpContentPublisher() {
+            @Override
+            public Optional<Long> contentLength() {
+                return Optional.of(contentLength);
+            }
+
+            @Override
+            public void subscribe(Subscriber<? super ByteBuffer> subscriber) {
+                subscriber.onSubscribe(new Subscription() {
+                    @Override
+                    public void request(long n) {
+                        subscriber.onError(error);
+                    }
+
+                    @Override
+                    public void cancel() {
+                    }
+                });
+            }
+        };
     }
 
     private void warmUpStaticDefaultEventLoopGroup() {

--- a/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/AwsCrtHttpClientWireMockTest.java
+++ b/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/AwsCrtHttpClientWireMockTest.java
@@ -20,6 +20,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.any;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static java.util.Collections.emptyMap;
 import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
@@ -34,6 +35,8 @@ import static software.amazon.awssdk.http.crt.CrtHttpClientTestUtils.waitForEven
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
 import java.net.URI;
 import java.time.Duration;
 import java.util.Set;
@@ -54,6 +57,7 @@ import software.amazon.awssdk.http.Protocol;
 import software.amazon.awssdk.http.SdkHttpClient;
 import software.amazon.awssdk.http.SdkHttpClientTestSuite;
 import software.amazon.awssdk.http.SdkHttpConfigurationOption;
+import software.amazon.awssdk.http.SdkHttpMethod;
 import software.amazon.awssdk.http.SdkHttpRequest;
 import software.amazon.awssdk.metrics.MetricCollection;
 import software.amazon.awssdk.metrics.MetricCollector;
@@ -274,6 +278,54 @@ public class AwsCrtHttpClientWireMockTest extends SdkHttpClientTestSuite  {
                 executableRequest.abort();
             assertThatThrownBy(() -> executableRequest.call()).isInstanceOf(IOException.class)
                 .hasMessageContaining("cancelled");
+        }
+    }
+
+    @Test
+    public void call_requestBodyStreamThrows_surfacesOriginalIoException() throws Exception {
+        try (SdkHttpClient client = AwsCrtHttpClient.create()) {
+            URI uri = URI.create("http://localhost:" + mockServer.port());
+            stubFor(any(urlPathEqualTo("/")).willReturn(aResponse().withStatus(200)));
+            SdkHttpRequest request = createRequest(uri, "/", new byte[] {1, 2, 3, 4, 5}, SdkHttpMethod.PUT, emptyMap());
+
+            HttpExecuteRequest.Builder executeRequestBuilder = HttpExecuteRequest.builder();
+            executeRequestBuilder.request(request)
+                                 .contentStreamProvider(() -> new InputStream() {
+                                     @Override
+                                     public int read() throws IOException {
+                                         throw new IOException("boom");
+                                     }
+
+                                     @Override
+                                     public int read(byte[] b, int off, int len) throws IOException {
+                                         throw new IOException("boom");
+                                     }
+                                 });
+            ExecutableHttpRequest executableRequest = client.prepareRequest(executeRequestBuilder.build());
+
+            assertThatThrownBy(executableRequest::call)
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("boom");
+        }
+    }
+
+    @Test
+    public void call_requestBodyProviderThrowsUncheckedIoException_surfacesOriginalError() throws Exception {
+        try (SdkHttpClient client = AwsCrtHttpClient.create()) {
+            URI uri = URI.create("http://localhost:" + mockServer.port());
+            stubFor(any(urlPathEqualTo("/")).willReturn(aResponse().withStatus(200)));
+            SdkHttpRequest request = createRequest(uri, "/", new byte[] {1, 2, 3, 4, 5}, SdkHttpMethod.PUT, emptyMap());
+
+            HttpExecuteRequest.Builder executeRequestBuilder = HttpExecuteRequest.builder();
+            executeRequestBuilder.request(request)
+                                 .contentStreamProvider(() -> {
+                                     throw new UncheckedIOException(new IOException("boom"));
+                                 });
+            ExecutableHttpRequest executableRequest = client.prepareRequest(executeRequestBuilder.build());
+
+            assertThatThrownBy(executableRequest::call)
+                .hasRootCauseInstanceOf(IOException.class)
+                .hasRootCauseMessage("boom");
         }
     }
 

--- a/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/internal/CrtResponseHandlerTest.java
+++ b/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/internal/CrtResponseHandlerTest.java
@@ -16,6 +16,9 @@
 package software.amazon.awssdk.http.crt.internal;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import java.nio.ByteBuffer;
@@ -71,6 +74,22 @@ public class CrtResponseHandlerTest extends BaseHttpStreamResponseHandlerTest {
         assertThatThrownBy(() -> requestFuture.join()).isInstanceOf(CancellationException.class).hasStackTraceContaining(
             "subscription has been cancelled");
         verify(httpStream).close();
+    }
+
+    @Test
+    void failRequest_thenCancelDerivedComplete_invokesOnErrorOnceWithOriginalError() {
+        SdkAsyncHttpResponseHandler responseHandler = spy(new TestAsyncHttpResponseHandler());
+        CrtResponseAdapter adapter = CrtResponseAdapter.toCrtResponseHandler(requestFuture, responseHandler);
+        adapter.onAcquireStream(httpStream);
+
+        RuntimeException original = new RuntimeException("test error");
+        adapter.failRequest(original);
+
+        // closeConnection's cancel later surfaces as a cancel-derived onResponseComplete; it must not re-notify onError.
+        adapter.onResponseComplete(httpStream, 1);
+
+        verify(responseHandler, times(1)).onError(any());
+        assertThatThrownBy(() -> requestFuture.join()).hasCause(original);
     }
 
     private static class TestAsyncHttpResponseHandler implements SdkAsyncHttpResponseHandler {

--- a/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/internal/request/CrtRequestAdapterTest.java
+++ b/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/internal/request/CrtRequestAdapterTest.java
@@ -95,7 +95,7 @@ public class CrtRequestAdapterTest {
                                                                .readBufferSize(2000)
                                                                .protocol(Protocol.HTTP1_1)
                                                                .build();
-        return CrtRequestAdapter.toAsyncCrtRequest(context);
+        return CrtRequestAdapter.toAsyncCrtRequest(context, t -> { });
     }
 
     private static HttpRequestBase toCrtRequest(SdkHttpFullRequest sdkRequest) {

--- a/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/internal/request/CrtRequestAdapterTest.java
+++ b/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/internal/request/CrtRequestAdapterTest.java
@@ -106,7 +106,7 @@ public class CrtRequestAdapterTest {
                                                      .request(executeRequest)
                                                      .readBufferSize(2000)
                                                      .build();
-        return CrtRequestAdapter.toCrtRequest(context);
+        return CrtRequestAdapter.toCrtRequest(context, t -> { });
     }
 
     private static List<String> headerNames(HttpRequestBase crtRequest) {

--- a/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/internal/request/CrtRequestBodyAdapterTest.java
+++ b/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/internal/request/CrtRequestBodyAdapterTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.crt.internal.request;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.ByteBuffer;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import software.amazon.awssdk.http.async.SdkHttpContentPublisher;
+
+class CrtRequestBodyAdapterTest {
+
+    @Test
+    void sendRequestBody_publisherThrows_signalsErrorWithoutThrowing() {
+        AtomicReference<Throwable> signaled = new AtomicReference<>();
+        CrtRequestBodyAdapter adapter =
+            new CrtRequestBodyAdapter(erroringPublisher(new RuntimeException("Something wrong happened")), 16, signaled::set);
+
+        assertThatNoException().isThrownBy(() -> adapter.sendRequestBody(ByteBuffer.allocate(16)));
+
+        assertThat(signaled.get()).isInstanceOf(RuntimeException.class)
+                                  .hasMessageContaining("Something wrong happened");
+    }
+
+    @Test
+    void sendRequestBody_publisherThrowsCheckedException_signalsWrappedError() {
+        AtomicReference<Throwable> signaled = new AtomicReference<>();
+        CrtRequestBodyAdapter adapter =
+            new CrtRequestBodyAdapter(erroringPublisher(new IOException("Some I/O error happened")), 16, signaled::set);
+
+        assertThatNoException().isThrownBy(() -> adapter.sendRequestBody(ByteBuffer.allocate(16)));
+
+        assertThat(signaled.get()).isInstanceOf(UncheckedIOException.class)
+                                  .hasCauseInstanceOf(IOException.class);
+    }
+
+    @Test
+    void sendRequestBody_calledAgainAfterError_signalsErrorOnlyOnce() {
+        AtomicInteger signalCount = new AtomicInteger(0);
+        CrtRequestBodyAdapter adapter =
+            new CrtRequestBodyAdapter(erroringPublisher(new RuntimeException("boom")), 16, t -> signalCount.incrementAndGet());
+
+        adapter.sendRequestBody(ByteBuffer.allocate(16));
+        assertThatNoException().isThrownBy(() -> adapter.sendRequestBody(ByteBuffer.allocate(16)));
+
+        assertThat(signalCount.get()).isEqualTo(1);
+    }
+
+    private static SdkHttpContentPublisher erroringPublisher(Throwable error) {
+        return new SdkHttpContentPublisher() {
+            @Override
+            public Optional<Long> contentLength() {
+                return Optional.of(0L);
+            }
+
+            @Override
+            public void subscribe(Subscriber<? super ByteBuffer> subscriber) {
+                subscriber.onSubscribe(new Subscription() {
+                    @Override
+                    public void request(long n) {
+                        subscriber.onError(error);
+                    }
+
+                    @Override
+                    public void cancel() {
+                    }
+                });
+            }
+        };
+    }
+}

--- a/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/internal/request/CrtRequestInputStreamAdapterTest.java
+++ b/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/internal/request/CrtRequestInputStreamAdapterTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.crt.internal.request;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.ByteBuffer;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.http.ContentStreamProvider;
+
+class CrtRequestInputStreamAdapterTest {
+
+    @Test
+    void sendRequestBody_streamReadThrows_signalsOriginalErrorAndReturnsFalse() {
+        IOException error = new IOException("boom");
+        AtomicReference<Throwable> signaled = new AtomicReference<>();
+        CrtRequestInputStreamAdapter adapter =
+            new CrtRequestInputStreamAdapter(readErroringProvider(error), signaled::set);
+
+        assertThat(adapter.sendRequestBody(ByteBuffer.allocate(16))).isFalse();
+
+        assertThat(signaled.get()).isSameAs(error);
+    }
+
+    @Test
+    void sendRequestBody_newStreamThrowsUncheckedIoException_signalsOriginalErrorAndReturnsFalse() {
+        UncheckedIOException error = new UncheckedIOException(new IOException("boom"));
+        AtomicReference<Throwable> signaled = new AtomicReference<>();
+        CrtRequestInputStreamAdapter adapter =
+            new CrtRequestInputStreamAdapter(() -> { throw error; }, signaled::set);
+
+        assertThat(adapter.sendRequestBody(ByteBuffer.allocate(16))).isFalse();
+
+        assertThat(signaled.get()).isSameAs(error);
+    }
+
+    @Test
+    void sendRequestBody_newStreamReturnsNull_signalsNpeAndReturnsFalse() {
+        AtomicReference<Throwable> signaled = new AtomicReference<>();
+        CrtRequestInputStreamAdapter adapter =
+            new CrtRequestInputStreamAdapter(() -> null, signaled::set);
+
+        assertThat(adapter.sendRequestBody(ByteBuffer.allocate(16))).isFalse();
+
+        assertThat(signaled.get()).isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void resetPosition_closingPreviousStreamThrows_signalsOriginalErrorAndReturnsFalse() {
+        IOException error = new IOException("cannot reset");
+        AtomicReference<Throwable> signaled = new AtomicReference<>();
+        CrtRequestInputStreamAdapter adapter =
+            new CrtRequestInputStreamAdapter(closeErroringProvider(error), signaled::set);
+
+        assertThat(adapter.resetPosition()).isTrue();
+        assertThat(adapter.resetPosition()).isFalse();
+
+        assertThat(signaled.get()).isSameAs(error);
+    }
+
+    @Test
+    void sendRequestBody_calledAgainAfterError_signalsErrorOnlyOnce() {
+        AtomicInteger signalCount = new AtomicInteger(0);
+        CrtRequestInputStreamAdapter adapter =
+            new CrtRequestInputStreamAdapter(readErroringProvider(new IOException("boom")),
+                                             t -> signalCount.incrementAndGet());
+
+        adapter.sendRequestBody(ByteBuffer.allocate(16));
+        assertThatNoException().isThrownBy(() -> adapter.sendRequestBody(ByteBuffer.allocate(16)));
+
+        assertThat(signalCount.get()).isEqualTo(1);
+    }
+
+    private static ContentStreamProvider readErroringProvider(IOException error) {
+        return () -> new InputStream() {
+            @Override
+            public int read() throws IOException {
+                throw error;
+            }
+
+            @Override
+            public int read(byte[] b, int off, int len) throws IOException {
+                throw error;
+            }
+        };
+    }
+
+    private static ContentStreamProvider closeErroringProvider(IOException error) {
+        return () -> new InputStream() {
+            @Override
+            public int read() {
+                return -1;
+            }
+
+            @Override
+            public void close() throws IOException {
+                throw error;
+            }
+        };
+    }
+}

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/S3CrtAsyncHttpClient.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/S3CrtAsyncHttpClient.java
@@ -138,7 +138,7 @@ public final class S3CrtAsyncHttpClient implements SdkAsyncHttpClient {
     public CompletableFuture<Void> execute(AsyncExecuteRequest asyncRequest) {
         CompletableFuture<Void> executeFuture = new CompletableFuture<>();
         URI uri = asyncRequest.request().getUri();
-        HttpRequest httpRequest = toCrtRequest(asyncRequest);
+        HttpRequest httpRequest = toCrtRequest(asyncRequest, executeFuture);
         SdkHttpExecutionAttributes httpExecutionAttributes = asyncRequest.httpExecutionAttributes();
         CompletableFuture<S3MetaRequestWrapper> s3MetaRequestFuture = new CompletableFuture<>();
 
@@ -261,7 +261,7 @@ public final class S3CrtAsyncHttpClient implements SdkAsyncHttpClient {
         return S3MetaRequestOptions.MetaRequestType.DEFAULT;
     }
 
-    private static HttpRequest toCrtRequest(AsyncExecuteRequest asyncRequest) {
+    private static HttpRequest toCrtRequest(AsyncExecuteRequest asyncRequest, CompletableFuture<Void> executeFuture) {
         SdkHttpRequest sdkRequest = asyncRequest.request();
 
         Path requestFilePath = asyncRequest.httpExecutionAttributes().getAttribute(OBJECT_FILE_PATH);
@@ -280,7 +280,9 @@ public final class S3CrtAsyncHttpClient implements SdkAsyncHttpClient {
 
 
         S3CrtRequestBodyStreamAdapter sdkToCrtRequestPublisher =
-            requestFilePath == null ? new S3CrtRequestBodyStreamAdapter(asyncRequest.requestContentPublisher()) : null;
+            requestFilePath == null
+            ? new S3CrtRequestBodyStreamAdapter(asyncRequest.requestContentPublisher(), executeFuture)
+            : null;
 
         return new HttpRequest(method, encodedPath + encodedQueryString, crtHeaderArray, sdkToCrtRequestPublisher);
     }

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/S3CrtRequestBodyStreamAdapter.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/S3CrtRequestBodyStreamAdapter.java
@@ -16,6 +16,7 @@
 package software.amazon.awssdk.services.s3.internal.crt;
 
 import java.nio.ByteBuffer;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.crt.http.HttpRequestBodyStream;
@@ -30,12 +31,14 @@ public final class S3CrtRequestBodyStreamAdapter implements HttpRequestBodyStrea
     private static final long MINIMUM_BYTES_BUFFERED = 16 * 1024 * 1024L;
     private final SdkHttpContentPublisher bodyPublisher;
     private final ByteBufferStoringSubscriber requestBodySubscriber;
+    private final CompletableFuture<Void> executeFuture;
 
     private final AtomicBoolean subscribed = new AtomicBoolean(false);
 
-    public S3CrtRequestBodyStreamAdapter(SdkHttpContentPublisher bodyPublisher) {
+    public S3CrtRequestBodyStreamAdapter(SdkHttpContentPublisher bodyPublisher, CompletableFuture<Void> executeFuture) {
         this.bodyPublisher = bodyPublisher;
         this.requestBodySubscriber = new ByteBufferStoringSubscriber(MINIMUM_BYTES_BUFFERED);
+        this.executeFuture = executeFuture;
     }
 
     @Override
@@ -44,7 +47,14 @@ public final class S3CrtRequestBodyStreamAdapter implements HttpRequestBodyStrea
             bodyPublisher.subscribe(requestBodySubscriber);
         }
 
-        return requestBodySubscriber.transferTo(outBuffer) == ByteBufferStoringSubscriber.TransferResult.END_OF_STREAM;
+        try {
+            return requestBodySubscriber.transferTo(outBuffer) == ByteBufferStoringSubscriber.TransferResult.END_OF_STREAM;
+        } catch (RuntimeException e) {
+            // This is a native JNI upcall: an escaping exception is printed to stderr and discarded by CRT (#6715).
+            // Fail the operation with the original publisher error instead; completing executeFuture cancels the meta request.
+            executeFuture.completeExceptionally(e);
+            return false;
+        }
     }
 
     @Override

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/S3CrtResponseHandlerAdapter.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/S3CrtResponseHandlerAdapter.java
@@ -28,6 +28,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.annotations.SdkTestInternalApi;
 import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
@@ -68,6 +69,10 @@ public final class S3CrtResponseHandlerAdapter implements S3MetaRequestResponseH
 
     private volatile boolean responseHandlingInitiated;
 
+    // Guards the single terminal responseHandler.onError notification. The first error to complete resultFuture wins;
+    // the later cancel-derived AWS_ERROR_S3_CANCELED must not re-notify. See #6715.
+    private final AtomicBoolean responseHandlerNotified = new AtomicBoolean(false);
+
     public S3CrtResponseHandlerAdapter(CompletableFuture<Void> executeFuture,
                                        SdkAsyncHttpResponseHandler responseHandler,
                                        PublisherListener<S3MetaRequestProgress> progressListener,
@@ -83,8 +88,17 @@ public final class S3CrtResponseHandlerAdapter implements S3MetaRequestResponseH
                                        Duration s3MetaRequestTimeout) {
         this.resultFuture = executeFuture;
         this.metaRequestFuture = metaRequestFuture;
+        this.responseHandler = responseHandler;
+        this.progressListener = progressListener == null ? new NoOpPublisherListener() : progressListener;
+        this.s3MetaRequestTimeout = s3MetaRequestTimeout;
 
+        // Registered last: the callback reads responseHandler and s3MetaRequestTimeout, so all fields must be assigned
+        // first in case resultFuture is already complete and the callback runs synchronously here.
         resultFuture.whenComplete((r, t) -> {
+            if (t != null) {
+                notifyResponseHandlerOnError(t);
+            }
+
             S3MetaRequestWrapper s3MetaRequest = s3MetaRequest();
             if (s3MetaRequest == null) {
                 return;
@@ -95,10 +109,6 @@ public final class S3CrtResponseHandlerAdapter implements S3MetaRequestResponseH
             }
             s3MetaRequest.close();
         });
-
-        this.responseHandler = responseHandler;
-        this.progressListener = progressListener == null ? new NoOpPublisherListener() : progressListener;
-        this.s3MetaRequestTimeout = s3MetaRequestTimeout;
     }
 
     private S3MetaRequestWrapper s3MetaRequest() {
@@ -290,9 +300,15 @@ public final class S3CrtResponseHandlerAdapter implements S3MetaRequestResponseH
     }
 
     private void failResponseHandlerAndFuture(Throwable exception) {
-        runAndLogError(log.logger(), "Exception thrown in SdkAsyncHttpResponseHandler#onError, ignoring",
-                       () -> responseHandler.onError(exception));
+        notifyResponseHandlerOnError(exception);
         resultFuture.completeExceptionally(exception);
+    }
+
+    private void notifyResponseHandlerOnError(Throwable exception) {
+        if (responseHandlerNotified.compareAndSet(false, true)) {
+            runAndLogError(log.logger(), "Exception thrown in SdkAsyncHttpResponseHandler#onError, ignoring",
+                           () -> responseHandler.onError(exception));
+        }
     }
 
     private static boolean isServiceError(int responseStatus) {

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crt/S3CrtClientWiremockTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crt/S3CrtClientWiremockTest.java
@@ -37,17 +37,23 @@ import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import com.github.tomakehurst.wiremock.stubbing.Scenario;
 import java.net.URI;
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.util.Optional;
 import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.core.ResponseBytes;
 import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.core.async.AsyncRequestBody;
 import software.amazon.awssdk.core.async.AsyncResponseTransformer;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.crt.CrtResource;
@@ -220,6 +226,52 @@ public class S3CrtClientWiremockTest {
                 SdkClientException exception = (SdkClientException) throwable;
                 assertThat(exception.getMessage()).contains("Failed to send the request");
             });
+    }
+
+    @Test
+    public void putObject_requestBodyPublisherErrors_futureCompletesWithOriginalError(WireMockRuntimeInfo wiremock) {
+        // Match all methods with a 200. WireMock waits for the full request body before responding, so when the body
+        // errors mid-send the body error (not a server response) is the meta request's terminal event.
+        stubFor(any(anyUrl()).willReturn(aResponse().withStatus(200)));
+        IllegalArgumentException bodyError = new IllegalArgumentException("test error");
+
+        // A small, known content length keeps this a single-part PutObject (avoids the @BeforeEach client's tiny part
+        // size that would otherwise force a multipart CreateMultipartUpload before the body is ever read).
+        AsyncRequestBody erroringBody = new AsyncRequestBody() {
+            @Override
+            public Optional<Long> contentLength() {
+                return Optional.of(16L);
+            }
+
+            @Override
+            public void subscribe(Subscriber<? super ByteBuffer> subscriber) {
+                subscriber.onSubscribe(new Subscription() {
+                    @Override
+                    public void request(long n) {
+                        subscriber.onError(bodyError);
+                    }
+
+                    @Override
+                    public void cancel() {
+                    }
+                });
+            }
+        };
+
+        try (S3AsyncClient singlePartClient =
+                 S3AsyncClient.crtBuilder()
+                              .region(Region.US_EAST_1)
+                              .endpointOverride(URI.create("http://localhost:" + wiremock.getHttpPort()))
+                              .credentialsProvider(
+                                  StaticCredentialsProvider.create(AwsBasicCredentials.create("key", "secret")))
+                              .build()) {
+            // Bounded wait so a regression that swallows the body error (leaving CRT waiting on the declared 16 bytes)
+            // fails fast instead of hanging to the global surefire timeout.
+            assertThatThrownBy(() -> singlePartClient.putObject(r -> r.bucket(BUCKET).key(KEY), erroringBody)
+                                                     .get(5, TimeUnit.SECONDS))
+                .hasRootCauseInstanceOf(IllegalArgumentException.class)
+                .hasRootCauseMessage("test error");
+        }
     }
 
     @Test

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crt/S3CrtRequestBodyStreamAdapterTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crt/S3CrtRequestBodyStreamAdapterTest.java
@@ -15,14 +15,16 @@
 
 package software.amazon.awssdk.services.s3.internal.crt;
 
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 
 import io.reactivex.Flowable;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
@@ -50,7 +52,7 @@ class S3CrtRequestBodyStreamAdapterTest {
 
         SdkHttpContentPublisher requestBody = requestBody(Flowable.fromIterable(data), 42L);
 
-        S3CrtRequestBodyStreamAdapter adapter = new S3CrtRequestBodyStreamAdapter(requestBody);
+        S3CrtRequestBodyStreamAdapter adapter = new S3CrtRequestBodyStreamAdapter(requestBody, new CompletableFuture<>());
 
         ByteBuffer inputBuffer = ByteBuffer.allocate(inputBufferSize);
         adapter.sendRequestBody(inputBuffer);
@@ -66,7 +68,7 @@ class S3CrtRequestBodyStreamAdapterTest {
         RequestTrackingPublisher requestTrackingPublisher = new RequestTrackingPublisher();
         SdkHttpContentPublisher requestBody = requestBody(requestTrackingPublisher, minBytesBuffered);
 
-        S3CrtRequestBodyStreamAdapter adapter = new S3CrtRequestBodyStreamAdapter(requestBody);
+        S3CrtRequestBodyStreamAdapter adapter = new S3CrtRequestBodyStreamAdapter(requestBody, new CompletableFuture<>());
 
         ByteBuffer inputBuffer = ByteBuffer.allocate(inputBufferSize);
         adapter.sendRequestBody(inputBuffer); // initiate the subscription, but no bytes available, makes 1 request
@@ -105,7 +107,7 @@ class S3CrtRequestBodyStreamAdapterTest {
 
         SdkHttpContentPublisher requestBody = requestBody(Flowable.just(data), 16L);
 
-        S3CrtRequestBodyStreamAdapter adapter = new S3CrtRequestBodyStreamAdapter(requestBody);
+        S3CrtRequestBodyStreamAdapter adapter = new S3CrtRequestBodyStreamAdapter(requestBody, new CompletableFuture<>());
 
         ByteBuffer inputBuffer = ByteBuffer.allocate(1);
 
@@ -117,27 +119,33 @@ class S3CrtRequestBodyStreamAdapterTest {
     }
 
     @Test
-    public void getRequestData_publisherThrows_surfacesException() {
+    public void sendRequestBody_publisherThrows_failsFutureWithoutThrowing() {
         Publisher<ByteBuffer> errorPublisher = Flowable.error(new RuntimeException("Something wrong happened"));
 
         SdkHttpContentPublisher requestBody = requestBody(errorPublisher, 0L);
-        S3CrtRequestBodyStreamAdapter adapter = new S3CrtRequestBodyStreamAdapter(requestBody);
+        CompletableFuture<Void> executeFuture = new CompletableFuture<>();
+        S3CrtRequestBodyStreamAdapter adapter = new S3CrtRequestBodyStreamAdapter(requestBody, executeFuture);
 
-        assertThatThrownBy(() -> adapter.sendRequestBody(ByteBuffer.allocate(16)))
-            .isInstanceOf(RuntimeException.class)
-            .hasMessageContaining("Something wrong happened");
+        assertThatNoException().isThrownBy(() -> adapter.sendRequestBody(ByteBuffer.allocate(16)));
+
+        assertThat(executeFuture).hasFailedWithThrowableThat()
+                                 .isInstanceOf(RuntimeException.class)
+                                 .hasMessageContaining("Something wrong happened");
     }
 
     @Test
-    public void getRequestData_publisherThrows_wrapsExceptionIfNotRuntimeException() {
+    public void sendRequestBody_publisherThrowsCheckedException_failsFutureWithWrappedCause() {
         Publisher<ByteBuffer> errorPublisher = Flowable.error(new IOException("Some I/O error happened"));
 
         SdkHttpContentPublisher requestBody = requestBody(errorPublisher, 0L);
-        S3CrtRequestBodyStreamAdapter adapter = new S3CrtRequestBodyStreamAdapter(requestBody);
+        CompletableFuture<Void> executeFuture = new CompletableFuture<>();
+        S3CrtRequestBodyStreamAdapter adapter = new S3CrtRequestBodyStreamAdapter(requestBody, executeFuture);
 
-        assertThatThrownBy(() -> adapter.sendRequestBody(ByteBuffer.allocate(16)))
-            .isInstanceOf(RuntimeException.class)
-            .hasCauseInstanceOf(IOException.class);
+        assertThatNoException().isThrownBy(() -> adapter.sendRequestBody(ByteBuffer.allocate(16)));
+
+        assertThat(executeFuture).hasFailedWithThrowableThat()
+                                 .isInstanceOf(UncheckedIOException.class)
+                                 .hasCauseInstanceOf(IOException.class);
     }
 
     private static class RequestTrackingPublisher implements Publisher<ByteBuffer> {

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crt/S3CrtResponseHandlerAdapterTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crt/S3CrtResponseHandlerAdapterTest.java
@@ -42,6 +42,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import software.amazon.awssdk.core.async.DrainingSubscriber;
+import software.amazon.awssdk.core.exception.ApiCallAttemptTimeoutException;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.crt.http.HttpHeader;
 import software.amazon.awssdk.crt.s3.S3FinishedResponseContext;
@@ -254,6 +255,44 @@ public class S3CrtResponseHandlerAdapterTest {
 
         assertThatThrownBy(() -> future.join()).hasRootCause(cause).hasMessageContaining(message);
         verify(s3MetaRequest).close();
+    }
+
+    @Test
+    public void bodyError_completesFutureWithOriginalError_andSuppressesLaterCancelOnError() {
+        RuntimeException originalError = new RuntimeException("test error");
+
+        // The body adapter fails the execute future with the original publisher error.
+        future.completeExceptionally(originalError);
+
+        assertThat(sdkResponseHandler.error).isSameAs(originalError);
+        assertThatThrownBy(() -> future.join()).hasCause(originalError);
+        verify(s3MetaRequest).cancel();
+        verify(s3MetaRequest).close();
+
+        // The cancel() above later surfaces as onFinished(AWS_ERROR_S3_CANCELED). It must not re-notify onError.
+        responseHandlerAdapter.onFinished(stubResponseContext(1, 0, null));
+
+        assertThat(sdkResponseHandler.error).isSameAs(originalError);
+        verify(sdkResponseHandler, times(1)).onError(any());
+    }
+
+    @Test
+    public void pipelineForwardedError_completesFutureWithThatError_andSuppressesLaterCancelOnError() {
+        // A pipeline-forwarded failure (e.g. an API-call-attempt timeout that MakeAsyncHttpRequestStage forwards onto the
+        // execute future) completes resultFuture exceptionally the same way a body error does. The whenComplete must
+        // deliver that error to onError exactly once, not the later cancel-derived S3_CANCELED wrapper.
+        ApiCallAttemptTimeoutException timeout = ApiCallAttemptTimeoutException.create(1000);
+
+        future.completeExceptionally(timeout);
+
+        assertThat(sdkResponseHandler.error).isSameAs(timeout);
+        assertThatThrownBy(() -> future.join()).hasCause(timeout);
+        verify(s3MetaRequest).cancel();
+
+        responseHandlerAdapter.onFinished(stubResponseContext(1, 0, null));
+
+        assertThat(sdkResponseHandler.error).isSameAs(timeout);
+        verify(sdkResponseHandler, times(1)).onError(any());
     }
 
     private S3FinishedResponseContext stubResponseContext(int errorCode, int responseStatus, byte[] errorPayload) {


### PR DESCRIPTION
## Motivation and Context

When uploading through a CRT-based client with `AsyncRequestBody.fromPublisher(publisher)` and the publisher emits `onError`, the exception was printed to the process stderr on a CRT event-loop thread, e.g.:

```
Exception in thread "AwsEventLoop6" java.lang.IllegalArgumentException: test error
```

The upload still failed, so the symptom was unexpected stderr noise plus a misleading exception on the returned future. The Netty client does not do this. Reported in #6715 (CRT-based S3 client via `S3AsyncClient.crtCreate()` + `S3TransferManager.upload()`).

**Root cause.** `ByteBufferStoringSubscriber.onError` stores the error, and `transferTo(...)` re-throws it as a `RuntimeException`. That `transferTo` call runs inside the CRT request-body adapter's `sendRequestBody`, which is a native JNI upcall (the adapter implements CRT's `HttpRequestBodyStream`) with no try/catch. When the upcall returns with a pending Java exception, CRT's native glue calls `ExceptionDescribe` (which prints the exception + stack trace to the process's native stderr) and then `ExceptionClear`, and raises `AWS_ERROR_HTTP_CALLBACK_FAILURE`. So the exception is printed and discarded natively, and the future completes with a generic `SdkClientException("Failed to send the request: ...CALLBACK_FAILURE")` whose cause is null — the original error survives only on stderr.

This affects both CRT request-body adapters: `S3CrtRequestBodyStreamAdapter` (S3 CRT client, the one #6715 reports) and the structurally identical `CrtRequestBodyAdapter` (aws-crt-client).

## Modifications

Two coordinated parts, no public API changes (all `@SdkInternalApi`):

**1. Contain the error at the JNI boundary (both adapters).** `sendRequestBody` now wraps the `transferTo(...)` call in `try/catch (RuntimeException)`. On a publisher error it fails the operation with the original error instead of letting it escape the upcall, and returns `false` (never `true` — returning "body complete" would upload a zero-byte object and report success). `ByteBufferStoringSubscriber.transferTo`'s throwing contract is unchanged; the fix is contained at the adapter.

**2. Deliver the original error to the caller, exactly once (per-client wiring).** The caller-facing future is driven by `SdkAsyncHttpResponseHandler.onError`, not by the HTTP client's execute future, so the two clients differ in how the error is surfaced:

- **S3 CRT** (`S3CrtRequestBodyStreamAdapter` + `S3CrtAsyncHttpClient` + `S3CrtResponseHandlerAdapter`): the adapter completes the operation's execute future exceptionally with the original error. `S3CrtAsyncHttpClient` wires that future (the same `resultFuture` the response handler holds) into the adapter. `S3CrtResponseHandlerAdapter`'s `resultFuture.whenComplete` now delivers `responseHandler.onError(originalError)` first and then cancels + closes the meta request (reusing the existing cleanup wiring). A one-shot `AtomicBoolean` guard around the single `onError` notification ensures the later, cancel-derived `AWS_ERROR_S3_CANCELED` `onFinished` does not re-notify — first error (the original) wins.

- **aws-crt-client** (`CrtRequestBodyAdapter` + `CrtRequestAdapter` + `CrtAsyncRequestExecutor` + `CrtResponseAdapter`): the adapter routes the body error through `CrtResponseAdapter.failRequest(...)`, which delivers `onError(originalError)` and completes the request future. Completing the future triggers `closeConnection()`, which cancels the stream so CRT delivers a cancel-derived `onResponseComplete`; a one-shot guard around `CrtResponseAdapter`'s `onError` chokepoint suppresses that second notification. (This also fixes a latent double-`onError` on the existing `onResponseBody`-write-failure path.)

Net: on both clients, a request-body publisher error now produces no native stderr line and completes the caller's future exceptionally carrying the original error, delivered to `onError` exactly once — matching the Netty client.

## Testing

Adapter/handler-level unit tests plus two end-to-end WireMock functional tests that exercise the real native CRT path.

- `S3CrtRequestBodyStreamAdapterTest`: `sendRequestBody` no longer throws on a publisher error; the wired execute future completes exceptionally with the original error (`RuntimeException` as-is; `IOException` wrapped as `UncheckedIOException`); repeated calls stay quiet and preserve the original error. (Updated the two tests that previously asserted `sendRequestBody` throws.)
- `S3CrtResponseHandlerAdapterTest`: completing the execute future with a body error delivers `onError` exactly once with the original error, cancels + closes the meta request, and a subsequent `onFinished(S3_CANCELED)` does not re-notify; same exactly-once behavior for a pipeline-forwarded timeout (`ApiCallAttemptTimeoutException`).
- `CrtRequestBodyAdapterTest` (new) and `CrtResponseHandlerTest`: the body-error sink is invoked once with the original error; `failRequest(...)` followed by a cancel-derived `onResponseComplete` notifies `onError` exactly once with the original error.
- `AwsCrtAsyncHttpClientWireMockTest` (new e2e): a real `AwsCrtAsyncHttpClient` PUT to WireMock with an erroring request-body publisher completes the returned future exceptionally with the original `IllegalArgumentException`.
- `S3CrtClientWiremockTest` (new e2e): a real `S3AsyncClient.crtBuilder()` (endpoint-overridden to WireMock) `putObject` with an erroring body completes the future exceptionally with the original error.

Note: the stderr line is written by native `ExceptionDescribe`, which bypasses both `System.setErr(...)` and `Thread.setDefaultUncaughtExceptionHandler`, so it is not assertable at the Java layer; the tests verify the future carries the original error, which is the meaningful, executed proof that the exception no longer escapes the upcall.

Build scope: `services/s3` and `http-clients/aws-crt-client` built with `mvn install` (module-level), all affected tests green. A full-repo `mvn install` was not run.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read the [[CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md)](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds <!-- built the two affected modules (services/s3, aws-crt-client), not a full-repo mvn install -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [[LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License

- [x] I confirm that this pull request can be released under the Apache 2 license

Closes #6715