### PR TITLE
Fix schedule failure signal being lost

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-23afb12.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-23afb12.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "AWS SDK for Java v2",
+    "contributor": "",
+    "description": "Fix an issue where futures from the async SDK clients don't complete with an exception when the client or its [scheduled executor service](https://docs.aws.amazon.com/java/api/latest/software/amazon/awssdk/core/client/config/ClientOverrideConfiguration.html#scheduledExecutorService()) is closed. See [#7313](https://github.com/aws/aws-sdk-java-v2/issues/7313) for more details."
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/AsyncRetryableStage.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/AsyncRetryableStage.java
@@ -22,6 +22,7 @@ import java.time.Duration;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.core.Response;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
@@ -105,7 +106,7 @@ public final class AsyncRetryableStage<OutputT> implements RequestPipeline<SdkHt
                 if (r.isZero() && Thread.currentThread().equals(caller)) {
                     attemptExecute(future);
                 } else {
-                    scheduledExecutor.schedule(() -> attemptExecute(future), r.toMillis(), MILLISECONDS);
+                    scheduleOrFail(() -> attemptExecute(future), r.toMillis(), MILLISECONDS, future);
                 }
             });
 
@@ -151,37 +152,41 @@ public final class AsyncRetryableStage<OutputT> implements RequestPipeline<SdkHt
         }
 
         public void maybeAttemptExecute(CompletableFuture<Response<OutputT>> future) {
-            retryableStageHelper.tryRefreshTokenAsync(suggestedDelay()).whenComplete((backoffDelay, t) -> {
-                if (t != null) {
-                    future.completeExceptionally(t);
+            retryableStageHelper.tryRefreshTokenAsync(suggestedDelay()).whenComplete((backoffDelay, err) -> {
+                if (err != null) {
+                    future.completeExceptionally(err);
                     return;
                 }
 
-                Optional<Duration> acquireFailureDelay = backoffDelay.right();
-                if (acquireFailureDelay.isPresent()) {
-                    Duration delay = acquireFailureDelay.get();
-                    retryableStageHelper.logAcquireFailureBackingOff(delay);
-                    SdkException disallowedException = retryableStageHelper.retryPolicyDisallowedRetryException();
-                    // Avoid needless scheduling if we won't wait
-                    if (delay.isZero()) {
-                        future.completeExceptionally(disallowedException);
-                    } else {
-                        scheduledExecutor.schedule(() -> future.completeExceptionally(disallowedException),
-                                                   delay.toMillis(), MILLISECONDS);
+                try {
+                    Optional<Duration> acquireFailureDelay = backoffDelay.right();
+                    if (acquireFailureDelay.isPresent()) {
+                        Duration delay = acquireFailureDelay.get();
+                        retryableStageHelper.logAcquireFailureBackingOff(delay);
+                        SdkException disallowedException = retryableStageHelper.retryPolicyDisallowedRetryException();
+                        // Avoid needless scheduling if we won't wait
+                        if (delay.isZero()) {
+                            future.completeExceptionally(disallowedException);
+                        } else {
+                            scheduleOrFail(() -> future.completeExceptionally(disallowedException), delay.toMillis(),
+                                           MILLISECONDS, future);
+                        }
+                        return;
                     }
-                    return;
+                    // We failed the last attempt, but will retry. The response handler wants to know when that happens.
+                    responseHandler.onError(retryableStageHelper.getLastException());
+
+                    // Reset the request provider to the original one before retries, in case it was modified downstream.
+                    context.requestProvider(originalRequestBody);
+
+                    // get() is safe, Either requires left OR right to be present
+                    Duration successDelay = backoffDelay.left().get();
+                    retryableStageHelper.logBackingOff(successDelay);
+                    long totalDelayMillis = successDelay.toMillis();
+                    scheduleOrFail(() -> attemptExecute(future), totalDelayMillis, MILLISECONDS, future);
+                } catch (Throwable t) {
+                    future.completeExceptionally(t);
                 }
-                // We failed the last attempt, but will retry. The response handler wants to know when that happens.
-                responseHandler.onError(retryableStageHelper.getLastException());
-
-                // Reset the request provider to the original one before retries, in case it was modified downstream.
-                context.requestProvider(originalRequestBody);
-
-                // get() is safe, Either requires left OR right to be present
-                Duration successDelay = backoffDelay.left().get();
-                retryableStageHelper.logBackingOff(successDelay);
-                long totalDelayMillis = successDelay.toMillis();
-                scheduledExecutor.schedule(() -> attemptExecute(future), totalDelayMillis, MILLISECONDS);
             });
         }
 
@@ -229,5 +234,16 @@ public final class AsyncRetryableStage<OutputT> implements RequestPipeline<SdkHt
         return executionContext.executionAttributes()
                                .getOptionalAttribute(SdkInternalExecutionAttribute.NEW_RETRIES_2026_ENABLED)
                                .orElse(false);
+    }
+
+    /**
+     * Schedule the runnable on the scheduled executor, failing the future if the schedule() call fails.
+     */
+    private void scheduleOrFail(Runnable r, long delay, TimeUnit timeUnit, CompletableFuture<?> future) {
+        try {
+            scheduledExecutor.schedule(r, delay, timeUnit);
+        } catch (Throwable t) {
+            future.completeExceptionally(t);
+        }
     }
 }

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/http/pipeline/stages/AsyncRetryableStageTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/http/pipeline/stages/AsyncRetryableStageTest.java
@@ -18,6 +18,7 @@ package software.amazon.awssdk.core.internal.http.pipeline.stages;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -30,6 +31,7 @@ import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Phaser;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -346,6 +348,122 @@ public class AsyncRetryableStageTest extends BaseRetryableStageTest {
         phaser.arriveAndAwaitAdvance();
 
         verify(mockExec).schedule(any(Runnable.class), eq(1L), eq(TimeUnit.MILLISECONDS));
+    }
+
+
+    @Test
+    void execute_isFirstAttempt_scheduleFails_completesExceptionally() throws Exception {
+        RequestExecutionContext ctx = createRequestExecutionContext(true);
+
+        SdkHttpFullResponse.Builder httpResponse = SdkHttpFullResponse.builder().statusCode(502);
+
+        Response<SdkResponse> response = Response.<SdkResponse>builder()
+                                                 .httpResponse(httpResponse.build())
+                                                 .isSuccess(false)
+                                                 .exception(SdkException.builder().build())
+                                                 .build();
+
+        when(mockDelegatePipeline.execute(any(), any())).thenReturn(CompletableFuture.completedFuture(response));
+
+
+        Duration delay = Duration.ofMillis(1);
+
+        AcquireInitialTokenResponse acquireTokenResponse = AcquireInitialTokenResponse.create(mock(RetryToken.class), delay);
+        when(mockRetryStrategy.acquireInitialTokenAsync(any(AcquireInitialTokenRequest.class))).thenReturn(
+            CompletableFuture.completedFuture(acquireTokenResponse));
+
+        ScheduledExecutorService mockExec = mock(ScheduledExecutorService.class);
+        AsyncRetryableStage<SdkResponse> retryableStage = createRetryableStage(mockRetryStrategy, mockExec);
+
+        SdkHttpFullRequest httpRequest = SdkHttpFullRequest.builder()
+                                                           .method(SdkHttpMethod.GET)
+                                                           .uri(URI.create("https://my-service.amazonaws.com"))
+                                                           .build();
+
+        when(mockExec.schedule(any(Runnable.class), eq(1L), eq(TimeUnit.MILLISECONDS)))
+            .thenThrow(new RejectedExecutionException("closed"));
+
+        CompletableFuture<Response<SdkResponse>> future = retryableStage.execute(httpRequest, ctx);
+
+        assertThatThrownBy(future::join).hasRootCauseInstanceOf(RejectedExecutionException.class)
+                                        .hasRootCauseMessage("closed");
+    }
+
+    @Test
+    void execute_isRetryAttempt_scheduleFails_completesExceptionally() throws Exception {
+        ScheduledExecutorService mockExecutor = mock(ScheduledExecutorService.class);
+
+        when(mockExecutor.schedule(any(Runnable.class), anyLong(), any(TimeUnit.class))).thenThrow(new RejectedExecutionException("closed"));
+        AsyncRetryableStage<SdkResponse> retryableStage = createRetryableStage(mockRetryStrategy, mockExecutor);
+
+        RequestExecutionContext ctx = createRequestExecutionContext(true);
+
+        SdkHttpFullResponse.Builder httpResponse = SdkHttpFullResponse.builder()
+                                                                      .statusCode(502);
+
+        Response<SdkResponse> response = Response.<SdkResponse>builder()
+                                                 .httpResponse(httpResponse.build())
+                                                 .isSuccess(false)
+                                                 .exception(SdkException.builder().build())
+                                                 .build();
+
+        when(mockDelegatePipeline.execute(any(), any())).thenReturn(CompletableFuture.completedFuture(response));
+
+            // only retry once, otherwise we'll get into an infinite loop
+            AtomicBoolean first = new AtomicBoolean();
+            when(mockRetryStrategy.refreshRetryTokenAsync(any())).thenAnswer(i -> {
+                if (first.compareAndSet(false, true)) {
+                    return CompletableFuture.completedFuture(RefreshRetryTokenResponse.create(mockRetryToken, Duration.ZERO));
+                }
+                return CompletableFutureUtils.failedFuture(new TokenAcquisitionFailedException("Acquire failed",
+                                                                                               mockRetryToken,
+                                                                                               null,
+                                                                                               Duration.ZERO));
+            });
+
+        SdkHttpFullRequest httpRequest = SdkHttpFullRequest.builder()
+                                                           .method(SdkHttpMethod.GET)
+                                                           .uri(URI.create("https://my-service.amazonaws.com"))
+                                                           .build();
+        CompletableFuture<Response<SdkResponse>> execute = retryableStage.execute(httpRequest, ctx);
+        assertThatThrownBy(execute::join).hasRootCauseInstanceOf(RejectedExecutionException.class).hasRootCauseMessage("closed");
+    }
+
+    @Test
+    void execute_retryDisallowed_delayNonZero_scheduleFails_completesExceptionally() throws Exception {
+        ScheduledExecutorService mockExecutor = mock(ScheduledExecutorService.class);
+
+        when(mockExecutor.schedule(any(Runnable.class), anyLong(), any(TimeUnit.class))).thenThrow(new RejectedExecutionException("closed"));
+        AsyncRetryableStage<SdkResponse> retryableStage = createRetryableStage(mockRetryStrategy, mockExecutor);
+
+        RequestExecutionContext ctx = createRequestExecutionContext(true);
+
+        SdkHttpFullResponse.Builder httpResponse = SdkHttpFullResponse.builder()
+                                                                      .statusCode(502);
+
+        Response<SdkResponse> response = Response.<SdkResponse>builder()
+                                                 .httpResponse(httpResponse.build())
+                                                 .isSuccess(false)
+                                                 .exception(SdkException.builder().build())
+                                                 .build();
+
+        when(mockDelegatePipeline.execute(any(), any())).thenReturn(CompletableFuture.completedFuture(response));
+
+        // only retry once, otherwise we'll get into an infinite loop
+        AtomicBoolean first = new AtomicBoolean();
+        when(mockRetryStrategy.refreshRetryTokenAsync(any()))
+            .thenAnswer(i ->
+                            CompletableFutureUtils.failedFuture(new TokenAcquisitionFailedException("Acquire failed",
+                                                                                                    mockRetryToken,
+                                                                                                    null,
+                                                                                                    Duration.ofSeconds(1))));
+
+        SdkHttpFullRequest httpRequest = SdkHttpFullRequest.builder()
+                                                           .method(SdkHttpMethod.GET)
+                                                           .uri(URI.create("https://my-service.amazonaws.com"))
+                                                           .build();
+        CompletableFuture<Response<SdkResponse>> execute = retryableStage.execute(httpRequest, ctx);
+        assertThatThrownBy(execute::join).hasRootCauseInstanceOf(RejectedExecutionException.class).hasRootCauseMessage("closed");
     }
 
     @Test


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Fix issue where if the call to schedule() fails, the result future is never completed. See #7313.

## Modifications
Propagate the schedule exception to the future.

## Testing
New tests in `AsyncRetryableStageTest`.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
