### PR TITLE
Port over table admin operations + remaining test infra

### DIFF
--- a/.brazil.json
+++ b/.brazil.json
@@ -319,7 +319,7 @@
       "skipImport": true
     },
     "dynamodb-mapper": {
-      "packageName": "AwsJavaSdk-DynamoDbMapper"
+      "skipImport": true
     }
   },
   "dependencies": {

--- a/services-custom/dynamodb-mapper/pom.xml
+++ b/services-custom/dynamodb-mapper/pom.xml
@@ -41,35 +41,16 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <!-- v1-coupled tests not yet ported to the v2 client/model; tracked for a dedicated
-                         follow-up port PR. The golden-master ShapeRequestTest/ShapeResponseTest suite
-                         proves the ported data-plane paths are behavior-preserving in the meantime. -->
+                    <!-- The only tests still excluded are the S3Link feature tests. They exercise S3Link
+                         main code that is still on the v1 client/model and is ported in a dedicated
+                         follow-up PR; these come off this list when that port lands. -->
                     <testExcludes>
                             <testExclude>software/amazon/awssdk/mapper/dynamodb/ConfigureS3LinksTest.java</testExclude>
                             <testExclude>software/amazon/awssdk/mapper/dynamodb/DynamoDBS3IntegrationTest.java</testExclude>
                             <testExclude>software/amazon/awssdk/mapper/dynamodb/DynamoDBS3IntegrationTestBase.java</testExclude>
-                            <testExclude>software/amazon/awssdk/mapper/dynamodb/GenerateDeleteTableRequestTest.java</testExclude>
-                            <testExclude>software/amazon/awssdk/mapper/dynamodb/GsiAlwaysUpdateTest.java</testExclude>
-                            <testExclude>software/amazon/awssdk/mapper/dynamodb/LocalDynamoDB.java</testExclude>
-                            <testExclude>software/amazon/awssdk/mapper/dynamodb/LocalDynamoDBTestBase.java</testExclude>
                             <testExclude>software/amazon/awssdk/mapper/dynamodb/S3ClientCacheIntegrationTest.java</testExclude>
                             <testExclude>software/amazon/awssdk/mapper/dynamodb/S3LinkIDTest.java</testExclude>
                             <testExclude>software/amazon/awssdk/mapper/dynamodb/S3LinkTest.java</testExclude>
-                            <testExclude>software/amazon/awssdk/mapper/dynamodb/BatchLoadTest.java</testExclude>
-                            <testExclude>software/amazon/awssdk/mapper/dynamodb/mapper/BatchWriteTest.java</testExclude>
-                            <!-- Blocked on Table-admin: calls mapper.generateCreateTableRequest(), which still
-                                 returns a v1 CreateTableRequest. Rides with the GenerateCreateTableRequest* PR. -->
-                            <testExclude>software/amazon/awssdk/mapper/dynamodb/JsonIntegrationTest.java</testExclude>
-                            <testExclude>software/amazon/awssdk/mapper/dynamodb/mapper/GenerateCreateTableRequest2Test.java</testExclude>
-                            <testExclude>software/amazon/awssdk/mapper/dynamodb/mapper/GenerateCreateTableRequestTest.java</testExclude>
-                            <testExclude>software/amazon/awssdk/mapper/dynamodb/mapper/HashKeyOnlyTableWithGSITest.java</testExclude>
-                            <testExclude>software/amazon/awssdk/mapper/dynamodb/mapper/MapperLoadingStrategyConfigTest.java</testExclude>
-                            <testExclude>software/amazon/awssdk/mapper/dynamodb/test/resources/DynamoDBTableResource.java</testExclude>
-                            <testExclude>software/amazon/awssdk/mapper/dynamodb/test/resources/ResourceCentricBlockJUnit4ClassRunner.java</testExclude>
-                            <testExclude>software/amazon/awssdk/mapper/dynamodb/test/resources/TestResourceUtils.java</testExclude>
-                            <testExclude>software/amazon/awssdk/mapper/dynamodb/test/resources/tables/BasicTempTable.java</testExclude>
-                            <testExclude>software/amazon/awssdk/mapper/dynamodb/test/resources/tables/TempTableWithBinaryKey.java</testExclude>
-                            <testExclude>software/amazon/awssdk/mapper/dynamodb/test/resources/tables/TempTableWithSecondaryIndexes.java</testExclude>
                     </testExcludes>
                 </configuration>
             </plugin>

--- a/services-custom/dynamodb-mapper/pom.xml
+++ b/services-custom/dynamodb-mapper/pom.xml
@@ -109,11 +109,6 @@
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-dynamodb</artifactId>
-            <version>${sdk-v1.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-s3</artifactId>
             <version>${sdk-v1.version}</version>
         </dependency>

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/AbstractDynamoDBMapper.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/AbstractDynamoDBMapper.java
@@ -16,8 +16,8 @@ package software.amazon.awssdk.mapper.dynamodb;
 
 import software.amazon.awssdk.mapper.dynamodb.DynamoDBMapper.FailedBatch;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
-import com.amazonaws.services.dynamodbv2.model.CreateTableRequest;
-import com.amazonaws.services.dynamodbv2.model.DeleteTableRequest;
+import software.amazon.awssdk.services.dynamodb.model.CreateTableRequest;
+import software.amazon.awssdk.services.dynamodb.model.DeleteTableRequest;
 import com.amazonaws.services.s3.model.Region;
 
 import java.util.Arrays;

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/DynamoDBMapper.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/DynamoDBMapper.java
@@ -44,9 +44,11 @@ import software.amazon.awssdk.services.dynamodb.model.ExpectedAttributeValue;
 import software.amazon.awssdk.services.dynamodb.model.Get;
 import software.amazon.awssdk.services.dynamodb.model.GetItemRequest;
 import software.amazon.awssdk.services.dynamodb.model.GetItemResponse;
+import software.amazon.awssdk.services.dynamodb.model.GlobalSecondaryIndex;
 import software.amazon.awssdk.services.dynamodb.model.ItemResponse;
 import software.amazon.awssdk.services.dynamodb.model.KeySchemaElement;
 import software.amazon.awssdk.services.dynamodb.model.KeysAndAttributes;
+import software.amazon.awssdk.services.dynamodb.model.LocalSecondaryIndex;
 import software.amazon.awssdk.services.dynamodb.model.Put;
 import software.amazon.awssdk.services.dynamodb.model.PutItemRequest;
 import software.amazon.awssdk.services.dynamodb.model.PutItemResponse;
@@ -2275,11 +2277,16 @@ public class DynamoDBMapper extends AbstractDynamoDBMapper {
             .tableName(getTableName(clazz, config))
             .keySchema(keySchema)
             .attributeDefinitions(attributeDefinitions);
-        if (model.globalSecondaryIndexes() != null) {
-            request.globalSecondaryIndexes(model.globalSecondaryIndexes());
+        // globalSecondaryIndexes()/localSecondaryIndexes() rebuild their collections on every call and
+        // return null (not empty) when the class declares none, so read once and guard on null to keep
+        // the v1 behavior of leaving the field unset.
+        final Collection<GlobalSecondaryIndex> globalSecondaryIndexes = model.globalSecondaryIndexes();
+        if (globalSecondaryIndexes != null) {
+            request.globalSecondaryIndexes(globalSecondaryIndexes);
         }
-        if (model.localSecondaryIndexes() != null) {
-            request.localSecondaryIndexes(model.localSecondaryIndexes());
+        final Collection<LocalSecondaryIndex> localSecondaryIndexes = model.localSecondaryIndexes();
+        if (localSecondaryIndexes != null) {
+            request.localSecondaryIndexes(localSecondaryIndexes);
         }
         return request.build();
     }

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/DynamoDBMapper.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/DynamoDBMapper.java
@@ -24,7 +24,7 @@ import software.amazon.awssdk.mapper.dynamodb.DynamoDBMapperConfig.BatchWriteRet
 import software.amazon.awssdk.mapper.dynamodb.DynamoDBMapperConfig.ConsistentReads;
 import software.amazon.awssdk.mapper.dynamodb.DynamoDBMapperConfig.SaveBehavior;
 import software.amazon.awssdk.services.dynamodb.model.AttributeAction;
-import com.amazonaws.services.dynamodbv2.model.AttributeDefinition;
+import software.amazon.awssdk.services.dynamodb.model.AttributeDefinition;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValueUpdate;
 import software.amazon.awssdk.services.dynamodb.model.BatchGetItemRequest;
@@ -35,17 +35,17 @@ import software.amazon.awssdk.services.dynamodb.model.Condition;
 import software.amazon.awssdk.services.dynamodb.model.ConditionCheck;
 import software.amazon.awssdk.services.dynamodb.model.ConditionalCheckFailedException;
 import software.amazon.awssdk.services.dynamodb.model.ConditionalOperator;
-import com.amazonaws.services.dynamodbv2.model.CreateTableRequest;
+import software.amazon.awssdk.services.dynamodb.model.CreateTableRequest;
 import software.amazon.awssdk.services.dynamodb.model.Delete;
 import software.amazon.awssdk.services.dynamodb.model.DeleteItemRequest;
 import software.amazon.awssdk.services.dynamodb.model.DeleteRequest;
-import com.amazonaws.services.dynamodbv2.model.DeleteTableRequest;
+import software.amazon.awssdk.services.dynamodb.model.DeleteTableRequest;
 import software.amazon.awssdk.services.dynamodb.model.ExpectedAttributeValue;
 import software.amazon.awssdk.services.dynamodb.model.Get;
 import software.amazon.awssdk.services.dynamodb.model.GetItemRequest;
 import software.amazon.awssdk.services.dynamodb.model.GetItemResponse;
 import software.amazon.awssdk.services.dynamodb.model.ItemResponse;
-import com.amazonaws.services.dynamodbv2.model.KeySchemaElement;
+import software.amazon.awssdk.services.dynamodb.model.KeySchemaElement;
 import software.amazon.awssdk.services.dynamodb.model.KeysAndAttributes;
 import software.amazon.awssdk.services.dynamodb.model.Put;
 import software.amazon.awssdk.services.dynamodb.model.PutItemRequest;
@@ -55,7 +55,7 @@ import software.amazon.awssdk.services.dynamodb.model.QueryRequest;
 import software.amazon.awssdk.services.dynamodb.model.QueryResponse;
 import software.amazon.awssdk.services.dynamodb.model.ReturnValue;
 import software.amazon.awssdk.services.dynamodb.model.ReturnValuesOnConditionCheckFailure;
-import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType;
+import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType;
 import software.amazon.awssdk.services.dynamodb.model.ScanRequest;
 import software.amazon.awssdk.services.dynamodb.model.ScanResponse;
 import software.amazon.awssdk.services.dynamodb.model.Select;
@@ -2255,31 +2255,39 @@ public class DynamoDBMapper extends AbstractDynamoDBMapper {
         config = mergeConfig(config);
         final DynamoDBMapperTableModel<T> model = getTableModel(clazz, config);
 
-        final CreateTableRequest request = new CreateTableRequest();
-        request.setTableName(getTableName(clazz, config));
-        request.withKeySchema(new KeySchemaElement(model.hashKey().name(), com.amazonaws.services.dynamodbv2.model.KeyType.HASH));
+        final List<KeySchemaElement> keySchema = new ArrayList<KeySchemaElement>();
+        keySchema.add(KeySchemaElement.builder().attributeName(model.hashKey().name()).keyType(HASH).build());
         if (model.rangeKeyIfExists() != null) {
-            request.withKeySchema(new KeySchemaElement(model.rangeKey().name(), com.amazonaws.services.dynamodbv2.model.KeyType.RANGE));
+            keySchema.add(KeySchemaElement.builder().attributeName(model.rangeKey().name()).keyType(RANGE).build());
         }
-        request.setGlobalSecondaryIndexes(model.globalSecondaryIndexes());
-        request.setLocalSecondaryIndexes(model.localSecondaryIndexes());
+
+        final List<AttributeDefinition> attributeDefinitions = new ArrayList<AttributeDefinition>();
         for (final DynamoDBMapperFieldModel<T,Object> field : model.fields()) {
             if (field.keyType() != null || field.indexed()) {
-                request.withAttributeDefinitions(new AttributeDefinition()
-                    .withAttributeType(ScalarAttributeType.valueOf(field.attributeType().name()))
-                    .withAttributeName(field.name())
-                );
+                attributeDefinitions.add(AttributeDefinition.builder()
+                    .attributeType(ScalarAttributeType.valueOf(field.attributeType().name()))
+                    .attributeName(field.name())
+                    .build());
             }
         }
-        return request;
+
+        final CreateTableRequest.Builder request = CreateTableRequest.builder()
+            .tableName(getTableName(clazz, config))
+            .keySchema(keySchema)
+            .attributeDefinitions(attributeDefinitions);
+        if (model.globalSecondaryIndexes() != null) {
+            request.globalSecondaryIndexes(model.globalSecondaryIndexes());
+        }
+        if (model.localSecondaryIndexes() != null) {
+            request.localSecondaryIndexes(model.localSecondaryIndexes());
+        }
+        return request.build();
     }
 
     @Override
     public <T> DeleteTableRequest generateDeleteTableRequest(Class<T> clazz, DynamoDBMapperConfig config) {
         config = mergeConfig(config);
-        DeleteTableRequest deleteTableRequest = new DeleteTableRequest();
-        deleteTableRequest.setTableName(getTableName(clazz, config));
-        return deleteTableRequest;
+        return DeleteTableRequest.builder().tableName(getTableName(clazz, config)).build();
     }
 
     /**

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/DynamoDBMapperTableModel.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/DynamoDBMapperTableModel.java
@@ -16,18 +16,18 @@ package software.amazon.awssdk.mapper.dynamodb;
 
 import static software.amazon.awssdk.services.dynamodb.model.KeyType.HASH;
 import static software.amazon.awssdk.services.dynamodb.model.KeyType.RANGE;
-import static com.amazonaws.services.dynamodbv2.model.ProjectionType.KEYS_ONLY;
+import static software.amazon.awssdk.services.dynamodb.model.ProjectionType.KEYS_ONLY;
 
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import software.amazon.awssdk.services.dynamodb.model.KeyType;
-import com.amazonaws.services.dynamodbv2.model.GlobalSecondaryIndex;
-import com.amazonaws.services.dynamodbv2.model.KeySchemaElement;
-import com.amazonaws.services.dynamodbv2.model.LocalSecondaryIndex;
-import com.amazonaws.services.dynamodbv2.model.Projection;
-import com.amazonaws.services.dynamodbv2.model.ProjectionType;
+import software.amazon.awssdk.services.dynamodb.model.GlobalSecondaryIndex;
+import software.amazon.awssdk.services.dynamodb.model.KeySchemaElement;
+import software.amazon.awssdk.services.dynamodb.model.LocalSecondaryIndex;
+import software.amazon.awssdk.services.dynamodb.model.Projection;
 
 import java.util.Arrays;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumMap;
@@ -190,12 +190,15 @@ public final class DynamoDBMapperTableModel<T> implements DynamoDBTypeConverter<
             return null;
         }
         final GlobalSecondaryIndex gsi = globalSecondaryIndexes.get(indexName);
-        final GlobalSecondaryIndex copy = new GlobalSecondaryIndex().withIndexName(gsi.getIndexName());
-        copy.withProjection(new Projection().withProjectionType(gsi.getProjection().getProjectionType()));
-        for (final KeySchemaElement key : gsi.getKeySchema()) {
-            copy.withKeySchema(new KeySchemaElement(key.getAttributeName(), key.getKeyType()));
+        final List<KeySchemaElement> keySchema = new ArrayList<KeySchemaElement>();
+        for (final KeySchemaElement key : gsi.keySchema()) {
+            keySchema.add(KeySchemaElement.builder().attributeName(key.attributeName()).keyType(key.keyType()).build());
         }
-        return copy;
+        return GlobalSecondaryIndex.builder()
+            .indexName(gsi.indexName())
+            .projection(Projection.builder().projectionType(gsi.projection().projectionType()).build())
+            .keySchema(keySchema)
+            .build();
     }
 
     /**
@@ -224,12 +227,15 @@ public final class DynamoDBMapperTableModel<T> implements DynamoDBTypeConverter<
             return null;
         }
         final LocalSecondaryIndex lsi = localSecondaryIndexes.get(indexName);
-        final LocalSecondaryIndex copy = new LocalSecondaryIndex().withIndexName(lsi.getIndexName());
-        copy.withProjection(new Projection().withProjectionType(lsi.getProjection().getProjectionType()));
-        for (final KeySchemaElement key : lsi.getKeySchema()) {
-            copy.withKeySchema(new KeySchemaElement(key.getAttributeName(), key.getKeyType()));
+        final List<KeySchemaElement> keySchema = new ArrayList<KeySchemaElement>();
+        for (final KeySchemaElement key : lsi.keySchema()) {
+            keySchema.add(KeySchemaElement.builder().attributeName(key.attributeName()).keyType(key.keyType()).build());
         }
-        return copy;
+        return LocalSecondaryIndex.builder()
+            .indexName(lsi.indexName())
+            .projection(Projection.builder().projectionType(lsi.projection().projectionType()).build())
+            .keySchema(keySchema)
+            .build();
     }
 
     /**
@@ -371,32 +377,41 @@ public final class DynamoDBMapperTableModel<T> implements DynamoDBTypeConverter<
         }
 
         public Map<String,GlobalSecondaryIndex> globalSecondaryIndexes() {
-            final Map<String,GlobalSecondaryIndex> map = new LinkedHashMap<String,GlobalSecondaryIndex>();
+            // v2 index models are immutable, so stage each index's key schema and build once. The hash
+            // key is collected first and the range key (if any) appended in a second pass, matching v1.
+            final Map<String,List<KeySchemaElement>> keySchemasByIndex = new LinkedHashMap<String,List<KeySchemaElement>>();
             for (final DynamoDBMapperFieldModel<T,Object> field : fields.values()) {
                 for (final String indexName : field.globalSecondaryIndexNames(HASH)) {
-                    final GlobalSecondaryIndex gsi = new GlobalSecondaryIndex().withIndexName(indexName);
-                    if (map.put(indexName, gsi) != null) {
+                    final List<KeySchemaElement> keySchema = new ArrayList<KeySchemaElement>();
+                    keySchema.add(KeySchemaElement.builder().attributeName(field.name()).keyType(KeyType.HASH).build());
+                    if (keySchemasByIndex.put(indexName, keySchema) != null) {
                         throw new DynamoDBMappingException(
                             targetType.getSimpleName() + "[" + field.name() + "]; must not duplicate GSI " + indexName
                         );
                     }
-                    gsi.withProjection(new Projection().withProjectionType(KEYS_ONLY));
-                    gsi.withKeySchema(new KeySchemaElement(field.name(), com.amazonaws.services.dynamodbv2.model.KeyType.HASH));
                 }
             }
             for (final DynamoDBMapperFieldModel<T,Object> field : fields.values()) {
                 for (final String indexName : field.globalSecondaryIndexNames(RANGE)) {
-                    final GlobalSecondaryIndex gsi = map.get(indexName);
-                    if (gsi == null) {
+                    final List<KeySchemaElement> keySchema = keySchemasByIndex.get(indexName);
+                    if (keySchema == null) {
                         throw new DynamoDBMappingException(
                             targetType.getSimpleName() + "[" + field.name() + "]; no HASH key for GSI " + indexName
                         );
                     }
-                    gsi.withKeySchema(new KeySchemaElement(field.name(), com.amazonaws.services.dynamodbv2.model.KeyType.RANGE));
+                    keySchema.add(KeySchemaElement.builder().attributeName(field.name()).keyType(KeyType.RANGE).build());
                 }
             }
-            if (map.isEmpty()) {
+            if (keySchemasByIndex.isEmpty()) {
                 return Collections.<String,GlobalSecondaryIndex>emptyMap();
+            }
+            final Map<String,GlobalSecondaryIndex> map = new LinkedHashMap<String,GlobalSecondaryIndex>();
+            for (final Map.Entry<String,List<KeySchemaElement>> entry : keySchemasByIndex.entrySet()) {
+                map.put(entry.getKey(), GlobalSecondaryIndex.builder()
+                    .indexName(entry.getKey())
+                    .projection(Projection.builder().projectionType(KEYS_ONLY).build())
+                    .keySchema(entry.getValue())
+                    .build());
             }
             return Collections.unmodifiableMap(map);
         }
@@ -405,15 +420,18 @@ public final class DynamoDBMapperTableModel<T> implements DynamoDBTypeConverter<
             final Map<String,LocalSecondaryIndex> map = new LinkedHashMap<String,LocalSecondaryIndex>();
             for (final DynamoDBMapperFieldModel<T,Object> field : fields.values()) {
                 for (final String indexName : field.localSecondaryIndexNames()) {
-                    final LocalSecondaryIndex lsi = new LocalSecondaryIndex().withIndexName(indexName);
+                    final LocalSecondaryIndex lsi = LocalSecondaryIndex.builder()
+                        .indexName(indexName)
+                        .projection(Projection.builder().projectionType(KEYS_ONLY).build())
+                        .keySchema(
+                            KeySchemaElement.builder().attributeName(keys.get(HASH).name()).keyType(KeyType.HASH).build(),
+                            KeySchemaElement.builder().attributeName(field.name()).keyType(KeyType.RANGE).build())
+                        .build();
                     if (map.put(indexName, lsi) != null) {
                         throw new DynamoDBMappingException(
                             targetType.getSimpleName() + "[" + field.name() + "]; must not duplicate LSI " + indexName
                         );
                     }
-                    lsi.withProjection(new Projection().withProjectionType(KEYS_ONLY));
-                    lsi.withKeySchema(new KeySchemaElement(keys.get(HASH).name(), com.amazonaws.services.dynamodbv2.model.KeyType.HASH));
-                    lsi.withKeySchema(new KeySchemaElement(field.name(), com.amazonaws.services.dynamodbv2.model.KeyType.RANGE));
                 }
             }
             if (map.isEmpty()) {

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/DynamoDBTableMapper.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/DynamoDBTableMapper.java
@@ -315,7 +315,7 @@ public final class DynamoDBTableMapper<T extends Object, H extends Object, R ext
      * @throws ConditionalCheckFailedException If the object exists.
      * @see software.amazon.awssdk.mapper.dynamodb.DynamoDBMapper#save
      * @see software.amazon.awssdk.mapper.dynamodb.DynamoDBSaveExpression
-     * @see com.amazonaws.services.dynamodbv2.model.ExpectedAttributeValue
+     * @see software.amazon.awssdk.services.dynamodb.model.ExpectedAttributeValue
      */
     public void saveIfNotExists(T object) throws ConditionalCheckFailedException {
         final DynamoDBSaveExpression saveExpression = new DynamoDBSaveExpression();
@@ -333,7 +333,7 @@ public final class DynamoDBTableMapper<T extends Object, H extends Object, R ext
      * @throws ConditionalCheckFailedException If the object does not exist.
      * @see software.amazon.awssdk.mapper.dynamodb.DynamoDBMapper#save
      * @see software.amazon.awssdk.mapper.dynamodb.DynamoDBSaveExpression
-     * @see com.amazonaws.services.dynamodbv2.model.ExpectedAttributeValue
+     * @see software.amazon.awssdk.services.dynamodb.model.ExpectedAttributeValue
      */
     public void saveIfExists(T object) throws ConditionalCheckFailedException {
         final DynamoDBSaveExpression saveExpression = new DynamoDBSaveExpression();
@@ -371,7 +371,7 @@ public final class DynamoDBTableMapper<T extends Object, H extends Object, R ext
      * @throws ConditionalCheckFailedException If the object does not exist.
      * @see software.amazon.awssdk.mapper.dynamodb.DynamoDBMapper#delete
      * @see software.amazon.awssdk.mapper.dynamodb.DynamoDBDeleteExpression
-     * @see com.amazonaws.services.dynamodbv2.model.ExpectedAttributeValue
+     * @see software.amazon.awssdk.services.dynamodb.model.ExpectedAttributeValue
      */
     public void deleteIfExists(T object) throws ConditionalCheckFailedException {
         final DynamoDBDeleteExpression deleteExpression = new DynamoDBDeleteExpression();
@@ -480,7 +480,7 @@ public final class DynamoDBTableMapper<T extends Object, H extends Object, R ext
      * @param throughput The provisioned throughput.
      * @return The table decription.
      * @see software.amazon.awssdk.services.dynamodb.DynamoDbClient#createTable
-     * @see com.amazonaws.services.dynamodbv2.model.CreateTableRequest
+     * @see software.amazon.awssdk.services.dynamodb.model.CreateTableRequest
      */
     public TableDescription createTable(ProvisionedThroughput throughput) {
         // v1 mutated the generated request in place to stamp throughput onto the table and every GSI;
@@ -503,7 +503,7 @@ public final class DynamoDBTableMapper<T extends Object, H extends Object, R ext
      * @param throughput The provisioned throughput.
      * @return True if created, or false if the table already existed.
      * @see software.amazon.awssdk.services.dynamodb.DynamoDbClient#createTable
-     * @see com.amazonaws.services.dynamodbv2.model.CreateTableRequest
+     * @see software.amazon.awssdk.services.dynamodb.model.CreateTableRequest
      */
     public boolean createTableIfNotExists(ProvisionedThroughput throughput) {
         try {
@@ -521,7 +521,7 @@ public final class DynamoDBTableMapper<T extends Object, H extends Object, R ext
      * Deletes the table.
      * @return The table decription.
      * @see software.amazon.awssdk.services.dynamodb.DynamoDbClient#deleteTable
-     * @see com.amazonaws.services.dynamodbv2.model.DeleteTableRequest
+     * @see software.amazon.awssdk.services.dynamodb.model.DeleteTableRequest
      */
     public TableDescription deleteTable() {
         return db.deleteTable(mapper.generateDeleteTableRequest(model.targetType())).tableDescription();
@@ -532,7 +532,7 @@ public final class DynamoDBTableMapper<T extends Object, H extends Object, R ext
      * it does not already exist.
      * @return True if the table was deleted, or false if the table did not exist.
      * @see software.amazon.awssdk.services.dynamodb.DynamoDbClient#deleteTable
-     * @see com.amazonaws.services.dynamodbv2.model.DeleteTableRequest
+     * @see software.amazon.awssdk.services.dynamodb.model.DeleteTableRequest
      */
     public boolean deleteTableIfExists() {
         try {

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/DynamoDBTableMapper.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/DynamoDBTableMapper.java
@@ -132,7 +132,7 @@ import org.apache.commons.logging.LogFactory;
  * @param <R> The range key value type; use <code>?</code> if no range key.
  *
  * @see software.amazon.awssdk.mapper.dynamodb.DynamoDBMapper
- * @see com.amazonaws.services.dynamodbv2.AmazonDynamoDB
+ * @see software.amazon.awssdk.services.dynamodb.DynamoDbClient
  */
 public final class DynamoDBTableMapper<T extends Object, H extends Object, R extends Object> {
 
@@ -466,7 +466,7 @@ public final class DynamoDBTableMapper<T extends Object, H extends Object, R ext
      * table, when it was created, the primary key schema, and any indexes on
      * the table.
      * @return The describe table results.
-     * @see com.amazonaws.services.dynamodbv2.AmazonDynamoDB#describeTable
+     * @see software.amazon.awssdk.services.dynamodb.DynamoDbClient#describeTable
      */
     public TableDescription describeTable() {
         return db.describeTable(DescribeTableRequest.builder()
@@ -479,7 +479,7 @@ public final class DynamoDBTableMapper<T extends Object, H extends Object, R ext
      * throughput for all global secondary indexes.
      * @param throughput The provisioned throughput.
      * @return The table decription.
-     * @see com.amazonaws.services.dynamodbv2.AmazonDynamoDB#createTable
+     * @see software.amazon.awssdk.services.dynamodb.DynamoDbClient#createTable
      * @see com.amazonaws.services.dynamodbv2.model.CreateTableRequest
      */
     public TableDescription createTable(ProvisionedThroughput throughput) {
@@ -502,7 +502,7 @@ public final class DynamoDBTableMapper<T extends Object, H extends Object, R ext
      * ialready exists.
      * @param throughput The provisioned throughput.
      * @return True if created, or false if the table already existed.
-     * @see com.amazonaws.services.dynamodbv2.AmazonDynamoDB#createTable
+     * @see software.amazon.awssdk.services.dynamodb.DynamoDbClient#createTable
      * @see com.amazonaws.services.dynamodbv2.model.CreateTableRequest
      */
     public boolean createTableIfNotExists(ProvisionedThroughput throughput) {
@@ -520,7 +520,7 @@ public final class DynamoDBTableMapper<T extends Object, H extends Object, R ext
     /**
      * Deletes the table.
      * @return The table decription.
-     * @see com.amazonaws.services.dynamodbv2.AmazonDynamoDB#deleteTable
+     * @see software.amazon.awssdk.services.dynamodb.DynamoDbClient#deleteTable
      * @see com.amazonaws.services.dynamodbv2.model.DeleteTableRequest
      */
     public TableDescription deleteTable() {
@@ -531,7 +531,7 @@ public final class DynamoDBTableMapper<T extends Object, H extends Object, R ext
      * Deletes the table and ignores the {@code ResourceNotFoundException} if
      * it does not already exist.
      * @return True if the table was deleted, or false if the table did not exist.
-     * @see com.amazonaws.services.dynamodbv2.AmazonDynamoDB#deleteTable
+     * @see software.amazon.awssdk.services.dynamodb.DynamoDbClient#deleteTable
      * @see com.amazonaws.services.dynamodbv2.model.DeleteTableRequest
      */
     public boolean deleteTableIfExists() {

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/DynamoDBTableMapper.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/DynamoDBTableMapper.java
@@ -18,12 +18,16 @@ import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.mapper.dynamodb.DynamoDBDeleteExpression;
 import software.amazon.awssdk.mapper.dynamodb.DynamoDBSaveExpression;
 import software.amazon.awssdk.services.dynamodb.model.ConditionalCheckFailedException;
+import software.amazon.awssdk.services.dynamodb.model.CreateTableRequest;
+import software.amazon.awssdk.services.dynamodb.model.DescribeTableRequest;
 import software.amazon.awssdk.services.dynamodb.model.ExpectedAttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.GlobalSecondaryIndex;
 import software.amazon.awssdk.services.dynamodb.model.ProvisionedThroughput;
 import software.amazon.awssdk.services.dynamodb.model.ResourceInUseException;
 import software.amazon.awssdk.services.dynamodb.model.ResourceNotFoundException;
 import software.amazon.awssdk.services.dynamodb.model.TableDescription;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -465,7 +469,9 @@ public final class DynamoDBTableMapper<T extends Object, H extends Object, R ext
      * @see com.amazonaws.services.dynamodbv2.AmazonDynamoDB#describeTable
      */
     public TableDescription describeTable() {
-        throw new UnsupportedOperationException("table admin not yet ported to v2");
+        return db.describeTable(DescribeTableRequest.builder()
+            .tableName(mapper.getTableName(model.targetType(), config))
+            .build()).table();
     }
 
     /**
@@ -477,7 +483,18 @@ public final class DynamoDBTableMapper<T extends Object, H extends Object, R ext
      * @see com.amazonaws.services.dynamodbv2.model.CreateTableRequest
      */
     public TableDescription createTable(ProvisionedThroughput throughput) {
-        throw new UnsupportedOperationException("table admin not yet ported to v2");
+        // v1 mutated the generated request in place to stamp throughput onto the table and every GSI;
+        // v2 requests/indexes are immutable, so rebuild each GSI with the throughput and rebuild the request.
+        final CreateTableRequest generated = mapper.generateCreateTableRequest(model.targetType());
+        final CreateTableRequest.Builder request = generated.toBuilder().provisionedThroughput(throughput);
+        if (generated.hasGlobalSecondaryIndexes()) {
+            final List<GlobalSecondaryIndex> indexes = new ArrayList<GlobalSecondaryIndex>();
+            for (final GlobalSecondaryIndex gsi : generated.globalSecondaryIndexes()) {
+                indexes.add(gsi.toBuilder().provisionedThroughput(throughput).build());
+            }
+            request.globalSecondaryIndexes(indexes);
+        }
+        return db.createTable(request.build()).tableDescription();
     }
 
     /**
@@ -507,7 +524,7 @@ public final class DynamoDBTableMapper<T extends Object, H extends Object, R ext
      * @see com.amazonaws.services.dynamodbv2.model.DeleteTableRequest
      */
     public TableDescription deleteTable() {
-        throw new UnsupportedOperationException("table admin not yet ported to v2");
+        return db.deleteTable(mapper.generateDeleteTableRequest(model.targetType())).tableDescription();
     }
 
     /**

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/DynamoDBVersionAttribute.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/DynamoDBVersionAttribute.java
@@ -35,7 +35,7 @@ import java.lang.annotation.Target;
  * matches the client's. New objects will be assigned a version of 1 when saved.</p>
  * <p>Note that for batchWrite, and by extension batchSave and batchDelete, <b>no
  * version checks are performed</b>, as required by the
- * {@link com.amazonaws.services.dynamodbv2.AmazonDynamoDB#batchWriteItem(BatchWriteItemRequest)}
+ * {@link software.amazon.awssdk.services.dynamodb.DynamoDbClient#batchWriteItem(BatchWriteItemRequest)}
  * API.</p>
  *
  * @see software.amazon.awssdk.mapper.dynamodb.DynamoDBVersioned

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/DynamoDBVersioned.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/DynamoDBVersioned.java
@@ -43,7 +43,7 @@ import java.util.Arrays;
  *
  * <p>Note that for batchWrite, and by extension batchSave and batchDelete,
  * <b>no version checks are performed</b>, as required by the
- * {@link com.amazonaws.services.dynamodbv2.AmazonDynamoDB#batchWriteItem(BatchWriteItemRequest)}
+ * {@link software.amazon.awssdk.services.dynamodb.DynamoDbClient#batchWriteItem(BatchWriteItemRequest)}
  * API.</p>
  *
  * <p>May be used as a meta-annotation.</p>

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/IDynamoDBMapper.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/IDynamoDBMapper.java
@@ -14,7 +14,7 @@
  */
 package software.amazon.awssdk.mapper.dynamodb;
 
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.mapper.dynamodb.DynamoDBMapper.FailedBatch;
 import software.amazon.awssdk.mapper.dynamodb.DynamoDBMapperConfig.PaginationLoadingStrategy;
 import software.amazon.awssdk.mapper.dynamodb.DynamoDBMapperConfig.SaveBehavior;
@@ -159,8 +159,8 @@ public interface IDynamoDBMapper {
     /**
      * Saves an item in DynamoDB. The service method used is determined by the
      * {@link DynamoDBMapperConfig#getSaveBehavior()} value, to use either
-     * {@link AmazonDynamoDB#putItem} or
-     * {@link AmazonDynamoDB#updateItem}:
+     * {@link DynamoDbClient#putItem} or
+     * {@link DynamoDbClient#updateItem}:
      * <ul>
      * <li><b>UPDATE</b> (default) : UPDATE will not affect unmodeled attributes on a save operation
      * and a null value for the modeled attribute will remove it from that item in DynamoDB. Because
@@ -217,7 +217,7 @@ public interface IDynamoDBMapper {
     <T> void delete(T object, DynamoDBDeleteExpression deleteExpression, DynamoDBMapperConfig config);
 
     /**
-     * Transactionally writes objects specified by transactionWriteRequest by calling {@link AmazonDynamoDB#transactWriteItems} API.
+     * Transactionally writes objects specified by transactionWriteRequest by calling {@link DynamoDbClient#transactWriteItems} API.
      * Changes to objects which are put or updated are applied in-memory. <b>Such in-memory updates are NOT thread safe.</b>
      * <p>
      * <b>This method ignores any SaveBehavior set on the mapper. Whether an object is put or updated is solely determined by the
@@ -242,7 +242,7 @@ public interface IDynamoDBMapper {
     void transactionWrite(TransactionWriteRequest transactionWriteRequest);
 
     /**
-     * Transactionally writes objects specified by transactionWriteRequest by calling {@link AmazonDynamoDB#transactWriteItems} API.
+     * Transactionally writes objects specified by transactionWriteRequest by calling {@link DynamoDbClient#transactWriteItems} API.
      * Changes to objects which are put or updated are applied in-memory. <b>Such in-memory updates are NOT thread safe.</b>
      * <p>
      * <b>This method ignores any SaveBehavior set on the mapper. Whether an object is put or updated is solely determined by the
@@ -272,7 +272,7 @@ public interface IDynamoDBMapper {
     void transactionWrite(TransactionWriteRequest transactionWriteRequest, DynamoDBMapperConfig config);
 
     /**
-     * Transactionally loads objects specified by transactionLoadRequest by calling {@link AmazonDynamoDB#transactGetItems} API.
+     * Transactionally loads objects specified by transactionLoadRequest by calling {@link DynamoDbClient#transactGetItems} API.
      * <p>
      * Any exceptions from underlying API are thrown as is. For more information, please refer
      * https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_TransactGetItems.html
@@ -286,7 +286,7 @@ public interface IDynamoDBMapper {
     List<Object> transactionLoad(TransactionLoadRequest transactionLoadRequest);
 
     /**
-     * Transactionally loads objects specified by transactionLoadRequest by calling {@link AmazonDynamoDB#transactGetItems} API.
+     * Transactionally loads objects specified by transactionLoadRequest by calling {@link DynamoDbClient#transactGetItems} API.
      * <p>
      * Any exceptions from underlying API are thrown as is. For more information, please refer
      * https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_TransactGetItems.html
@@ -306,7 +306,7 @@ public interface IDynamoDBMapper {
 
     /**
      * Deletes the objects given using one or more calls to the
-     * {@link AmazonDynamoDB#batchWriteItem} API. <b>No version checks are
+     * {@link DynamoDbClient#batchWriteItem} API. <b>No version checks are
      * performed</b>, as required by the API.
      *
      * @see DynamoDBMapper#batchWrite(Iterable, Iterable)
@@ -315,7 +315,7 @@ public interface IDynamoDBMapper {
 
     /**
      * Deletes the objects given using one or more calls to the
-     * {@link AmazonDynamoDB#batchWriteItem} API. <b>No version checks are
+     * {@link DynamoDbClient#batchWriteItem} API. <b>No version checks are
      * performed</b>, as required by the API.
      *
      * @see DynamoDBMapper#batchWrite(Iterable, Iterable)
@@ -324,11 +324,11 @@ public interface IDynamoDBMapper {
 
     /**
      * Saves the objects given using one or more calls to the
-     * {@link AmazonDynamoDB#batchWriteItem} API. <b>No version checks are
+     * {@link DynamoDbClient#batchWriteItem} API. <b>No version checks are
      * performed</b>, as required by the API.
      * <p/>
      * <b>This method ignores any SaveBehavior set on the mapper</b>, and always behaves as if
-     * SaveBehavior.CLOBBER was specified, as the AmazonDynamoDB.batchWriteItem() request does not
+     * SaveBehavior.CLOBBER was specified, as the DynamoDbClient.batchWriteItem() request does not
      * support updating existing items.
      * <p>
      * This method fails to save the batch if the size of an individual object in the batch exceeds
@@ -342,11 +342,11 @@ public interface IDynamoDBMapper {
 
     /**
      * Saves the objects given using one or more calls to the
-     * {@link AmazonDynamoDB#batchWriteItem} API. <b>No version checks are
+     * {@link DynamoDbClient#batchWriteItem} API. <b>No version checks are
      * performed</b>, as required by the API.
      * <p/>
      * <b>This method ignores any SaveBehavior set on the mapper</b>, and always behaves as if
-     * SaveBehavior.CLOBBER was specified, as the AmazonDynamoDB.batchWriteItem() request does not
+     * SaveBehavior.CLOBBER was specified, as the DynamoDbClient.batchWriteItem() request does not
      * support updating existing items. *
      * <p>
      * This method fails to save the batch if the size of an individual object in the batch exceeds
@@ -360,11 +360,11 @@ public interface IDynamoDBMapper {
 
     /**
      * Saves and deletes the objects given using one or more calls to the
-     * {@link AmazonDynamoDB#batchWriteItem} API. <b>No version checks are
+     * {@link DynamoDbClient#batchWriteItem} API. <b>No version checks are
      * performed</b>, as required by the API.
      * <p/>
      * <b>This method ignores any SaveBehavior set on the mapper</b>, and always behaves as if
-     * SaveBehavior.CLOBBER was specified, as the AmazonDynamoDB.batchWriteItem() request does not
+     * SaveBehavior.CLOBBER was specified, as the DynamoDbClient.batchWriteItem() request does not
      * support updating existing items.
      * <p>
      * This method fails to save the batch if the size of an individual object in the batch exceeds
@@ -383,7 +383,7 @@ public interface IDynamoDBMapper {
 
     /**
      * Saves and deletes the objects given using one or more calls to the
-     * {@link AmazonDynamoDB#batchWriteItem} API. Use mapper config to
+     * {@link DynamoDbClient#batchWriteItem} API. Use mapper config to
      * control the retry strategy when UnprocessedItems are returned by the BatchWriteItem API
      * <p>
      * This method fails to save the batch if the size of an individual object in the batch exceeds
@@ -398,10 +398,10 @@ public interface IDynamoDBMapper {
      *
      * @param objectsToWrite
      *            A list of objects to save to DynamoDB. <b>No version checks are performed</b>, as
-     *            required by the {@link AmazonDynamoDB#batchWriteItem} API.
+     *            required by the {@link DynamoDbClient#batchWriteItem} API.
      * @param objectsToDelete
      *            A list of objects to delete from DynamoDB. <b>No version checks are performed</b>,
-     *            as required by the {@link AmazonDynamoDB#batchWriteItem}
+     *            as required by the {@link DynamoDbClient#batchWriteItem}
      *            API.
      * @param config
      *            Only {@link DynamoDBMapperConfig#getTableNameOverride()} and
@@ -452,7 +452,7 @@ public interface IDynamoDBMapper {
 
     /**
      * Retrieves the attributes for multiple items from multiple tables using their primary keys.
-     * {@link AmazonDynamoDB#batchGetItem} API.
+     * {@link DynamoDbClient#batchGetItem} API.
      *
      * @return A map of the loaded objects. Each key in the map is the name of a DynamoDB table.
      *         Each value in the map is a list of objects that have been loaded from that table. All

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/IDynamoDBMapper.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/IDynamoDBMapper.java
@@ -19,8 +19,8 @@ import software.amazon.awssdk.mapper.dynamodb.DynamoDBMapper.FailedBatch;
 import software.amazon.awssdk.mapper.dynamodb.DynamoDBMapperConfig.PaginationLoadingStrategy;
 import software.amazon.awssdk.mapper.dynamodb.DynamoDBMapperConfig.SaveBehavior;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
-import com.amazonaws.services.dynamodbv2.model.CreateTableRequest;
-import com.amazonaws.services.dynamodbv2.model.DeleteTableRequest;
+import software.amazon.awssdk.services.dynamodb.model.CreateTableRequest;
+import software.amazon.awssdk.services.dynamodb.model.DeleteTableRequest;
 import com.amazonaws.services.s3.model.Region;
 
 import java.util.List;

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/BooleanSetUnmarshaller.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/BooleanSetUnmarshaller.java
@@ -24,7 +24,7 @@ import software.amazon.awssdk.mapper.dynamodb.DynamoDBMappingException;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 /**
- * A special unmarshaller for Set&lt;Boolean>, which the V1 schema stores as
+ * A special unmarshaller for Set&lt;Boolean&gt;, which the V1 schema stores as
  * an NS using 0/1 for true/false. In the V2 schema these fall through to
  * the {@code ObjectSetToListMarshaller} which stores them as an L or BOOLs.
  */

--- a/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/BooleanSetUnmarshaller.java
+++ b/services-custom/dynamodb-mapper/src/main/java/software/amazon/awssdk/mapper/dynamodb/unmarshallers/BooleanSetUnmarshaller.java
@@ -24,7 +24,7 @@ import software.amazon.awssdk.mapper.dynamodb.DynamoDBMappingException;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 /**
- * A special unmarshaller for Set&lt;Boolean&gt;, which the V1 schema stores as
+ * A special unmarshaller for Set&lt;Boolean>, which the V1 schema stores as
  * an NS using 0/1 for true/false. In the V2 schema these fall through to
  * the {@code ObjectSetToListMarshaller} which stores them as an L or BOOLs.
  */

--- a/services-custom/dynamodb-mapper/src/test/java/software/amazon/awssdk/mapper/dynamodb/GenerateDeleteTableRequestTest.java
+++ b/services-custom/dynamodb-mapper/src/test/java/software/amazon/awssdk/mapper/dynamodb/GenerateDeleteTableRequestTest.java
@@ -19,7 +19,7 @@ import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 
-import com.amazonaws.services.dynamodbv2.model.DeleteTableRequest;
+import software.amazon.awssdk.services.dynamodb.model.DeleteTableRequest;
 
 /**
  * Unit tests for {@link DynamoDBMapper#generateDeleteTableRequest(Class)}.
@@ -33,7 +33,7 @@ public class GenerateDeleteTableRequestTest {
     public void tableNameNotOverriden_UsesTableNameAttributeInAnnotation() {
         DynamoDBMapper dynamoDBMapper = new DynamoDBMapper(null);
         DeleteTableRequest deleteTableRequest = dynamoDBMapper.generateDeleteTableRequest(ObjectORMExample.class);
-        assertEquals(deleteTableRequest.getTableName(), TABLE_NAME);
+        assertEquals(deleteTableRequest.tableName(), TABLE_NAME);
     }
 
     @Test
@@ -44,7 +44,7 @@ public class GenerateDeleteTableRequestTest {
         DynamoDBMapper dynamoDBMapper = new DynamoDBMapper(null, config);
 
         DeleteTableRequest deleteTableRequest = dynamoDBMapper.generateDeleteTableRequest(ObjectORMExample.class);
-        assertEquals(deleteTableRequest.getTableName(), TABLE_PREFIX.concat(TABLE_NAME));
+        assertEquals(deleteTableRequest.tableName(), TABLE_PREFIX.concat(TABLE_NAME));
     }
 
     @DynamoDBTable(tableName = TABLE_NAME)

--- a/services-custom/dynamodb-mapper/src/test/java/software/amazon/awssdk/mapper/dynamodb/GsiAlwaysUpdateTest.java
+++ b/services-custom/dynamodb-mapper/src/test/java/software/amazon/awssdk/mapper/dynamodb/GsiAlwaysUpdateTest.java
@@ -14,17 +14,15 @@
  */
 package software.amazon.awssdk.mapper.dynamodb;
 
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 
 import static org.junit.Assert.assertNotEquals;
 
 import software.amazon.awssdk.mapper.dynamodb.DynamoDBMapper;
 import software.amazon.awssdk.mapper.dynamodb.DynamoDBMapperConfig;
 import software.amazon.awssdk.mapper.dynamodb.DynamoDBTableMapper;
-import com.amazonaws.services.dynamodbv2.model.DescribeTableRequest;
-import com.amazonaws.services.dynamodbv2.model.ProvisionedThroughput;
+import software.amazon.awssdk.services.dynamodb.model.ProvisionedThroughput;
 import software.amazon.awssdk.mapper.dynamodb.pojos.GsiWithAlwaysUpdateTimestamp;
-import com.amazonaws.waiters.WaiterParameters;
 import java.util.UUID;
 import org.junit.After;
 import org.junit.Before;
@@ -35,7 +33,7 @@ public class GsiAlwaysUpdateTest extends LocalDynamoDBTestBase {
     private static final String TABLE_NAME =
         GsiAlwaysUpdateTest.class.getSimpleName() + "-" + System.currentTimeMillis();
 
-    private AmazonDynamoDB ddb;
+    private DynamoDbClient ddb;
     private DynamoDBTableMapper<GsiWithAlwaysUpdateTimestamp, String, String> mapper;
 
     @Before
@@ -44,16 +42,14 @@ public class GsiAlwaysUpdateTest extends LocalDynamoDBTestBase {
         mapper = new DynamoDBMapper(ddb, DynamoDBMapperConfig.builder()
                 .withTableNameOverride(new DynamoDBMapperConfig.TableNameOverride(TABLE_NAME))
                 .build()).newTableMapper(GsiWithAlwaysUpdateTimestamp.class);
-        mapper.createTable(new ProvisionedThroughput(5L, 5L));
-        ddb.waiters().tableExists()
-                .run(new WaiterParameters<DescribeTableRequest>(new DescribeTableRequest(TABLE_NAME)));
+        mapper.createTable(ProvisionedThroughput.builder().readCapacityUnits(5L).writeCapacityUnits(5L).build());
+        ddb.waiter().waitUntilTableExists(b -> b.tableName(TABLE_NAME));
     }
 
     @After
     public void tearDown() {
         mapper.deleteTableIfExists();
-        ddb.waiters().tableNotExists()
-                .run(new WaiterParameters<DescribeTableRequest>(new DescribeTableRequest(TABLE_NAME)));
+        ddb.waiter().waitUntilTableNotExists(b -> b.tableName(TABLE_NAME));
     }
 
     @Test

--- a/services-custom/dynamodb-mapper/src/test/java/software/amazon/awssdk/mapper/dynamodb/JsonIntegrationTest.java
+++ b/services-custom/dynamodb-mapper/src/test/java/software/amazon/awssdk/mapper/dynamodb/JsonIntegrationTest.java
@@ -27,29 +27,27 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClient;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.mapper.dynamodb.DynamoDBMapperConfig.ConsistentReads;
 import software.amazon.awssdk.mapper.dynamodb.DynamoDBMapperConfig.TableNameOverride;
-import com.amazonaws.services.dynamodbv2.model.CreateTableRequest;
-import com.amazonaws.services.dynamodbv2.model.ProvisionedThroughput;
-import com.amazonaws.services.dynamodbv2.model.ResourceNotFoundException;
-import com.amazonaws.services.dynamodbv2.model.TableStatus;
-import software.amazon.awssdk.mapper.dynamodb.test.AWSTestBase;
+import software.amazon.awssdk.services.dynamodb.model.CreateTableRequest;
+import software.amazon.awssdk.services.dynamodb.model.DeleteTableRequest;
+import software.amazon.awssdk.services.dynamodb.model.ProvisionedThroughput;
+import software.amazon.awssdk.services.dynamodb.model.ResourceNotFoundException;
 
 import static software.amazon.awssdk.mapper.dynamodb.pojos.TestDocClass.ChildClass;
 
-public class JsonIntegrationTest extends AWSTestBase {
+public class JsonIntegrationTest extends LocalDynamoDBTestBase {
 
     private static final String TABLE_NAME = "test-table-"
             + UUID.randomUUID().toString();
 
-    private static AmazonDynamoDBClient client;
+    private static DynamoDbClient client;
     private static DynamoDBMapper mapper;
 
     @BeforeClass
     public static void setup() throws Exception {
-        setUpCredentials();
-        client = new AmazonDynamoDBClient(credentials);
+        client = client();
 
         mapper = new DynamoDBMapper(
                 client,
@@ -62,25 +60,13 @@ public class JsonIntegrationTest extends AWSTestBase {
 
         CreateTableRequest request = mapper
                 .generateCreateTableRequest(TestDocClass.class)
-                .withProvisionedThroughput(new ProvisionedThroughput(1L, 1L));
+                .toBuilder()
+                .provisionedThroughput(ProvisionedThroughput.builder()
+                        .readCapacityUnits(1L).writeCapacityUnits(1L).build())
+                .build();
 
         client.createTable(request);
-
-        Thread.sleep(10000);
-
-        while (true) {
-            String status = client.describeTable(TABLE_NAME)
-                    .getTable()
-                    .getTableStatus();
-
-            if (status.equals(TableStatus.ACTIVE.toString())) {
-                break;
-            } else if (!status.equals(TableStatus.CREATING.toString())) {
-                throw new RuntimeException("Table creation failed");
-            }
-
-            Thread.sleep(2000);
-        }
+        client.waiter().waitUntilTableExists(b -> b.tableName(TABLE_NAME));
     }
 
     @AfterClass
@@ -90,7 +76,7 @@ public class JsonIntegrationTest extends AWSTestBase {
         }
 
         try {
-            client.deleteTable(TABLE_NAME);
+            client.deleteTable(DeleteTableRequest.builder().tableName(TABLE_NAME).build());
         } catch (ResourceNotFoundException e) {
         }
     }

--- a/services-custom/dynamodb-mapper/src/test/java/software/amazon/awssdk/mapper/dynamodb/mapper/GenerateCreateTableRequest2Test.java
+++ b/services-custom/dynamodb-mapper/src/test/java/software/amazon/awssdk/mapper/dynamodb/mapper/GenerateCreateTableRequest2Test.java
@@ -4,27 +4,28 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.mapper.dynamodb.LocalDynamoDBTestBase;
 import software.amazon.awssdk.mapper.dynamodb.DynamoDBMapper;
-import com.amazonaws.services.dynamodbv2.model.AttributeDefinition;
-import com.amazonaws.services.dynamodbv2.model.CreateTableRequest;
-import com.amazonaws.services.dynamodbv2.model.GlobalSecondaryIndex;
-import com.amazonaws.services.dynamodbv2.model.GlobalSecondaryIndexDescription;
-import com.amazonaws.services.dynamodbv2.model.KeySchemaElement;
-import com.amazonaws.services.dynamodbv2.model.KeyType;
-import com.amazonaws.services.dynamodbv2.model.LocalSecondaryIndex;
-import com.amazonaws.services.dynamodbv2.model.LocalSecondaryIndexDescription;
-import com.amazonaws.services.dynamodbv2.model.ProvisionedThroughput;
-import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType;
-import com.amazonaws.services.dynamodbv2.model.TableDescription;
-import com.amazonaws.services.dynamodbv2.util.TableUtils;
+import software.amazon.awssdk.services.dynamodb.model.AttributeDefinition;
+import software.amazon.awssdk.services.dynamodb.model.CreateTableRequest;
+import software.amazon.awssdk.services.dynamodb.model.DeleteTableRequest;
+import software.amazon.awssdk.services.dynamodb.model.GlobalSecondaryIndex;
+import software.amazon.awssdk.services.dynamodb.model.GlobalSecondaryIndexDescription;
+import software.amazon.awssdk.services.dynamodb.model.KeySchemaElement;
+import software.amazon.awssdk.services.dynamodb.model.KeyType;
+import software.amazon.awssdk.services.dynamodb.model.LocalSecondaryIndex;
+import software.amazon.awssdk.services.dynamodb.model.LocalSecondaryIndexDescription;
+import software.amazon.awssdk.services.dynamodb.model.ProvisionedThroughput;
+import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType;
+import software.amazon.awssdk.services.dynamodb.model.TableDescription;
 import software.amazon.awssdk.mapper.dynamodb.test.util.UnorderedCollectionComparator;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -36,9 +37,10 @@ import org.junit.Test;
 public class GenerateCreateTableRequest2Test extends LocalDynamoDBTestBase {
 
     private static final Set<String> testedTableName = new HashSet<String>();
-    private static final ProvisionedThroughput DEFAULT_CAPACITY = new ProvisionedThroughput(5L, 5L);
+    private static final ProvisionedThroughput DEFAULT_CAPACITY =
+            ProvisionedThroughput.builder().readCapacityUnits(5L).writeCapacityUnits(5L).build();
     private static DynamoDBMapper mapper;
-    private static AmazonDynamoDB dynamo;
+    private static DynamoDbClient dynamo;
 
     @BeforeClass
     public static void setUp() throws Exception {
@@ -49,158 +51,179 @@ public class GenerateCreateTableRequest2Test extends LocalDynamoDBTestBase {
     @AfterClass
     public static void tearDown() {
         for (String tableName : testedTableName) {
-            dynamo.deleteTable(tableName);
+            dynamo.deleteTable(DeleteTableRequest.builder().tableName(tableName).build());
         }
     }
 
     @Test
     public void testParseIndexRangeKeyClass() throws Exception {
         CreateTableRequest request = mapper.generateCreateTableRequest(IndexRangeKeyClass.class);
-        String createdTableName = appendCurrentTimeToTableName(request);
+        String createdTableName = appendCurrentTimeToTableName(request.tableName());
         testedTableName.add(createdTableName);
-        setProvisionedThroughput(request, DEFAULT_CAPACITY);
+        request = withTableNameAndThroughput(request, createdTableName, DEFAULT_CAPACITY);
 
-        TableDescription createdTableDescription = dynamo.createTable(request).getTableDescription();
+        TableDescription createdTableDescription = dynamo.createTable(request).tableDescription();
 
-        assertEquals(createdTableName, createdTableDescription.getTableName());
+        assertEquals(createdTableName, createdTableDescription.tableName());
         List<KeySchemaElement> expectedKeyElements = Arrays.asList(
-                new KeySchemaElement("key", KeyType.HASH),
-                new KeySchemaElement("rangeKey", KeyType.RANGE)
+                KeySchemaElement.builder().attributeName("key").keyType(KeyType.HASH).build(),
+                KeySchemaElement.builder().attributeName("rangeKey").keyType(KeyType.RANGE).build()
                 );
-        assertEquals(expectedKeyElements, createdTableDescription.getKeySchema());
+        assertEquals(expectedKeyElements, createdTableDescription.keySchema());
 
         List<AttributeDefinition> expectedAttrDefinitions = Arrays.asList(
-                new AttributeDefinition("key", ScalarAttributeType.N),
-                new AttributeDefinition("rangeKey", ScalarAttributeType.N),
-                new AttributeDefinition("indexFooRangeKey", ScalarAttributeType.N),
-                new AttributeDefinition("indexBarRangeKey", ScalarAttributeType.N),
-                new AttributeDefinition("multipleIndexRangeKey", ScalarAttributeType.N)
+                AttributeDefinition.builder().attributeName("key").attributeType(ScalarAttributeType.N).build(),
+                AttributeDefinition.builder().attributeName("rangeKey").attributeType(ScalarAttributeType.N).build(),
+                AttributeDefinition.builder().attributeName("indexFooRangeKey").attributeType(ScalarAttributeType.N).build(),
+                AttributeDefinition.builder().attributeName("indexBarRangeKey").attributeType(ScalarAttributeType.N).build(),
+                AttributeDefinition.builder().attributeName("multipleIndexRangeKey").attributeType(ScalarAttributeType.N).build()
                 );
         assertTrue(UnorderedCollectionComparator.equalUnorderedCollections(
                 expectedAttrDefinitions,
-                createdTableDescription.getAttributeDefinitions()));
+                createdTableDescription.attributeDefinitions()));
 
         List<LocalSecondaryIndex> expectedLsi = Arrays.asList(
-                new LocalSecondaryIndex()
-                        .withIndexName("index_foo")
-                        .withKeySchema(
-                                new KeySchemaElement("key", KeyType.HASH),
-                                new KeySchemaElement("indexFooRangeKey", KeyType.RANGE)),
-                new LocalSecondaryIndex()
-                        .withIndexName("index_bar")
-                        .withKeySchema(
-                                new KeySchemaElement("key", KeyType.HASH),
-                                new KeySchemaElement("indexBarRangeKey", KeyType.RANGE)),
-                new LocalSecondaryIndex()
-                        .withIndexName("index_foo_copy")
-                        .withKeySchema(
-                                new KeySchemaElement("key", KeyType.HASH),
-                                new KeySchemaElement("multipleIndexRangeKey", KeyType.RANGE)),
-                new LocalSecondaryIndex()
-                        .withIndexName("index_bar_copy")
-                        .withKeySchema(
-                                new KeySchemaElement("key", KeyType.HASH),
-                                new KeySchemaElement("multipleIndexRangeKey", KeyType.RANGE)));
-        assertTrue(equalLsi(expectedLsi, createdTableDescription.getLocalSecondaryIndexes()));
+                LocalSecondaryIndex.builder()
+                        .indexName("index_foo")
+                        .keySchema(
+                                KeySchemaElement.builder().attributeName("key").keyType(KeyType.HASH).build(),
+                                KeySchemaElement.builder().attributeName("indexFooRangeKey").keyType(KeyType.RANGE).build())
+                        .build(),
+                LocalSecondaryIndex.builder()
+                        .indexName("index_bar")
+                        .keySchema(
+                                KeySchemaElement.builder().attributeName("key").keyType(KeyType.HASH).build(),
+                                KeySchemaElement.builder().attributeName("indexBarRangeKey").keyType(KeyType.RANGE).build())
+                        .build(),
+                LocalSecondaryIndex.builder()
+                        .indexName("index_foo_copy")
+                        .keySchema(
+                                KeySchemaElement.builder().attributeName("key").keyType(KeyType.HASH).build(),
+                                KeySchemaElement.builder().attributeName("multipleIndexRangeKey").keyType(KeyType.RANGE).build())
+                        .build(),
+                LocalSecondaryIndex.builder()
+                        .indexName("index_bar_copy")
+                        .keySchema(
+                                KeySchemaElement.builder().attributeName("key").keyType(KeyType.HASH).build(),
+                                KeySchemaElement.builder().attributeName("multipleIndexRangeKey").keyType(KeyType.RANGE).build())
+                        .build());
+        assertTrue(equalLsi(expectedLsi, createdTableDescription.localSecondaryIndexes()));
 
-        assertNull(request.getGlobalSecondaryIndexes());
-        assertEquals(DEFAULT_CAPACITY, request.getProvisionedThroughput());
+        assertTrue(request.globalSecondaryIndexes().isEmpty());
+        assertEquals(DEFAULT_CAPACITY, request.provisionedThroughput());
 
         // Only one table with indexes can be created simultaneously
-        TableUtils.waitUntilActive(dynamo, createdTableName);
+        dynamo.waiter().waitUntilTableExists(b -> b.tableName(createdTableName));
     }
 
     @Test
     public void testComplexIndexedHashRangeClass() throws Exception {
         CreateTableRequest request = mapper.generateCreateTableRequest(MapperQueryExpressionTest.HashRangeClass.class);
-        String createdTableName = appendCurrentTimeToTableName(request);
+        String createdTableName = appendCurrentTimeToTableName(request.tableName());
         testedTableName.add(createdTableName);
-        setProvisionedThroughput(request, DEFAULT_CAPACITY);
+        request = withTableNameAndThroughput(request, createdTableName, DEFAULT_CAPACITY);
 
-        TableDescription createdTableDescription = dynamo.createTable(request).getTableDescription();
+        TableDescription createdTableDescription = dynamo.createTable(request).tableDescription();
 
-        assertEquals(createdTableName, createdTableDescription.getTableName());
+        assertEquals(createdTableName, createdTableDescription.tableName());
         List<KeySchemaElement> expectedKeyElements = Arrays.asList(
-                new KeySchemaElement("primaryHashKey", KeyType.HASH),
-                new KeySchemaElement("primaryRangeKey", KeyType.RANGE)
+                KeySchemaElement.builder().attributeName("primaryHashKey").keyType(KeyType.HASH).build(),
+                KeySchemaElement.builder().attributeName("primaryRangeKey").keyType(KeyType.RANGE).build()
                 );
-        assertEquals(expectedKeyElements, createdTableDescription.getKeySchema());
+        assertEquals(expectedKeyElements, createdTableDescription.keySchema());
 
         List<AttributeDefinition> expectedAttrDefinitions = Arrays.asList(
-                new AttributeDefinition("primaryHashKey", ScalarAttributeType.S),
-                new AttributeDefinition("indexHashKey", ScalarAttributeType.S),
-                new AttributeDefinition("primaryRangeKey", ScalarAttributeType.S),
-                new AttributeDefinition("indexRangeKey", ScalarAttributeType.S),
-                new AttributeDefinition("anotherIndexRangeKey", ScalarAttributeType.S)
+                AttributeDefinition.builder().attributeName("primaryHashKey").attributeType(ScalarAttributeType.S).build(),
+                AttributeDefinition.builder().attributeName("indexHashKey").attributeType(ScalarAttributeType.S).build(),
+                AttributeDefinition.builder().attributeName("primaryRangeKey").attributeType(ScalarAttributeType.S).build(),
+                AttributeDefinition.builder().attributeName("indexRangeKey").attributeType(ScalarAttributeType.S).build(),
+                AttributeDefinition.builder().attributeName("anotherIndexRangeKey").attributeType(ScalarAttributeType.S).build()
                 );
         assertTrue(UnorderedCollectionComparator.equalUnorderedCollections(
                 expectedAttrDefinitions,
-                createdTableDescription.getAttributeDefinitions()));
+                createdTableDescription.attributeDefinitions()));
 
         List<LocalSecondaryIndex> expectedLsi = Arrays.asList(
-                new LocalSecondaryIndex()
-                        .withIndexName("LSI-primary-range")
-                        .withKeySchema(
-                                new KeySchemaElement("primaryHashKey", KeyType.HASH),
-                                new KeySchemaElement("primaryRangeKey", KeyType.RANGE)),
-                new LocalSecondaryIndex()
-                        .withIndexName("LSI-index-range-1")
-                        .withKeySchema(
-                                new KeySchemaElement("primaryHashKey", KeyType.HASH),
-                                new KeySchemaElement("indexRangeKey", KeyType.RANGE)),
-                new LocalSecondaryIndex()
-                        .withIndexName("LSI-index-range-2")
-                        .withKeySchema(
-                                new KeySchemaElement("primaryHashKey", KeyType.HASH),
-                                new KeySchemaElement("indexRangeKey", KeyType.RANGE)),
-                new LocalSecondaryIndex()
-                        .withIndexName("LSI-index-range-3")
-                        .withKeySchema(
-                                new KeySchemaElement("primaryHashKey", KeyType.HASH),
-                                new KeySchemaElement("anotherIndexRangeKey", KeyType.RANGE)));
-        assertTrue(equalLsi(expectedLsi, createdTableDescription.getLocalSecondaryIndexes()));
+                LocalSecondaryIndex.builder()
+                        .indexName("LSI-primary-range")
+                        .keySchema(
+                                KeySchemaElement.builder().attributeName("primaryHashKey").keyType(KeyType.HASH).build(),
+                                KeySchemaElement.builder().attributeName("primaryRangeKey").keyType(KeyType.RANGE).build())
+                        .build(),
+                LocalSecondaryIndex.builder()
+                        .indexName("LSI-index-range-1")
+                        .keySchema(
+                                KeySchemaElement.builder().attributeName("primaryHashKey").keyType(KeyType.HASH).build(),
+                                KeySchemaElement.builder().attributeName("indexRangeKey").keyType(KeyType.RANGE).build())
+                        .build(),
+                LocalSecondaryIndex.builder()
+                        .indexName("LSI-index-range-2")
+                        .keySchema(
+                                KeySchemaElement.builder().attributeName("primaryHashKey").keyType(KeyType.HASH).build(),
+                                KeySchemaElement.builder().attributeName("indexRangeKey").keyType(KeyType.RANGE).build())
+                        .build(),
+                LocalSecondaryIndex.builder()
+                        .indexName("LSI-index-range-3")
+                        .keySchema(
+                                KeySchemaElement.builder().attributeName("primaryHashKey").keyType(KeyType.HASH).build(),
+                                KeySchemaElement.builder().attributeName("anotherIndexRangeKey").keyType(KeyType.RANGE).build())
+                        .build());
+        assertTrue(equalLsi(expectedLsi, createdTableDescription.localSecondaryIndexes()));
 
         List<GlobalSecondaryIndex> expectedGsi = Arrays.asList(
-                new GlobalSecondaryIndex()
-                        .withIndexName("GSI-primary-hash-index-range-1")
-                        .withKeySchema(
-                                new KeySchemaElement("primaryHashKey", KeyType.HASH),
-                                new KeySchemaElement("indexRangeKey", KeyType.RANGE)),
-                new GlobalSecondaryIndex()
-                        .withIndexName("GSI-primary-hash-index-range-2")
-                        .withKeySchema(
-                                new KeySchemaElement("primaryHashKey", KeyType.HASH),
-                                new KeySchemaElement("anotherIndexRangeKey", KeyType.RANGE)),
-                new GlobalSecondaryIndex()
-                        .withIndexName("GSI-index-hash-primary-range")
-                        .withKeySchema(
-                                new KeySchemaElement("indexHashKey", KeyType.HASH),
-                                new KeySchemaElement("primaryRangeKey", KeyType.RANGE)),
-                new GlobalSecondaryIndex()
-                        .withIndexName("GSI-index-hash-index-range-1")
-                        .withKeySchema(
-                                new KeySchemaElement("indexHashKey", KeyType.HASH),
-                                new KeySchemaElement("indexRangeKey", KeyType.RANGE)),
-                new GlobalSecondaryIndex()
-                        .withIndexName("GSI-index-hash-index-range-2")
-                        .withKeySchema(
-                                new KeySchemaElement("indexHashKey", KeyType.HASH),
-                                new KeySchemaElement("indexRangeKey", KeyType.RANGE)));
-        assertTrue(equalGsi(expectedGsi, createdTableDescription.getGlobalSecondaryIndexes()));
+                GlobalSecondaryIndex.builder()
+                        .indexName("GSI-primary-hash-index-range-1")
+                        .keySchema(
+                                KeySchemaElement.builder().attributeName("primaryHashKey").keyType(KeyType.HASH).build(),
+                                KeySchemaElement.builder().attributeName("indexRangeKey").keyType(KeyType.RANGE).build())
+                        .build(),
+                GlobalSecondaryIndex.builder()
+                        .indexName("GSI-primary-hash-index-range-2")
+                        .keySchema(
+                                KeySchemaElement.builder().attributeName("primaryHashKey").keyType(KeyType.HASH).build(),
+                                KeySchemaElement.builder().attributeName("anotherIndexRangeKey").keyType(KeyType.RANGE).build())
+                        .build(),
+                GlobalSecondaryIndex.builder()
+                        .indexName("GSI-index-hash-primary-range")
+                        .keySchema(
+                                KeySchemaElement.builder().attributeName("indexHashKey").keyType(KeyType.HASH).build(),
+                                KeySchemaElement.builder().attributeName("primaryRangeKey").keyType(KeyType.RANGE).build())
+                        .build(),
+                GlobalSecondaryIndex.builder()
+                        .indexName("GSI-index-hash-index-range-1")
+                        .keySchema(
+                                KeySchemaElement.builder().attributeName("indexHashKey").keyType(KeyType.HASH).build(),
+                                KeySchemaElement.builder().attributeName("indexRangeKey").keyType(KeyType.RANGE).build())
+                        .build(),
+                GlobalSecondaryIndex.builder()
+                        .indexName("GSI-index-hash-index-range-2")
+                        .keySchema(
+                                KeySchemaElement.builder().attributeName("indexHashKey").keyType(KeyType.HASH).build(),
+                                KeySchemaElement.builder().attributeName("indexRangeKey").keyType(KeyType.RANGE).build())
+                        .build());
+        assertTrue(equalGsi(expectedGsi, createdTableDescription.globalSecondaryIndexes()));
 
-        assertEquals(DEFAULT_CAPACITY, request.getProvisionedThroughput());
+        assertEquals(DEFAULT_CAPACITY, request.provisionedThroughput());
 
         // Only one table with indexes can be created simultaneously
-        TableUtils.waitUntilActive(dynamo, createdTableName);
+        dynamo.waiter().waitUntilTableExists(b -> b.tableName(createdTableName));
     }
 
-    private static void setProvisionedThroughput(CreateTableRequest request, ProvisionedThroughput throughput) {
-        request.setProvisionedThroughput(throughput);
-        if (request.getGlobalSecondaryIndexes() != null) {
-            for (GlobalSecondaryIndex gsi : request.getGlobalSecondaryIndexes()) {
-                gsi.setProvisionedThroughput(throughput);
-            }
+    private static CreateTableRequest withTableNameAndThroughput(CreateTableRequest request,
+                                                                 String tableName,
+                                                                 ProvisionedThroughput throughput) {
+        List<GlobalSecondaryIndex> gsis = request.globalSecondaryIndexes().stream()
+                .map(gsi -> gsi.toBuilder().provisionedThroughput(throughput).build())
+                .collect(Collectors.toList());
+        CreateTableRequest.Builder builder = request.toBuilder()
+                .tableName(tableName)
+                .provisionedThroughput(throughput);
+        // Only set the GSI list when the class actually declares one; passing an empty list
+        // to createTable is rejected by the service ("GSI list is empty/invalid").
+        if (!gsis.isEmpty()) {
+            builder.globalSecondaryIndexes(gsis);
         }
+        return builder.build();
     }
 
     private static boolean equalLsi(Collection<LocalSecondaryIndex> a, Collection<LocalSecondaryIndexDescription> b) {
@@ -217,8 +240,8 @@ public class GenerateCreateTableRequest2Test extends LocalDynamoDBTestBase {
 
         @Override
         public boolean equals(LocalSecondaryIndex a, LocalSecondaryIndexDescription b) {
-            return a.getIndexName().equals(b.getIndexName())
-                    && a.getKeySchema().equals(b.getKeySchema());
+            return a.indexName().equals(b.indexName())
+                    && a.keySchema().equals(b.keySchema());
         }
 
     }
@@ -229,14 +252,12 @@ public class GenerateCreateTableRequest2Test extends LocalDynamoDBTestBase {
 
         @Override
         public boolean equals(GlobalSecondaryIndex a, GlobalSecondaryIndexDescription b) {
-            return a.getIndexName().equals(b.getIndexName())
-                    && a.getKeySchema().equals(b.getKeySchema());
+            return a.indexName().equals(b.indexName())
+                    && a.keySchema().equals(b.keySchema());
         }
     }
 
-    private static String appendCurrentTimeToTableName(CreateTableRequest request) {
-        String appendedName = String.format("%s-%d", request.getTableName(), System.currentTimeMillis());
-        request.setTableName(appendedName);
-        return appendedName;
+    private static String appendCurrentTimeToTableName(String tableName) {
+        return String.format("%s-%d", tableName, System.currentTimeMillis());
     }
 }

--- a/services-custom/dynamodb-mapper/src/test/java/software/amazon/awssdk/mapper/dynamodb/mapper/GenerateCreateTableRequestTest.java
+++ b/services-custom/dynamodb-mapper/src/test/java/software/amazon/awssdk/mapper/dynamodb/mapper/GenerateCreateTableRequestTest.java
@@ -11,17 +11,15 @@ import java.util.List;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import com.amazonaws.auth.AnonymousAWSCredentials;
 import software.amazon.awssdk.mapper.dynamodb.test.util.DynamoDBTestBase;
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClient;
 import software.amazon.awssdk.mapper.dynamodb.DynamoDBMapper;
-import com.amazonaws.services.dynamodbv2.model.AttributeDefinition;
-import com.amazonaws.services.dynamodbv2.model.CreateTableRequest;
-import com.amazonaws.services.dynamodbv2.model.GlobalSecondaryIndex;
-import com.amazonaws.services.dynamodbv2.model.KeySchemaElement;
-import com.amazonaws.services.dynamodbv2.model.KeyType;
-import com.amazonaws.services.dynamodbv2.model.LocalSecondaryIndex;
-import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType;
+import software.amazon.awssdk.services.dynamodb.model.AttributeDefinition;
+import software.amazon.awssdk.services.dynamodb.model.CreateTableRequest;
+import software.amazon.awssdk.services.dynamodb.model.GlobalSecondaryIndex;
+import software.amazon.awssdk.services.dynamodb.model.KeySchemaElement;
+import software.amazon.awssdk.services.dynamodb.model.KeyType;
+import software.amazon.awssdk.services.dynamodb.model.LocalSecondaryIndex;
+import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType;
 import software.amazon.awssdk.mapper.dynamodb.test.util.UnorderedCollectionComparator;
 
 /**
@@ -33,133 +31,141 @@ public class GenerateCreateTableRequestTest extends DynamoDBTestBase {
 
     @BeforeClass
     public static void setUp() {
-        dynamo = new AmazonDynamoDBClient(new AnonymousAWSCredentials());
-        mapper = new DynamoDBMapper(dynamo);
+        // generateCreateTableRequest is a pure client-side operation, so no service client is needed.
+        mapper = new DynamoDBMapper(null);
     }
 
     @Test
     public void testParseIndexRangeKeyClass() {
         CreateTableRequest request = mapper.generateCreateTableRequest(IndexRangeKeyClass.class);
 
-        assertEquals("aws-java-sdk-index-range-test", request.getTableName());
+        assertEquals("aws-java-sdk-index-range-test", request.tableName());
         List<KeySchemaElement> expectedKeyElements = Arrays.asList(
-                new KeySchemaElement("key", KeyType.HASH),
-                new KeySchemaElement("rangeKey", KeyType.RANGE)
+                keySchema("key", KeyType.HASH),
+                keySchema("rangeKey", KeyType.RANGE)
                 );
-        assertEquals(expectedKeyElements, request.getKeySchema());
+        assertEquals(expectedKeyElements, request.keySchema());
 
         List<AttributeDefinition> expectedAttrDefinitions = Arrays.asList(
-                new AttributeDefinition("key", ScalarAttributeType.N),
-                new AttributeDefinition("rangeKey", ScalarAttributeType.N),
-                new AttributeDefinition("indexFooRangeKey", ScalarAttributeType.N),
-                new AttributeDefinition("indexBarRangeKey", ScalarAttributeType.N),
-                new AttributeDefinition("multipleIndexRangeKey", ScalarAttributeType.N)
+                attrDefinition("key", ScalarAttributeType.N),
+                attrDefinition("rangeKey", ScalarAttributeType.N),
+                attrDefinition("indexFooRangeKey", ScalarAttributeType.N),
+                attrDefinition("indexBarRangeKey", ScalarAttributeType.N),
+                attrDefinition("multipleIndexRangeKey", ScalarAttributeType.N)
                 );
         assertTrue(UnorderedCollectionComparator.equalUnorderedCollections(
                 expectedAttrDefinitions,
-                request.getAttributeDefinitions()));
+                request.attributeDefinitions()));
 
         List<LocalSecondaryIndex> expectedLsi = Arrays.asList(
-                new LocalSecondaryIndex()
-                        .withIndexName("index_foo")
-                        .withKeySchema(
-                                new KeySchemaElement("key", KeyType.HASH),
-                                new KeySchemaElement("indexFooRangeKey", KeyType.RANGE)),
-                new LocalSecondaryIndex()
-                        .withIndexName("index_bar")
-                        .withKeySchema(
-                                new KeySchemaElement("key", KeyType.HASH),
-                                new KeySchemaElement("indexBarRangeKey", KeyType.RANGE)),
-                new LocalSecondaryIndex()
-                        .withIndexName("index_foo_copy")
-                        .withKeySchema(
-                                new KeySchemaElement("key", KeyType.HASH),
-                                new KeySchemaElement("multipleIndexRangeKey", KeyType.RANGE)),
-                new LocalSecondaryIndex()
-                        .withIndexName("index_bar_copy")
-                        .withKeySchema(
-                                new KeySchemaElement("key", KeyType.HASH),
-                                new KeySchemaElement("multipleIndexRangeKey", KeyType.RANGE)));
-        assertTrue(equalLsi(expectedLsi, request.getLocalSecondaryIndexes()));
+                LocalSecondaryIndex.builder()
+                        .indexName("index_foo")
+                        .keySchema(
+                                keySchema("key", KeyType.HASH),
+                                keySchema("indexFooRangeKey", KeyType.RANGE)).build(),
+                LocalSecondaryIndex.builder()
+                        .indexName("index_bar")
+                        .keySchema(
+                                keySchema("key", KeyType.HASH),
+                                keySchema("indexBarRangeKey", KeyType.RANGE)).build(),
+                LocalSecondaryIndex.builder()
+                        .indexName("index_foo_copy")
+                        .keySchema(
+                                keySchema("key", KeyType.HASH),
+                                keySchema("multipleIndexRangeKey", KeyType.RANGE)).build(),
+                LocalSecondaryIndex.builder()
+                        .indexName("index_bar_copy")
+                        .keySchema(
+                                keySchema("key", KeyType.HASH),
+                                keySchema("multipleIndexRangeKey", KeyType.RANGE)).build());
+        assertTrue(equalLsi(expectedLsi, request.localSecondaryIndexes()));
 
-        assertNull(request.getGlobalSecondaryIndexes());
-        assertNull(request.getProvisionedThroughput());
+        assertTrue(request.globalSecondaryIndexes().isEmpty());
+        assertNull(request.provisionedThroughput());
     }
 
     @Test
     public void testComplexIndexedHashRangeClass() {
         CreateTableRequest request = mapper.generateCreateTableRequest(MapperQueryExpressionTest.HashRangeClass.class);
 
-        assertEquals("table_name", request.getTableName());
+        assertEquals("table_name", request.tableName());
         List<KeySchemaElement> expectedKeyElements = Arrays.asList(
-                new KeySchemaElement("primaryHashKey", KeyType.HASH),
-                new KeySchemaElement("primaryRangeKey", KeyType.RANGE)
+                keySchema("primaryHashKey", KeyType.HASH),
+                keySchema("primaryRangeKey", KeyType.RANGE)
                 );
-        assertEquals(expectedKeyElements, request.getKeySchema());
+        assertEquals(expectedKeyElements, request.keySchema());
 
         List<AttributeDefinition> expectedAttrDefinitions = Arrays.asList(
-                new AttributeDefinition("primaryHashKey", ScalarAttributeType.S),
-                new AttributeDefinition("indexHashKey", ScalarAttributeType.S),
-                new AttributeDefinition("primaryRangeKey", ScalarAttributeType.S),
-                new AttributeDefinition("indexRangeKey", ScalarAttributeType.S),
-                new AttributeDefinition("anotherIndexRangeKey", ScalarAttributeType.S)
+                attrDefinition("primaryHashKey", ScalarAttributeType.S),
+                attrDefinition("indexHashKey", ScalarAttributeType.S),
+                attrDefinition("primaryRangeKey", ScalarAttributeType.S),
+                attrDefinition("indexRangeKey", ScalarAttributeType.S),
+                attrDefinition("anotherIndexRangeKey", ScalarAttributeType.S)
                 );
         assertTrue(UnorderedCollectionComparator.equalUnorderedCollections(
                 expectedAttrDefinitions,
-                request.getAttributeDefinitions()));
+                request.attributeDefinitions()));
 
         List<LocalSecondaryIndex> expectedLsi = Arrays.asList(
-                new LocalSecondaryIndex()
-                        .withIndexName("LSI-primary-range")
-                        .withKeySchema(
-                                new KeySchemaElement("primaryHashKey", KeyType.HASH),
-                                new KeySchemaElement("primaryRangeKey", KeyType.RANGE)),
-                new LocalSecondaryIndex()
-                        .withIndexName("LSI-index-range-1")
-                        .withKeySchema(
-                                new KeySchemaElement("primaryHashKey", KeyType.HASH),
-                                new KeySchemaElement("indexRangeKey", KeyType.RANGE)),
-                new LocalSecondaryIndex()
-                        .withIndexName("LSI-index-range-2")
-                        .withKeySchema(
-                                new KeySchemaElement("primaryHashKey", KeyType.HASH),
-                                new KeySchemaElement("indexRangeKey", KeyType.RANGE)),
-                new LocalSecondaryIndex()
-                        .withIndexName("LSI-index-range-3")
-                        .withKeySchema(
-                                new KeySchemaElement("primaryHashKey", KeyType.HASH),
-                                new KeySchemaElement("anotherIndexRangeKey", KeyType.RANGE)));
-        assertTrue(equalLsi(expectedLsi, request.getLocalSecondaryIndexes()));
+                LocalSecondaryIndex.builder()
+                        .indexName("LSI-primary-range")
+                        .keySchema(
+                                keySchema("primaryHashKey", KeyType.HASH),
+                                keySchema("primaryRangeKey", KeyType.RANGE)).build(),
+                LocalSecondaryIndex.builder()
+                        .indexName("LSI-index-range-1")
+                        .keySchema(
+                                keySchema("primaryHashKey", KeyType.HASH),
+                                keySchema("indexRangeKey", KeyType.RANGE)).build(),
+                LocalSecondaryIndex.builder()
+                        .indexName("LSI-index-range-2")
+                        .keySchema(
+                                keySchema("primaryHashKey", KeyType.HASH),
+                                keySchema("indexRangeKey", KeyType.RANGE)).build(),
+                LocalSecondaryIndex.builder()
+                        .indexName("LSI-index-range-3")
+                        .keySchema(
+                                keySchema("primaryHashKey", KeyType.HASH),
+                                keySchema("anotherIndexRangeKey", KeyType.RANGE)).build());
+        assertTrue(equalLsi(expectedLsi, request.localSecondaryIndexes()));
 
         List<GlobalSecondaryIndex> expectedGsi = Arrays.asList(
-                new GlobalSecondaryIndex()
-                        .withIndexName("GSI-primary-hash-index-range-1")
-                        .withKeySchema(
-                                new KeySchemaElement("primaryHashKey", KeyType.HASH),
-                                new KeySchemaElement("indexRangeKey", KeyType.RANGE)),
-                new GlobalSecondaryIndex()
-                        .withIndexName("GSI-primary-hash-index-range-2")
-                        .withKeySchema(
-                                new KeySchemaElement("primaryHashKey", KeyType.HASH),
-                                new KeySchemaElement("anotherIndexRangeKey", KeyType.RANGE)),
-                new GlobalSecondaryIndex()
-                        .withIndexName("GSI-index-hash-primary-range")
-                        .withKeySchema(
-                                new KeySchemaElement("indexHashKey", KeyType.HASH),
-                                new KeySchemaElement("primaryRangeKey", KeyType.RANGE)),
-                new GlobalSecondaryIndex()
-                        .withIndexName("GSI-index-hash-index-range-1")
-                        .withKeySchema(
-                                new KeySchemaElement("indexHashKey", KeyType.HASH),
-                                new KeySchemaElement("indexRangeKey", KeyType.RANGE)),
-                new GlobalSecondaryIndex()
-                        .withIndexName("GSI-index-hash-index-range-2")
-                        .withKeySchema(
-                                new KeySchemaElement("indexHashKey", KeyType.HASH),
-                                new KeySchemaElement("indexRangeKey", KeyType.RANGE)));
-        assertTrue(equalGsi(expectedGsi, request.getGlobalSecondaryIndexes()));
+                GlobalSecondaryIndex.builder()
+                        .indexName("GSI-primary-hash-index-range-1")
+                        .keySchema(
+                                keySchema("primaryHashKey", KeyType.HASH),
+                                keySchema("indexRangeKey", KeyType.RANGE)).build(),
+                GlobalSecondaryIndex.builder()
+                        .indexName("GSI-primary-hash-index-range-2")
+                        .keySchema(
+                                keySchema("primaryHashKey", KeyType.HASH),
+                                keySchema("anotherIndexRangeKey", KeyType.RANGE)).build(),
+                GlobalSecondaryIndex.builder()
+                        .indexName("GSI-index-hash-primary-range")
+                        .keySchema(
+                                keySchema("indexHashKey", KeyType.HASH),
+                                keySchema("primaryRangeKey", KeyType.RANGE)).build(),
+                GlobalSecondaryIndex.builder()
+                        .indexName("GSI-index-hash-index-range-1")
+                        .keySchema(
+                                keySchema("indexHashKey", KeyType.HASH),
+                                keySchema("indexRangeKey", KeyType.RANGE)).build(),
+                GlobalSecondaryIndex.builder()
+                        .indexName("GSI-index-hash-index-range-2")
+                        .keySchema(
+                                keySchema("indexHashKey", KeyType.HASH),
+                                keySchema("indexRangeKey", KeyType.RANGE)).build());
+        assertTrue(equalGsi(expectedGsi, request.globalSecondaryIndexes()));
 
-        assertNull(request.getProvisionedThroughput());
+        assertNull(request.provisionedThroughput());
+    }
+
+    private static KeySchemaElement keySchema(String attributeName, KeyType keyType) {
+        return KeySchemaElement.builder().attributeName(attributeName).keyType(keyType).build();
+    }
+
+    private static AttributeDefinition attrDefinition(String attributeName, ScalarAttributeType type) {
+        return AttributeDefinition.builder().attributeName(attributeName).attributeType(type).build();
     }
 
     private static boolean equalLsi(Collection<LocalSecondaryIndex> a, Collection<LocalSecondaryIndex> b) {
@@ -176,10 +182,10 @@ public class GenerateCreateTableRequestTest extends DynamoDBTestBase {
 
         @Override
         public boolean equals(LocalSecondaryIndex a, LocalSecondaryIndex b) {
-            return a.getIndexName().equals(b.getIndexName())
-                    && a.getKeySchema().equals(b.getKeySchema());
+            return a.indexName().equals(b.indexName())
+                    && a.keySchema().equals(b.keySchema());
         }
-        
+
     }
 
     private static class GlobalSecondaryIndexDefinitionComparator
@@ -188,8 +194,8 @@ public class GenerateCreateTableRequestTest extends DynamoDBTestBase {
 
         @Override
         public boolean equals(GlobalSecondaryIndex a, GlobalSecondaryIndex b) {
-            return a.getIndexName().equals(b.getIndexName())
-                    && a.getKeySchema().equals(b.getKeySchema());
+            return a.indexName().equals(b.indexName())
+                    && a.keySchema().equals(b.keySchema());
         }
     }
 }

--- a/services-custom/dynamodb-mapper/src/test/java/software/amazon/awssdk/mapper/dynamodb/mapper/HashKeyOnlyTableWithGSITest.java
+++ b/services-custom/dynamodb-mapper/src/test/java/software/amazon/awssdk/mapper/dynamodb/mapper/HashKeyOnlyTableWithGSITest.java
@@ -2,7 +2,7 @@ package software.amazon.awssdk.mapper.dynamodb.mapper;
 
 import static org.junit.Assert.assertEquals;
 
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.mapper.dynamodb.LocalDynamoDBTestBase;
 import software.amazon.awssdk.mapper.dynamodb.DynamoDBHashKey;
 import software.amazon.awssdk.mapper.dynamodb.DynamoDBIndexHashKey;
@@ -11,20 +11,20 @@ import software.amazon.awssdk.mapper.dynamodb.DynamoDBMapper;
 import software.amazon.awssdk.mapper.dynamodb.DynamoDBQueryExpression;
 import software.amazon.awssdk.mapper.dynamodb.DynamoDBTable;
 import software.amazon.awssdk.mapper.dynamodb.PaginatedQueryList;
-import com.amazonaws.services.dynamodbv2.model.AttributeDefinition;
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
-import com.amazonaws.services.dynamodbv2.model.ComparisonOperator;
-import com.amazonaws.services.dynamodbv2.model.Condition;
-import com.amazonaws.services.dynamodbv2.model.CreateTableRequest;
-import com.amazonaws.services.dynamodbv2.model.GlobalSecondaryIndex;
-import com.amazonaws.services.dynamodbv2.model.KeySchemaElement;
-import com.amazonaws.services.dynamodbv2.model.KeyType;
-import com.amazonaws.services.dynamodbv2.model.Projection;
-import com.amazonaws.services.dynamodbv2.model.ProjectionType;
-import com.amazonaws.services.dynamodbv2.model.ProvisionedThroughput;
-import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType;
-import com.amazonaws.services.dynamodbv2.util.TableUtils;
-import java.util.ArrayList;
+import software.amazon.awssdk.services.dynamodb.model.AttributeDefinition;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.ComparisonOperator;
+import software.amazon.awssdk.services.dynamodb.model.Condition;
+import software.amazon.awssdk.services.dynamodb.model.CreateTableRequest;
+import software.amazon.awssdk.services.dynamodb.model.DeleteTableRequest;
+import software.amazon.awssdk.services.dynamodb.model.GlobalSecondaryIndex;
+import software.amazon.awssdk.services.dynamodb.model.KeySchemaElement;
+import software.amazon.awssdk.services.dynamodb.model.KeyType;
+import software.amazon.awssdk.services.dynamodb.model.Projection;
+import software.amazon.awssdk.services.dynamodb.model.ProjectionType;
+import software.amazon.awssdk.services.dynamodb.model.ProvisionedThroughput;
+import software.amazon.awssdk.services.dynamodb.model.ResourceInUseException;
+import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType;
 import java.util.List;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -36,38 +36,44 @@ import org.junit.Test;
 public class HashKeyOnlyTableWithGSITest extends LocalDynamoDBTestBase {
 
     public static final String HASH_KEY_ONLY_TABLE_NAME = "no-primary-range-key-gsi-test";
-    private static AmazonDynamoDB dynamo;
+    private static DynamoDbClient dynamo;
 
 
     @BeforeClass
     public static void setUp() throws Exception {
         dynamo = client();
-        List<KeySchemaElement> keySchema = new ArrayList<KeySchemaElement>();
-        keySchema.add(new KeySchemaElement("id", KeyType.HASH));
 
-        CreateTableRequest req = new CreateTableRequest(HASH_KEY_ONLY_TABLE_NAME, keySchema)
-                .withProvisionedThroughput(new ProvisionedThroughput(10L, 10L))
-                .withAttributeDefinitions(
-                        new AttributeDefinition("id", ScalarAttributeType.S),
-                        new AttributeDefinition("status", ScalarAttributeType.S),
-                        new AttributeDefinition("ts", ScalarAttributeType.S))
-                .withGlobalSecondaryIndexes(
-                        new GlobalSecondaryIndex()
-                                .withProvisionedThroughput(new ProvisionedThroughput(10L, 10L))
-                                .withIndexName("statusAndCreation")
-                                .withKeySchema(
-                                        new KeySchemaElement("status", KeyType.HASH),
-                                        new KeySchemaElement("ts", KeyType.RANGE))
-                                .withProjection(
-                                        new Projection().withProjectionType(ProjectionType.ALL)));
+        CreateTableRequest req = CreateTableRequest.builder()
+                .tableName(HASH_KEY_ONLY_TABLE_NAME)
+                .keySchema(KeySchemaElement.builder().attributeName("id").keyType(KeyType.HASH).build())
+                .provisionedThroughput(ProvisionedThroughput.builder().readCapacityUnits(10L).writeCapacityUnits(10L).build())
+                .attributeDefinitions(
+                        AttributeDefinition.builder().attributeName("id").attributeType(ScalarAttributeType.S).build(),
+                        AttributeDefinition.builder().attributeName("status").attributeType(ScalarAttributeType.S).build(),
+                        AttributeDefinition.builder().attributeName("ts").attributeType(ScalarAttributeType.S).build())
+                .globalSecondaryIndexes(
+                        GlobalSecondaryIndex.builder()
+                                .provisionedThroughput(ProvisionedThroughput.builder().readCapacityUnits(10L).writeCapacityUnits(10L).build())
+                                .indexName("statusAndCreation")
+                                .keySchema(
+                                        KeySchemaElement.builder().attributeName("status").keyType(KeyType.HASH).build(),
+                                        KeySchemaElement.builder().attributeName("ts").keyType(KeyType.RANGE).build())
+                                .projection(
+                                        Projection.builder().projectionType(ProjectionType.ALL).build())
+                                .build())
+                .build();
 
-        TableUtils.createTableIfNotExists(dynamo, req);
-        TableUtils.waitUntilActive(dynamo, HASH_KEY_ONLY_TABLE_NAME);
+        try {
+            dynamo.createTable(req);
+        } catch (ResourceInUseException e) {
+            // Table already exists.
+        }
+        dynamo.waiter().waitUntilTableExists(b -> b.tableName(HASH_KEY_ONLY_TABLE_NAME));
     }
 
     @AfterClass
     public static void tearDown() throws Exception {
-        dynamo.deleteTable(HASH_KEY_ONLY_TABLE_NAME);
+        dynamo.deleteTable(DeleteTableRequest.builder().tableName(HASH_KEY_ONLY_TABLE_NAME).build());
     }
 
     @DynamoDBTable(tableName = HASH_KEY_ONLY_TABLE_NAME)
@@ -126,9 +132,10 @@ public class HashKeyOnlyTableWithGSITest extends LocalDynamoDBTestBase {
                     .withConsistentRead(false)
                     .withHashKeyValues(user)
                     .withRangeKeyCondition("ts",
-                                        new Condition()
-                                                .withComparisonOperator(ComparisonOperator.GT)
-                                                .withAttributeValueList(new AttributeValue("100")));
+                                        Condition.builder()
+                                                .comparisonOperator(ComparisonOperator.GT)
+                                                .attributeValueList(AttributeValue.builder().s("100").build())
+                                                .build());
 
             queryResult = mapper.query(User.class, expr);
         } while (queryResult.size() == 0 && System.currentTimeMillis() < endTime);

--- a/services-custom/dynamodb-mapper/src/test/java/software/amazon/awssdk/mapper/dynamodb/mapper/MapperLoadingStrategyConfigTest.java
+++ b/services-custom/dynamodb-mapper/src/test/java/software/amazon/awssdk/mapper/dynamodb/mapper/MapperLoadingStrategyConfigTest.java
@@ -2,7 +2,7 @@ package software.amazon.awssdk.mapper.dynamodb.mapper;
 
 import static org.junit.Assert.*;
 
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.mapper.dynamodb.LocalDynamoDBTestBase;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
@@ -11,7 +11,6 @@ import java.util.List;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import software.amazon.awssdk.mapper.dynamodb.DynamoDBMapperIntegrationTestBase;
 import software.amazon.awssdk.mapper.dynamodb.DynamoDBMapper;
 import software.amazon.awssdk.mapper.dynamodb.DynamoDBMapperConfig;
 import software.amazon.awssdk.mapper.dynamodb.DynamoDBMapperConfig.ConsistentReads;
@@ -19,9 +18,9 @@ import software.amazon.awssdk.mapper.dynamodb.DynamoDBMapperConfig.PaginationLoa
 import software.amazon.awssdk.mapper.dynamodb.DynamoDBQueryExpression;
 import software.amazon.awssdk.mapper.dynamodb.DynamoDBScanExpression;
 import software.amazon.awssdk.mapper.dynamodb.PaginatedList;
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
-import com.amazonaws.services.dynamodbv2.model.ComparisonOperator;
-import com.amazonaws.services.dynamodbv2.model.Condition;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.ComparisonOperator;
+import software.amazon.awssdk.services.dynamodb.model.Condition;
 import software.amazon.awssdk.mapper.dynamodb.pojos.RangeKeyClass;
 
 /**
@@ -34,14 +33,14 @@ public class MapperLoadingStrategyConfigTest extends LocalDynamoDBTestBase {
     private static int PARALLEL_SEGMENT = 3;
     private static int OBJECTS_NUM = 50;
     private static int RESULTS_NUM = OBJECTS_NUM - 2; // condition: rangeKey > 1.0
-    private static AmazonDynamoDB dynamo;
+    private static DynamoDbClient dynamo;
 
     @BeforeClass
     public static void setUp() throws Exception {
         dynamo = client();
         DynamoDBMapper mapper = new DynamoDBMapper(dynamo);
         dynamo.createTable(mapper.generateCreateTableRequest(RangeKeyClass.class)
-                                 .withProvisionedThroughput(DEFAULT_PROVISIONED_THROUGHPUT));
+                                 .toBuilder().provisionedThroughput(DEFAULT_PROVISIONED_THROUGHPUT).build());
         createTestData();
     }
 
@@ -138,8 +137,8 @@ public class MapperLoadingStrategyConfigTest extends LocalDynamoDBTestBase {
         keyObject.setKey(hashKey);
         DynamoDBQueryExpression<RangeKeyClass> queryExpression = new DynamoDBQueryExpression<RangeKeyClass>().withHashKeyValues(keyObject);
         queryExpression.withRangeKeyCondition("rangeKey",
-                new Condition().withComparisonOperator(ComparisonOperator.GT.toString()).withAttributeValueList(
-                        new AttributeValue().withN("1.0"))).withLimit(PAGE_SIZE);
+                Condition.builder().comparisonOperator(ComparisonOperator.GT).attributeValueList(
+                        AttributeValue.builder().n("1.0").build()).build()).withLimit(PAGE_SIZE);
         
         return mapper.query(RangeKeyClass.class, queryExpression, new DynamoDBMapperConfig(paginationLoadingStrategy));
     }
@@ -150,12 +149,12 @@ public class MapperLoadingStrategyConfigTest extends LocalDynamoDBTestBase {
         
         // Construct the scan expression with the exact same conditions
         DynamoDBScanExpression scanExpression = new DynamoDBScanExpression();
-        scanExpression.addFilterCondition("key", 
-                new Condition().withComparisonOperator(ComparisonOperator.EQ).withAttributeValueList(
-                        new AttributeValue().withN(Long.toString(hashKey))));
-        scanExpression.addFilterCondition("rangeKey", 
-                new Condition().withComparisonOperator(ComparisonOperator.GT).withAttributeValueList(
-                        new AttributeValue().withN("1.0")));
+        scanExpression.addFilterCondition("key",
+                Condition.builder().comparisonOperator(ComparisonOperator.EQ).attributeValueList(
+                        AttributeValue.builder().n(Long.toString(hashKey)).build()).build());
+        scanExpression.addFilterCondition("rangeKey",
+                Condition.builder().comparisonOperator(ComparisonOperator.GT).attributeValueList(
+                        AttributeValue.builder().n("1.0").build()).build());
         scanExpression.setLimit(PAGE_SIZE);
         
         return mapper.scan(RangeKeyClass.class, scanExpression, new DynamoDBMapperConfig(paginationLoadingStrategy));
@@ -167,12 +166,12 @@ public class MapperLoadingStrategyConfigTest extends LocalDynamoDBTestBase {
         
         // Construct the scan expression with the exact same conditions
         DynamoDBScanExpression scanExpression = new DynamoDBScanExpression();
-        scanExpression.addFilterCondition("key", 
-                new Condition().withComparisonOperator(ComparisonOperator.EQ).withAttributeValueList(
-                        new AttributeValue().withN(Long.toString(hashKey))));
-        scanExpression.addFilterCondition("rangeKey", 
-                new Condition().withComparisonOperator(ComparisonOperator.GT).withAttributeValueList(
-                        new AttributeValue().withN("1.0")));
+        scanExpression.addFilterCondition("key",
+                Condition.builder().comparisonOperator(ComparisonOperator.EQ).attributeValueList(
+                        AttributeValue.builder().n(Long.toString(hashKey)).build()).build());
+        scanExpression.addFilterCondition("rangeKey",
+                Condition.builder().comparisonOperator(ComparisonOperator.GT).attributeValueList(
+                        AttributeValue.builder().n("1.0").build()).build());
         scanExpression.setLimit(PAGE_SIZE);
         
         return mapper.parallelScan(RangeKeyClass.class, scanExpression, PARALLEL_SEGMENT, new DynamoDBMapperConfig(paginationLoadingStrategy));

--- a/services-custom/dynamodb-mapper/src/test/java/software/amazon/awssdk/mapper/dynamodb/test/resources/DynamoDBTableResource.java
+++ b/services-custom/dynamodb-mapper/src/test/java/software/amazon/awssdk/mapper/dynamodb/test/resources/DynamoDBTableResource.java
@@ -16,25 +16,25 @@ package software.amazon.awssdk.mapper.dynamodb.test.resources;
 
 import java.util.List;
 
-import com.amazonaws.AmazonServiceException;
 import software.amazon.awssdk.mapper.dynamodb.test.util.DynamoDBTestBase;
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
-import com.amazonaws.services.dynamodbv2.model.CreateTableRequest;
-import com.amazonaws.services.dynamodbv2.model.GlobalSecondaryIndex;
-import com.amazonaws.services.dynamodbv2.model.GlobalSecondaryIndexDescription;
-import com.amazonaws.services.dynamodbv2.model.LocalSecondaryIndex;
-import com.amazonaws.services.dynamodbv2.model.LocalSecondaryIndexDescription;
-import com.amazonaws.services.dynamodbv2.model.Projection;
-import com.amazonaws.services.dynamodbv2.model.TableDescription;
-import com.amazonaws.services.dynamodbv2.model.TableStatus;
-import com.amazonaws.services.dynamodbv2.util.TableUtils;
-import software.amazon.awssdk.mapper.dynamodb.test.resources.TestResource;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.CreateTableRequest;
+import software.amazon.awssdk.services.dynamodb.model.DeleteTableRequest;
+import software.amazon.awssdk.services.dynamodb.model.DescribeTableRequest;
+import software.amazon.awssdk.services.dynamodb.model.GlobalSecondaryIndex;
+import software.amazon.awssdk.services.dynamodb.model.GlobalSecondaryIndexDescription;
+import software.amazon.awssdk.services.dynamodb.model.LocalSecondaryIndex;
+import software.amazon.awssdk.services.dynamodb.model.LocalSecondaryIndexDescription;
+import software.amazon.awssdk.services.dynamodb.model.Projection;
+import software.amazon.awssdk.services.dynamodb.model.ResourceNotFoundException;
+import software.amazon.awssdk.services.dynamodb.model.TableDescription;
+import software.amazon.awssdk.services.dynamodb.model.TableStatus;
 import software.amazon.awssdk.mapper.dynamodb.test.util.UnorderedCollectionComparator;
 import software.amazon.awssdk.mapper.dynamodb.test.util.UnorderedCollectionComparator.CrossTypeComparator;
 
 public abstract class DynamoDBTableResource implements TestResource {
 
-    protected abstract AmazonDynamoDB getClient();
+    protected abstract DynamoDbClient getClient();
 
     protected abstract CreateTableRequest getCreateTableRequest();
 
@@ -49,22 +49,20 @@ public abstract class DynamoDBTableResource implements TestResource {
 
         if (waitTillFinished) {
             System.out.println("Waiting for " + this + " to become active...");
-            try {
-                TableUtils.waitUntilActive(getClient(), getCreateTableRequest().getTableName());
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-            }
+            getClient().waiter().waitUntilTableExists(
+                    b -> b.tableName(getCreateTableRequest().tableName()));
         }
     }
 
     @Override
     public void delete(boolean waitTillFinished) {
         System.out.println("Deleting " + this + "...");
-        getClient().deleteTable(getCreateTableRequest().getTableName());
+        getClient().deleteTable(DeleteTableRequest.builder()
+                .tableName(getCreateTableRequest().tableName()).build());
 
         if (waitTillFinished) {
             System.out.println("Waiting for " + this + " to become deleted...");
-            DynamoDBTestBase.waitForTableToBecomeDeleted(getClient(), getCreateTableRequest().getTableName());
+            DynamoDBTestBase.waitForTableToBecomeDeleted(getClient(), getCreateTableRequest().tableName());
         }
     }
 
@@ -73,29 +71,27 @@ public abstract class DynamoDBTableResource implements TestResource {
         CreateTableRequest createRequest = getCreateTableRequest();
         TableDescription table = null;
         try {
-            table = getClient().describeTable(
-                    createRequest.getTableName()).getTable();
-        } catch (AmazonServiceException ase) {
-            if ( ase.getErrorCode().equalsIgnoreCase("ResourceNotFoundException")) {
-                return ResourceStatus.NOT_EXIST;
-            }
+            table = getClient().describeTable(DescribeTableRequest.builder()
+                    .tableName(createRequest.tableName()).build()).table();
+        } catch (ResourceNotFoundException rnfe) {
+            return ResourceStatus.NOT_EXIST;
         }
 
-        String tableStatus = table.getTableStatus();
+        TableStatus tableStatus = table.tableStatus();
 
-        if (tableStatus.equals(TableStatus.ACTIVE.toString())) {
+        if (tableStatus == TableStatus.ACTIVE) {
             // returns AVAILABLE only if table KeySchema + LSIs + GSIs all match.
-            if (UnorderedCollectionComparator.equalUnorderedCollections(createRequest.getKeySchema(), table.getKeySchema())
-                 && equalUnorderedGsiLists(createRequest.getGlobalSecondaryIndexes(), table.getGlobalSecondaryIndexes())
-                 && equalUnorderedLsiLists(createRequest.getLocalSecondaryIndexes(), table.getLocalSecondaryIndexes())
+            if (UnorderedCollectionComparator.equalUnorderedCollections(createRequest.keySchema(), table.keySchema())
+                 && equalUnorderedGsiLists(createRequest.globalSecondaryIndexes(), table.globalSecondaryIndexes())
+                 && equalUnorderedLsiLists(createRequest.localSecondaryIndexes(), table.localSecondaryIndexes())
                ) {
                 return ResourceStatus.AVAILABLE;
             } else {
                 return ResourceStatus.EXIST_INCOMPATIBLE_RESOURCE;
             }
-        } else if (tableStatus.equals(TableStatus.CREATING.toString())
-                || tableStatus.equals(TableStatus.UPDATING.toString())
-                || tableStatus.equals(TableStatus.DELETING.toString())) {
+        } else if (tableStatus == TableStatus.CREATING
+                || tableStatus == TableStatus.UPDATING
+                || tableStatus == TableStatus.DELETING) {
             return ResourceStatus.TRANSIENT;
         } else {
             return ResourceStatus.NOT_EXIST;
@@ -115,9 +111,9 @@ public abstract class DynamoDBTableResource implements TestResource {
                 new CrossTypeComparator<GlobalSecondaryIndex, GlobalSecondaryIndexDescription>() {
                     @Override
                     public boolean equals(GlobalSecondaryIndex a, GlobalSecondaryIndexDescription b) {
-                        return a.getIndexName().equals(b.getIndexName())
-                                && equalProjections(a.getProjection(), b.getProjection())
-                                && UnorderedCollectionComparator.equalUnorderedCollections(a.getKeySchema(), b.getKeySchema());
+                        return a.indexName().equals(b.indexName())
+                                && equalProjections(a.projection(), b.projection())
+                                && UnorderedCollectionComparator.equalUnorderedCollections(a.keySchema(), b.keySchema());
                     }
                 });
     }
@@ -138,9 +134,9 @@ public abstract class DynamoDBTableResource implements TestResource {
                         // Project parameter might not be specified in the
                         // CreateTableRequest. But it should be treated as equal
                         // to the default projection type - KEYS_ONLY.
-                        return a.getIndexName().equals(b.getIndexName())
-                                && equalProjections(a.getProjection(), b.getProjection())
-                                && UnorderedCollectionComparator.equalUnorderedCollections(a.getKeySchema(), b.getKeySchema());
+                        return a.indexName().equals(b.indexName())
+                                && equalProjections(a.projection(), b.projection())
+                                && UnorderedCollectionComparator.equalUnorderedCollections(a.keySchema(), b.keySchema());
                     }
                 });
     }
@@ -154,11 +150,11 @@ public abstract class DynamoDBTableResource implements TestResource {
             throw new IllegalStateException("The projection parameter should never be null.");
         }
 
-        return fromCreateTableRequest.getProjectionType().equals(
-                    fromDescribeTableResult.getProjectionType())
+        return fromCreateTableRequest.projectionType().equals(
+                    fromDescribeTableResult.projectionType())
                 && UnorderedCollectionComparator.equalUnorderedCollections(
-                        fromCreateTableRequest.getNonKeyAttributes(),
-                        fromDescribeTableResult.getNonKeyAttributes());
+                        fromCreateTableRequest.nonKeyAttributes(),
+                        fromDescribeTableResult.nonKeyAttributes());
     }
 
 
@@ -167,7 +163,7 @@ public abstract class DynamoDBTableResource implements TestResource {
      */
     @Override
     public String toString() {
-        return "DynamoDB Table [" + getCreateTableRequest().getTableName() + "]";
+        return "DynamoDB Table [" + getCreateTableRequest().tableName() + "]";
     }
 
     @Override

--- a/services-custom/dynamodb-mapper/src/test/java/software/amazon/awssdk/mapper/dynamodb/test/resources/TestResourceUtils.java
+++ b/services-custom/dynamodb-mapper/src/test/java/software/amazon/awssdk/mapper/dynamodb/test/resources/TestResourceUtils.java
@@ -14,7 +14,7 @@
  */
 package software.amazon.awssdk.mapper.dynamodb.test.resources;
 
-import com.amazonaws.AmazonClientException;
+import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.mapper.dynamodb.test.resources.RequiredResources.ResourceCreationPolicy;
 import software.amazon.awssdk.mapper.dynamodb.test.resources.TestResource.ResourceStatus;
 
@@ -60,6 +60,6 @@ public class TestResourceUtils {
             Thread.sleep(1000 * 10);
         }
 
-        throw new AmazonClientException("Resource never escaped the transient state.");
+        throw SdkClientException.create("Resource never escaped the transient state.");
     }
 }

--- a/services-custom/dynamodb-mapper/src/test/java/software/amazon/awssdk/mapper/dynamodb/test/resources/tables/BasicTempTable.java
+++ b/services-custom/dynamodb-mapper/src/test/java/software/amazon/awssdk/mapper/dynamodb/test/resources/tables/BasicTempTable.java
@@ -1,11 +1,11 @@
 package software.amazon.awssdk.mapper.dynamodb.test.resources.tables;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeDefinition;
-import com.amazonaws.services.dynamodbv2.model.CreateTableRequest;
-import com.amazonaws.services.dynamodbv2.model.KeySchemaElement;
-import com.amazonaws.services.dynamodbv2.model.KeyType;
-import com.amazonaws.services.dynamodbv2.model.ProvisionedThroughput;
-import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType;
+import software.amazon.awssdk.services.dynamodb.model.AttributeDefinition;
+import software.amazon.awssdk.services.dynamodb.model.CreateTableRequest;
+import software.amazon.awssdk.services.dynamodb.model.KeySchemaElement;
+import software.amazon.awssdk.services.dynamodb.model.KeyType;
+import software.amazon.awssdk.services.dynamodb.model.ProvisionedThroughput;
+import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType;
 
 public class BasicTempTable {
     public static final String TEMP_TABLE_NAME = "basic-temp-table";
@@ -13,20 +13,19 @@ public class BasicTempTable {
     public static final Long READ_CAPACITY = 10L;
     public static final Long WRITE_CAPACITY = 5L;
     public static final ProvisionedThroughput DEFAULT_PROVISIONED_THROUGHPUT =
-            new ProvisionedThroughput().withReadCapacityUnits(READ_CAPACITY).withWriteCapacityUnits(WRITE_CAPACITY);
+            ProvisionedThroughput.builder().readCapacityUnits(READ_CAPACITY).writeCapacityUnits(WRITE_CAPACITY).build();
 
     public static CreateTableRequest getCreateTableRequest() {
-        CreateTableRequest request = new CreateTableRequest()
-                .withTableName(TEMP_TABLE_NAME)
-                .withKeySchema(
-                        new KeySchemaElement().withAttributeName(HASH_KEY_NAME)
-                                .withKeyType(KeyType.HASH))
-                .withAttributeDefinitions(
-                        new AttributeDefinition().withAttributeName(
-                                HASH_KEY_NAME).withAttributeType(
-                                ScalarAttributeType.S));
-        request.setProvisionedThroughput(DEFAULT_PROVISIONED_THROUGHPUT);
-        return request;
+        return CreateTableRequest.builder()
+                .tableName(TEMP_TABLE_NAME)
+                .keySchema(
+                        KeySchemaElement.builder().attributeName(HASH_KEY_NAME)
+                                .keyType(KeyType.HASH).build())
+                .attributeDefinitions(
+                        AttributeDefinition.builder().attributeName(HASH_KEY_NAME)
+                                .attributeType(ScalarAttributeType.S).build())
+                .provisionedThroughput(DEFAULT_PROVISIONED_THROUGHPUT)
+                .build();
     }
 
 }

--- a/services-custom/dynamodb-mapper/src/test/java/software/amazon/awssdk/mapper/dynamodb/test/resources/tables/TempTableWithBinaryKey.java
+++ b/services-custom/dynamodb-mapper/src/test/java/software/amazon/awssdk/mapper/dynamodb/test/resources/tables/TempTableWithBinaryKey.java
@@ -1,11 +1,11 @@
 package software.amazon.awssdk.mapper.dynamodb.test.resources.tables;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeDefinition;
-import com.amazonaws.services.dynamodbv2.model.CreateTableRequest;
-import com.amazonaws.services.dynamodbv2.model.KeySchemaElement;
-import com.amazonaws.services.dynamodbv2.model.KeyType;
-import com.amazonaws.services.dynamodbv2.model.ProvisionedThroughput;
-import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType;
+import software.amazon.awssdk.services.dynamodb.model.AttributeDefinition;
+import software.amazon.awssdk.services.dynamodb.model.CreateTableRequest;
+import software.amazon.awssdk.services.dynamodb.model.KeySchemaElement;
+import software.amazon.awssdk.services.dynamodb.model.KeyType;
+import software.amazon.awssdk.services.dynamodb.model.ProvisionedThroughput;
+import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType;
 
 public class TempTableWithBinaryKey {
 
@@ -14,20 +14,19 @@ public class TempTableWithBinaryKey {
     public static final Long READ_CAPACITY = 10L;
     public static final Long WRITE_CAPACITY = 5L;
     public static final ProvisionedThroughput DEFAULT_PROVISIONED_THROUGHPUT =
-            new ProvisionedThroughput().withReadCapacityUnits(READ_CAPACITY).withWriteCapacityUnits(WRITE_CAPACITY);
+            ProvisionedThroughput.builder().readCapacityUnits(READ_CAPACITY).writeCapacityUnits(WRITE_CAPACITY).build();
 
     public static CreateTableRequest getCreateTableRequest() {
-        CreateTableRequest request = new CreateTableRequest()
-                .withTableName(TEMP_BINARY_TABLE_NAME)
-                .withKeySchema(
-                        new KeySchemaElement().withAttributeName(HASH_KEY_NAME)
-                                .withKeyType(KeyType.HASH))
-                .withAttributeDefinitions(
-                        new AttributeDefinition().withAttributeName(
-                                HASH_KEY_NAME).withAttributeType(
-                                ScalarAttributeType.B));
-        request.setProvisionedThroughput(DEFAULT_PROVISIONED_THROUGHPUT);
-        return request;
+        return CreateTableRequest.builder()
+                .tableName(TEMP_BINARY_TABLE_NAME)
+                .keySchema(
+                        KeySchemaElement.builder().attributeName(HASH_KEY_NAME)
+                                .keyType(KeyType.HASH).build())
+                .attributeDefinitions(
+                        AttributeDefinition.builder().attributeName(HASH_KEY_NAME)
+                                .attributeType(ScalarAttributeType.B).build())
+                .provisionedThroughput(DEFAULT_PROVISIONED_THROUGHPUT)
+                .build();
     }
 
 }

--- a/services-custom/dynamodb-mapper/src/test/java/software/amazon/awssdk/mapper/dynamodb/test/resources/tables/TempTableWithSecondaryIndexes.java
+++ b/services-custom/dynamodb-mapper/src/test/java/software/amazon/awssdk/mapper/dynamodb/test/resources/tables/TempTableWithSecondaryIndexes.java
@@ -1,15 +1,15 @@
 package software.amazon.awssdk.mapper.dynamodb.test.resources.tables;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeDefinition;
-import com.amazonaws.services.dynamodbv2.model.CreateTableRequest;
-import com.amazonaws.services.dynamodbv2.model.GlobalSecondaryIndex;
-import com.amazonaws.services.dynamodbv2.model.KeySchemaElement;
-import com.amazonaws.services.dynamodbv2.model.KeyType;
-import com.amazonaws.services.dynamodbv2.model.LocalSecondaryIndex;
-import com.amazonaws.services.dynamodbv2.model.Projection;
-import com.amazonaws.services.dynamodbv2.model.ProjectionType;
-import com.amazonaws.services.dynamodbv2.model.ProvisionedThroughput;
-import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType;
+import software.amazon.awssdk.services.dynamodb.model.AttributeDefinition;
+import software.amazon.awssdk.services.dynamodb.model.CreateTableRequest;
+import software.amazon.awssdk.services.dynamodb.model.GlobalSecondaryIndex;
+import software.amazon.awssdk.services.dynamodb.model.KeySchemaElement;
+import software.amazon.awssdk.services.dynamodb.model.KeyType;
+import software.amazon.awssdk.services.dynamodb.model.LocalSecondaryIndex;
+import software.amazon.awssdk.services.dynamodb.model.Projection;
+import software.amazon.awssdk.services.dynamodb.model.ProjectionType;
+import software.amazon.awssdk.services.dynamodb.model.ProvisionedThroughput;
+import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType;
 
 /**
  * The table used by SecondaryIndexesIntegrationTest
@@ -24,67 +24,58 @@ public class TempTableWithSecondaryIndexes {
     public static final String GSI_NAME = "global_secondary_index";
     public static final String GSI_HASH_KEY_NAME = "global_secondary_index_hash_attribute";
     public static final String GSI_RANGE_KEY_NAME = "global_secondary_index_range_attribute";
-    public static final ProvisionedThroughput GSI_PROVISIONED_THROUGHPUT = new ProvisionedThroughput(
-            5L, 5L);
+    public static final ProvisionedThroughput GSI_PROVISIONED_THROUGHPUT =
+            ProvisionedThroughput.builder().readCapacityUnits(5L).writeCapacityUnits(5L).build();
 
     public static CreateTableRequest getCreateTableRequest() {
-        CreateTableRequest createTableRequest = new CreateTableRequest()
-                .withTableName(TEMP_TABLE_NAME)
-                .withKeySchema(
-                        new KeySchemaElement().withAttributeName(HASH_KEY_NAME)
-                                .withKeyType(KeyType.HASH),
-                        new KeySchemaElement()
-                                .withAttributeName(RANGE_KEY_NAME).withKeyType(
-                                        KeyType.RANGE))
-                .withAttributeDefinitions(
-                        new AttributeDefinition().withAttributeName(
-                                HASH_KEY_NAME).withAttributeType(
-                                ScalarAttributeType.S),
-                        new AttributeDefinition().withAttributeName(
-                                RANGE_KEY_NAME).withAttributeType(
-                                ScalarAttributeType.N),
-                        new AttributeDefinition().withAttributeName(
-                                LSI_RANGE_KEY_NAME).withAttributeType(
-                                ScalarAttributeType.N),
-                        new AttributeDefinition().withAttributeName(
-                                GSI_HASH_KEY_NAME).withAttributeType(
-                                ScalarAttributeType.S),
-                        new AttributeDefinition().withAttributeName(
-                                GSI_RANGE_KEY_NAME).withAttributeType(
-                                ScalarAttributeType.N))
-                .withProvisionedThroughput(BasicTempTable.DEFAULT_PROVISIONED_THROUGHPUT)
-                .withLocalSecondaryIndexes(
-                        new LocalSecondaryIndex()
-                                .withIndexName(LSI_NAME)
-                                .withKeySchema(
-                                        new KeySchemaElement()
-                                                .withAttributeName(
-                                                        HASH_KEY_NAME)
-                                                .withKeyType(KeyType.HASH),
-                                        new KeySchemaElement()
-                                                .withAttributeName(
-                                                        LSI_RANGE_KEY_NAME)
-                                                .withKeyType(KeyType.RANGE))
-                                .withProjection(
-                                        new Projection()
-                                                .withProjectionType(ProjectionType.KEYS_ONLY)))
-                .withGlobalSecondaryIndexes(
-                        new GlobalSecondaryIndex().withIndexName(GSI_NAME)
-                                .withKeySchema(
-                                        new KeySchemaElement()
-                                                .withAttributeName(
-                                                        GSI_HASH_KEY_NAME)
-                                                .withKeyType(KeyType.HASH),
-                                        new KeySchemaElement()
-                                                .withAttributeName(
-                                                        GSI_RANGE_KEY_NAME)
-                                                .withKeyType(KeyType.RANGE))
-                                .withProjection(
-                                        new Projection()
-                                                .withProjectionType(ProjectionType.KEYS_ONLY))
-                                .withProvisionedThroughput(
-                                        GSI_PROVISIONED_THROUGHPUT));
-        return createTableRequest;
+        return CreateTableRequest.builder()
+                .tableName(TEMP_TABLE_NAME)
+                .keySchema(
+                        KeySchemaElement.builder().attributeName(HASH_KEY_NAME)
+                                .keyType(KeyType.HASH).build(),
+                        KeySchemaElement.builder()
+                                .attributeName(RANGE_KEY_NAME).keyType(KeyType.RANGE).build())
+                .attributeDefinitions(
+                        AttributeDefinition.builder().attributeName(HASH_KEY_NAME)
+                                .attributeType(ScalarAttributeType.S).build(),
+                        AttributeDefinition.builder().attributeName(RANGE_KEY_NAME)
+                                .attributeType(ScalarAttributeType.N).build(),
+                        AttributeDefinition.builder().attributeName(LSI_RANGE_KEY_NAME)
+                                .attributeType(ScalarAttributeType.N).build(),
+                        AttributeDefinition.builder().attributeName(GSI_HASH_KEY_NAME)
+                                .attributeType(ScalarAttributeType.S).build(),
+                        AttributeDefinition.builder().attributeName(GSI_RANGE_KEY_NAME)
+                                .attributeType(ScalarAttributeType.N).build())
+                .provisionedThroughput(BasicTempTable.DEFAULT_PROVISIONED_THROUGHPUT)
+                .localSecondaryIndexes(
+                        LocalSecondaryIndex.builder()
+                                .indexName(LSI_NAME)
+                                .keySchema(
+                                        KeySchemaElement.builder()
+                                                .attributeName(HASH_KEY_NAME)
+                                                .keyType(KeyType.HASH).build(),
+                                        KeySchemaElement.builder()
+                                                .attributeName(LSI_RANGE_KEY_NAME)
+                                                .keyType(KeyType.RANGE).build())
+                                .projection(
+                                        Projection.builder()
+                                                .projectionType(ProjectionType.KEYS_ONLY).build())
+                                .build())
+                .globalSecondaryIndexes(
+                        GlobalSecondaryIndex.builder().indexName(GSI_NAME)
+                                .keySchema(
+                                        KeySchemaElement.builder()
+                                                .attributeName(GSI_HASH_KEY_NAME)
+                                                .keyType(KeyType.HASH).build(),
+                                        KeySchemaElement.builder()
+                                                .attributeName(GSI_RANGE_KEY_NAME)
+                                                .keyType(KeyType.RANGE).build())
+                                .projection(
+                                        Projection.builder()
+                                                .projectionType(ProjectionType.KEYS_ONLY).build())
+                                .provisionedThroughput(GSI_PROVISIONED_THROUGHPUT)
+                                .build())
+                .build();
     }
 
 }


### PR DESCRIPTION
This is almost entirely a dependency swap PR. The mapper's Table Admin API (createTable, deleteTable, describeTable, and the generate*Request builders) and its test infrastructure move from the v1 SDK (com.amazonaws.*) to v2 (software.amazon.awssdk.*). Most of the diff is repetitive, new `X().withY(` becomes `X.builder().y().build()`, `.getX()` becomes `.x()`, plus import changes. 

additionally, I marked `"skipImport": true` on the mapper module in the `brazil.json` file, so the SDK builds can run through (will get re-enabled in the near future)

Two things are worth a closer look:

**1. Null vs. empty collections**
v1 collection getters return null when unset whereas v2 returns an empty collection and a separate `hasXxx()` presence check, never null. So a == null check copied from v1 never fires on v2. Response side reads follow the v2 form throughout the port, and this PR is no exception. 

The only real UX impact could be if a user reads from `generateCreateTableRequest`, which returns a low level v2 `CreateTableRequest`. For a class with no GSIs, `request.globalSecondaryIndexes()` returns an empty list instead of v1's null. That empty list is the v2 client's own getter contract, identical for anyone calling v2 directly, and the mapper does not control it.

**2. Test infrastructure**
The test framework and fixtures use `ddb.waiter().waitUntilTableExists` and `waitUntilTableNotExists` instead of the old v1 TableUtils polling loops, and compare TableStatus by enum identity instead of string equality. One helper sets the GSI list only when it is non empty, because v2 createTable reject an explicitly empty GSI list that v1 accepted as unset.

----


```diff
DDB mapper v2 roadmap

** BASE PACKAGE SETUP **
+ 1. Source verbatim port ✅
+ 2. Test verbatim port ✅
+ 3. Namespace swap (main + datamodeling tests) ✅ 
+ 4. Namespace swap (remaining test packages) 

** PORTING OPERATIONS **
+ 0. converters (AttributeValue seam) ✅ 
+ 1. load() ✅
+ 2. save() ✅
+ 3. query() + scan() ✅
+ 4. deleteItem() ✅
+ 5. updateItem() ✅
+ 6. Batch operations ✅
+ 7. Transactions ✅
8. S3Link
9. Table Admin (control plane convenience methods) <--- current PR

** PERFORMANCE IMPROVEMENTS **
1. getTableModel caching
2. Wire "fast" createX AV factory methods to convertors
3. ByteBuffer → SdkBytes copy
4. Others

** DEPENDENCY MODERNIZATION **
+ 1. EasyMock -> Mockito ✅
2. Log4j 1.x -> 2.x
3. commons-logging -> SLF4J
```