### PR TITLE
Add request-level MetricPublisher support to the S3 CRT client

### DIFF
--- a/services/s3/src/it/java/software/amazon/awssdk/services/s3/crt/S3CrtClientMetricPublisherIntegrationTest.java
+++ b/services/s3/src/it/java/software/amazon/awssdk/services/s3/crt/S3CrtClientMetricPublisherIntegrationTest.java
@@ -184,10 +184,11 @@ public class S3CrtClientMetricPublisherIntegrationTest extends S3IntegrationTest
             r -> r.bucket(BUCKET).key(LARGE_KEY)
                   .tagging(t -> t.tagSet(Tag.builder().key("env").value("t").build())));
 
+        CapturingMetricPublisher clientPublisher = new CapturingMetricPublisher();
         CapturingMetricPublisher requestPublisher = new CapturingMetricPublisher();
         String destinationKey = "copy-tagged-dest-" + System.nanoTime();
 
-        try (S3AsyncClient client = crtClientWith(new CapturingMetricPublisher())) {
+        try (S3AsyncClient client = crtClientWith(clientPublisher)) {
             client.copyObject(b -> b.sourceBucket(BUCKET).sourceKey(LARGE_KEY)
                                     .destinationBucket(BUCKET).destinationKey(destinationKey)
                                     .taggingDirective(TaggingDirective.COPY)
@@ -200,6 +201,9 @@ public class S3CrtClientMetricPublisherIntegrationTest extends S3IntegrationTest
                 c -> assertThat(c.metricValues(CoreMetric.OPERATION_NAME)).contains("GetObjectTagging"));
             assertThat(collections).anySatisfy(
                 c -> assertThat(c.metricValues(CoreMetric.OPERATION_NAME)).contains("PutObjectTagging"));
+
+            // request-level takes precedence, so this client's own client-level publisher sees none of the sub-requests.
+            assertThat(clientPublisher.awaitAtLeast(1, Duration.ofSeconds(1))).isEmpty();
         }
     }
 

--- a/services/s3/src/it/java/software/amazon/awssdk/services/s3/crt/S3CrtClientMetricPublisherIntegrationTest.java
+++ b/services/s3/src/it/java/software/amazon/awssdk/services/s3/crt/S3CrtClientMetricPublisherIntegrationTest.java
@@ -41,9 +41,9 @@ import software.amazon.awssdk.testutils.RandomTempFile;
 import software.amazon.awssdk.testutils.service.AwsTestBase;
 
 /**
- * Verifies that the CRT-based S3 client publishes CRT native request telemetry to a client-level {@link MetricPublisher}
- * configured via {@code crtBuilder().addMetricPublisher(...)}. Each underlying CRT request attempt is published as its
- * own {@code ApiCall -> ApiCallAttempt -> HttpClient} {@link MetricCollection}, so a multipart transfer yields several.
+ * Verifies that the CRT-based S3 client publishes CRT native request telemetry to client-level and request-level
+ * {@link MetricPublisher}s. Each underlying CRT request attempt is published as its own
+ * {@code ApiCall -> ApiCallAttempt -> HttpClient} {@link MetricCollection}, so a multipart transfer yields several.
  */
 @Timeout(value = 5, unit = TimeUnit.MINUTES)
 public class S3CrtClientMetricPublisherIntegrationTest extends S3IntegrationTestBase {
@@ -132,6 +132,60 @@ public class S3CrtClientMetricPublisherIntegrationTest extends S3IntegrationTest
         collections.forEach(S3CrtClientMetricPublisherIntegrationTest::assertIsCrtApiCallCollection);
         assertThat(collections).anySatisfy(
             c -> assertThat(c.metricValues(CoreMetric.API_CALL_SUCCESSFUL)).contains(false));
+    }
+
+    @Test
+    void requestLevelPublisher_overridesClientLevelPublisher() throws InterruptedException {
+        CapturingMetricPublisher clientPublisher = new CapturingMetricPublisher();
+        CapturingMetricPublisher requestPublisher = new CapturingMetricPublisher();
+
+        try (S3AsyncClient client = crtClientWith(clientPublisher)) {
+            client.getObject(b -> b.bucket(BUCKET).key(SMALL_KEY)
+                                   .overrideConfiguration(o -> o.addMetricPublisher(requestPublisher)),
+                             AsyncResponseTransformer.toBytes()).join();
+
+            // The request-level publisher receives the CRT telemetry ...
+            List<MetricCollection> requestCollections = requestPublisher.awaitAtLeast(1, Duration.ofSeconds(30));
+            assertThat(requestCollections).isNotEmpty();
+            requestCollections.forEach(S3CrtClientMetricPublisherIntegrationTest::assertIsCrtApiCallCollection);
+
+            // ... and this client's own client-level publisher receives nothing, since request-level takes precedence.
+            assertThat(clientPublisher.awaitAtLeast(1, Duration.ofSeconds(1))).isEmpty();
+        }
+    }
+
+    @Test
+    void copyObjectWithRequestLevelPublisher_publishesSubRequestTelemetryToIt() throws InterruptedException {
+        CapturingMetricPublisher clientPublisher = new CapturingMetricPublisher();
+        CapturingMetricPublisher requestPublisher = new CapturingMetricPublisher();
+        String destinationKey = "copy-dest-" + System.nanoTime();
+
+        try (S3AsyncClient client = crtClientWith(clientPublisher)) {
+            // Copy the large object so the copy is orchestrated as multiple sub-requests (head, create, part-copies,
+            // complete). The wrapper attaches the request-level publisher to every sub-request, so each publishes its
+            // own CRT ApiCall collection to it - proving the copyObject wrapper path end-to-end against real S3.
+            client.copyObject(b -> b.sourceBucket(BUCKET).sourceKey(LARGE_KEY)
+                                    .destinationBucket(BUCKET).destinationKey(destinationKey)
+                                    .overrideConfiguration(o -> o.addMetricPublisher(requestPublisher)))
+                  .join();
+
+            List<MetricCollection> collections = requestPublisher.awaitAtLeast(2, Duration.ofSeconds(60));
+            assertThat(collections).hasSizeGreaterThanOrEqualTo(2);
+            collections.forEach(S3CrtClientMetricPublisherIntegrationTest::assertIsCrtApiCallCollection);
+
+            // request-level takes precedence, so this client's own client-level publisher sees none of the sub-requests.
+            assertThat(clientPublisher.awaitAtLeast(1, Duration.ofSeconds(1))).isEmpty();
+        }
+    }
+
+    private static S3AsyncClient crtClientWith(MetricPublisher clientLevelPublisher) {
+        return S3AsyncClient.crtBuilder()
+                            .region(S3IntegrationTestBase.DEFAULT_REGION)
+                            .credentialsProvider(AwsTestBase.CREDENTIALS_PROVIDER_CHAIN)
+                            .minimumPartSizeInBytes(PART_SIZE)
+                            .thresholdInBytes(PART_SIZE)
+                            .addMetricPublisher(clientLevelPublisher)
+                            .build();
     }
 
     private static void assertIsCrtApiCallCollection(MetricCollection apiCall) {

--- a/services/s3/src/it/java/software/amazon/awssdk/services/s3/crt/S3CrtClientMetricPublisherIntegrationTest.java
+++ b/services/s3/src/it/java/software/amazon/awssdk/services/s3/crt/S3CrtClientMetricPublisherIntegrationTest.java
@@ -37,6 +37,8 @@ import software.amazon.awssdk.metrics.MetricPublisher;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.S3IntegrationTestBase;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.Tag;
+import software.amazon.awssdk.services.s3.model.TaggingDirective;
 import software.amazon.awssdk.testutils.RandomTempFile;
 import software.amazon.awssdk.testutils.service.AwsTestBase;
 
@@ -161,9 +163,6 @@ public class S3CrtClientMetricPublisherIntegrationTest extends S3IntegrationTest
         String destinationKey = "copy-dest-" + System.nanoTime();
 
         try (S3AsyncClient client = crtClientWith(clientPublisher)) {
-            // Copy the large object so the copy is orchestrated as multiple sub-requests (head, create, part-copies,
-            // complete). The wrapper attaches the request-level publisher to every sub-request, so each publishes its
-            // own CRT ApiCall collection to it - proving the copyObject wrapper path end-to-end against real S3.
             client.copyObject(b -> b.sourceBucket(BUCKET).sourceKey(LARGE_KEY)
                                     .destinationBucket(BUCKET).destinationKey(destinationKey)
                                     .overrideConfiguration(o -> o.addMetricPublisher(requestPublisher)))
@@ -175,6 +174,32 @@ public class S3CrtClientMetricPublisherIntegrationTest extends S3IntegrationTest
 
             // request-level takes precedence, so this client's own client-level publisher sees none of the sub-requests.
             assertThat(clientPublisher.awaitAtLeast(1, Duration.ofSeconds(1))).isEmpty();
+        }
+    }
+
+    @Test
+    void copyObjectWithTaggingDirective_requestLevelPublisher_receivesTaggingSubRequestMetrics() throws InterruptedException {
+        // Tag the source so a taggingDirective(COPY) copy actually issues GetObjectTagging + PutObjectTagging sub-requests.
+        S3IntegrationTestBase.s3.putObjectTagging(
+            r -> r.bucket(BUCKET).key(LARGE_KEY)
+                  .tagging(t -> t.tagSet(Tag.builder().key("env").value("t").build())));
+
+        CapturingMetricPublisher requestPublisher = new CapturingMetricPublisher();
+        String destinationKey = "copy-tagged-dest-" + System.nanoTime();
+
+        try (S3AsyncClient client = crtClientWith(new CapturingMetricPublisher())) {
+            client.copyObject(b -> b.sourceBucket(BUCKET).sourceKey(LARGE_KEY)
+                                    .destinationBucket(BUCKET).destinationKey(destinationKey)
+                                    .taggingDirective(TaggingDirective.COPY)
+                                    .overrideConfiguration(o -> o.addMetricPublisher(requestPublisher)))
+                  .join();
+
+            List<MetricCollection> collections = requestPublisher.awaitAtLeast(2, Duration.ofSeconds(60));
+            collections.forEach(S3CrtClientMetricPublisherIntegrationTest::assertIsCrtApiCallCollection);
+            assertThat(collections).anySatisfy(
+                c -> assertThat(c.metricValues(CoreMetric.OPERATION_NAME)).contains("GetObjectTagging"));
+            assertThat(collections).anySatisfy(
+                c -> assertThat(c.metricValues(CoreMetric.OPERATION_NAME)).contains("PutObjectTagging"));
         }
     }
 

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/DefaultS3CrtAsyncClient.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/DefaultS3CrtAsyncClient.java
@@ -31,10 +31,12 @@ import java.net.URI;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
+import java.util.function.Function;
 import software.amazon.awssdk.annotations.SdkInternalApi;
 import software.amazon.awssdk.annotations.SdkTestInternalApi;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
@@ -82,6 +84,7 @@ import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectResponse;
+import software.amazon.awssdk.services.s3.model.S3Request;
 import software.amazon.awssdk.services.s3.presignedurl.AsyncPresignedUrlExtension;
 import software.amazon.awssdk.utils.AttributeMap;
 import software.amazon.awssdk.utils.CollectionUtils;
@@ -93,17 +96,21 @@ public final class DefaultS3CrtAsyncClient extends DelegatingS3AsyncClient imple
     public static final ExecutionAttribute<Path> RESPONSE_FILE_PATH = new ExecutionAttribute<>("responseFilePath");
     public static final ExecutionAttribute<S3MetaRequestOptions.ResponseFileOption> RESPONSE_FILE_OPTION =
         new ExecutionAttribute<>("responseFileOption");
+    public static final ExecutionAttribute<List<MetricPublisher>> REQUEST_METRIC_PUBLISHERS =
+        new ExecutionAttribute<>("requestMetricPublishers");
     private static final String CRT_CLIENT_CLASSPATH = "software.amazon.awssdk.crt.s3.S3Client";
     private final CopyObjectHelper copyObjectHelper;
+    private final long copyPartSizeInBytes;
+    private final long copyThresholdInBytes;
 
     private DefaultS3CrtAsyncClient(DefaultS3CrtClientBuilder builder) {
         super(initializeS3AsyncClient(builder));
-        long partSizeInBytes = builder.minimalPartSizeInBytes == null ? DEFAULT_PART_SIZE_IN_BYTES :
-                               builder.minimalPartSizeInBytes;
-        long thresholdInBytes = builder.thresholdInBytes == null ? partSizeInBytes : builder.thresholdInBytes;
+        this.copyPartSizeInBytes = builder.minimalPartSizeInBytes == null ? DEFAULT_PART_SIZE_IN_BYTES :
+                                   builder.minimalPartSizeInBytes;
+        this.copyThresholdInBytes = builder.thresholdInBytes == null ? copyPartSizeInBytes : builder.thresholdInBytes;
         this.copyObjectHelper = new CopyObjectHelper((S3AsyncClient) delegate(),
-                                                     partSizeInBytes,
-                                                     thresholdInBytes);
+                                                     copyPartSizeInBytes,
+                                                     copyThresholdInBytes);
     }
 
     @Override
@@ -137,7 +144,84 @@ public final class DefaultS3CrtAsyncClient extends DelegatingS3AsyncClient imple
 
     @Override
     public CompletableFuture<CopyObjectResponse> copyObject(CopyObjectRequest copyObjectRequest) {
-        return copyObjectHelper.copyObject(copyObjectRequest);
+        List<MetricPublisher> requestMetricPublishers =
+            copyObjectRequest.overrideConfiguration()
+                             .map(AwsRequestOverrideConfiguration::metricPublishers)
+                             .orElse(Collections.emptyList());
+        if (CollectionUtils.isNullOrEmpty(requestMetricPublishers)) {
+            return copyObjectHelper.copyObject(copyObjectRequest);
+        }
+        // copyObject fans out into sub-requests that bypass invokeOperation, so wrap the delegate to attach the
+        // request-level publishers to each sub-request (keeping the inner pipeline no-op).
+        S3AsyncClient publisherInjectingClient =
+            new RequestMetricPublisherInjectingClient((S3AsyncClient) delegate(), requestMetricPublishers);
+        return new CopyObjectHelper(publisherInjectingClient, copyPartSizeInBytes, copyThresholdInBytes)
+            .copyObject(copyObjectRequest);
+    }
+
+    /**
+     * All operations funnel through here. If the request carries request-level metric publishers, move them off the
+     * request override (so the inner standard client's resolveMetricPublishers stays empty -> NoOp, no hollow ApiCall)
+     * and stash them in an execution attribute that the CRT transport reads to publish telemetry to them instead of
+     * (overriding) the client-level publishers.
+     */
+    @Override
+    protected <T extends S3Request, ReturnT> CompletableFuture<ReturnT> invokeOperation(
+        T request, Function<T, CompletableFuture<ReturnT>> operation) {
+        return operation.apply(stashRequestMetricPublishers(request));
+    }
+
+    @SdkTestInternalApi
+    @SuppressWarnings("unchecked")
+    static <T extends S3Request> T stashRequestMetricPublishers(T request) {
+        AwsRequestOverrideConfiguration override = request.overrideConfiguration().orElse(null);
+        if (override == null || CollectionUtils.isNullOrEmpty(override.metricPublishers())) {
+            return request;
+        }
+        AwsRequestOverrideConfiguration newOverride =
+            override.toBuilder()
+                    .metricPublishers(Collections.emptyList())
+                    .putExecutionAttribute(REQUEST_METRIC_PUBLISHERS, override.metricPublishers())
+                    .build();
+        return (T) request.toBuilder().overrideConfiguration(newOverride).build();
+    }
+
+    /**
+     * Always sets {@link #REQUEST_METRIC_PUBLISHERS} on the request to the given publishers and clears any inline
+     * metric publishers, so the inner pipeline stays no-op while the CRT transport publishes telemetry to them. Used to
+     * attach a copy's request-level publishers to each copy sub-request, which are otherwise built without them.
+     */
+    @SdkTestInternalApi
+    @SuppressWarnings("unchecked")
+    static <T extends S3Request> T putRequestMetricPublishers(T request, List<MetricPublisher> publishers) {
+        AwsRequestOverrideConfiguration override =
+            request.overrideConfiguration()
+                   .map(AwsRequestOverrideConfiguration::toBuilder)
+                   .orElseGet(AwsRequestOverrideConfiguration::builder)
+                   .metricPublishers(Collections.emptyList())
+                   .putExecutionAttribute(REQUEST_METRIC_PUBLISHERS, publishers)
+                   .build();
+        return (T) request.toBuilder().overrideConfiguration(override).build();
+    }
+
+    /**
+     * Wraps the inner client so that every operation it is asked to perform carries the given request-level metric
+     * publishers. Used only by {@link #copyObject(CopyObjectRequest)} when the copy request specifies request-level
+     * publishers, so each copy sub-request publishes CRT telemetry to them instead of to the client-level publishers.
+     */
+    static final class RequestMetricPublisherInjectingClient extends DelegatingS3AsyncClient {
+        private final List<MetricPublisher> metricPublishers;
+
+        RequestMetricPublisherInjectingClient(S3AsyncClient delegate, List<MetricPublisher> metricPublishers) {
+            super(delegate);
+            this.metricPublishers = metricPublishers;
+        }
+
+        @Override
+        protected <T extends S3Request, ReturnT> CompletableFuture<ReturnT> invokeOperation(
+            T request, Function<T, CompletableFuture<ReturnT>> operation) {
+            return operation.apply(putRequestMetricPublishers(request, metricPublishers));
+        }
     }
 
     private static S3AsyncClient initializeS3AsyncClient(DefaultS3CrtClientBuilder builder) {
@@ -460,7 +544,9 @@ public final class DefaultS3CrtAsyncClient extends DelegatingS3AsyncClient imple
                    .put(S3InternalSdkHttpExecutionAttribute.RESPONSE_FILE_PATH,
                         executionAttributes.getAttribute(RESPONSE_FILE_PATH))
                    .put(S3InternalSdkHttpExecutionAttribute.RESPONSE_FILE_OPTION,
-                        executionAttributes.getAttribute(RESPONSE_FILE_OPTION));
+                        executionAttributes.getAttribute(RESPONSE_FILE_OPTION))
+                   .put(S3InternalSdkHttpExecutionAttribute.METRIC_PUBLISHERS,
+                        executionAttributes.getAttribute(REQUEST_METRIC_PUBLISHERS));
 
             SdkRequest request = context.request();
             if (request instanceof AwsRequest) {
@@ -515,10 +601,6 @@ public final class DefaultS3CrtAsyncClient extends DelegatingS3AsyncClient imple
                     (AwsRequestOverrideConfiguration) request.overrideConfiguration().get();
                 if (overrideConfiguration.signer().isPresent()) {
                     throw new UnsupportedOperationException("Request-level signer override is not supported");
-                }
-
-                if (!CollectionUtils.isNullOrEmpty(overrideConfiguration.metricPublishers())) {
-                    throw new UnsupportedOperationException("Request-level Metric Publishers override is not supported");
                 }
 
                 if (overrideConfiguration.apiCallAttemptTimeout().isPresent()) {

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/DefaultS3CrtAsyncClient.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/DefaultS3CrtAsyncClient.java
@@ -100,17 +100,15 @@ public final class DefaultS3CrtAsyncClient extends DelegatingS3AsyncClient imple
         new ExecutionAttribute<>("requestMetricPublishers");
     private static final String CRT_CLIENT_CLASSPATH = "software.amazon.awssdk.crt.s3.S3Client";
     private final CopyObjectHelper copyObjectHelper;
-    private final long copyPartSizeInBytes;
-    private final long copyThresholdInBytes;
 
     private DefaultS3CrtAsyncClient(DefaultS3CrtClientBuilder builder) {
         super(initializeS3AsyncClient(builder));
-        this.copyPartSizeInBytes = builder.minimalPartSizeInBytes == null ? DEFAULT_PART_SIZE_IN_BYTES :
-                                   builder.minimalPartSizeInBytes;
-        this.copyThresholdInBytes = builder.thresholdInBytes == null ? copyPartSizeInBytes : builder.thresholdInBytes;
+        long partSizeInBytes = builder.minimalPartSizeInBytes == null ? DEFAULT_PART_SIZE_IN_BYTES :
+                               builder.minimalPartSizeInBytes;
+        long thresholdInBytes = builder.thresholdInBytes == null ? partSizeInBytes : builder.thresholdInBytes;
         this.copyObjectHelper = new CopyObjectHelper((S3AsyncClient) delegate(),
-                                                     copyPartSizeInBytes,
-                                                     copyThresholdInBytes);
+                                                     partSizeInBytes,
+                                                     thresholdInBytes);
     }
 
     @Override
@@ -144,19 +142,9 @@ public final class DefaultS3CrtAsyncClient extends DelegatingS3AsyncClient imple
 
     @Override
     public CompletableFuture<CopyObjectResponse> copyObject(CopyObjectRequest copyObjectRequest) {
-        List<MetricPublisher> requestMetricPublishers =
-            copyObjectRequest.overrideConfiguration()
-                             .map(AwsRequestOverrideConfiguration::metricPublishers)
-                             .orElse(Collections.emptyList());
-        if (CollectionUtils.isNullOrEmpty(requestMetricPublishers)) {
-            return copyObjectHelper.copyObject(copyObjectRequest);
-        }
-        // copyObject fans out into sub-requests that bypass invokeOperation, so wrap the delegate to attach the
-        // request-level publishers to each sub-request (keeping the inner pipeline no-op).
-        S3AsyncClient publisherInjectingClient =
-            new RequestMetricPublisherInjectingClient((S3AsyncClient) delegate(), requestMetricPublishers);
-        return new CopyObjectHelper(publisherInjectingClient, copyPartSizeInBytes, copyThresholdInBytes)
-            .copyObject(copyObjectRequest);
+        // copyObject's sub-requests bypass invokeOperation, so stash once here; CopyObjectHelper propagates the copy's
+        // override (with the stashed attribute) to each sub-request.
+        return copyObjectHelper.copyObject(stashRequestMetricPublishers(copyObjectRequest));
     }
 
     /**
@@ -183,43 +171,6 @@ public final class DefaultS3CrtAsyncClient extends DelegatingS3AsyncClient imple
                     .putExecutionAttribute(REQUEST_METRIC_PUBLISHERS, override.metricPublishers())
                     .build();
         return (T) request.toBuilder().overrideConfiguration(newOverride).build();
-    }
-
-    /**
-     * Always sets {@link #REQUEST_METRIC_PUBLISHERS} on the request to the given publishers and clears any inline
-     * metric publishers, so the inner pipeline stays no-op while the CRT transport publishes telemetry to them. Used to
-     * attach a copy's request-level publishers to each copy sub-request, which are otherwise built without them.
-     */
-    @SuppressWarnings("unchecked")
-    static <T extends S3Request> T putRequestMetricPublishers(T request, List<MetricPublisher> publishers) {
-        AwsRequestOverrideConfiguration override =
-            request.overrideConfiguration()
-                   .map(AwsRequestOverrideConfiguration::toBuilder)
-                   .orElseGet(AwsRequestOverrideConfiguration::builder)
-                   .metricPublishers(Collections.emptyList())
-                   .putExecutionAttribute(REQUEST_METRIC_PUBLISHERS, publishers)
-                   .build();
-        return (T) request.toBuilder().overrideConfiguration(override).build();
-    }
-
-    /**
-     * Wraps the inner client so that every operation it is asked to perform carries the given request-level metric
-     * publishers. Used only by {@link #copyObject(CopyObjectRequest)} when the copy request specifies request-level
-     * publishers, so each copy sub-request publishes CRT telemetry to them instead of to the client-level publishers.
-     */
-    static final class RequestMetricPublisherInjectingClient extends DelegatingS3AsyncClient {
-        private final List<MetricPublisher> metricPublishers;
-
-        RequestMetricPublisherInjectingClient(S3AsyncClient delegate, List<MetricPublisher> metricPublishers) {
-            super(delegate);
-            this.metricPublishers = metricPublishers;
-        }
-
-        @Override
-        protected <T extends S3Request, ReturnT> CompletableFuture<ReturnT> invokeOperation(
-            T request, Function<T, CompletableFuture<ReturnT>> operation) {
-            return operation.apply(putRequestMetricPublishers(request, metricPublishers));
-        }
     }
 
     private static S3AsyncClient initializeS3AsyncClient(DefaultS3CrtClientBuilder builder) {

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/DefaultS3CrtAsyncClient.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/DefaultS3CrtAsyncClient.java
@@ -171,7 +171,6 @@ public final class DefaultS3CrtAsyncClient extends DelegatingS3AsyncClient imple
         return operation.apply(stashRequestMetricPublishers(request));
     }
 
-    @SdkTestInternalApi
     @SuppressWarnings("unchecked")
     static <T extends S3Request> T stashRequestMetricPublishers(T request) {
         AwsRequestOverrideConfiguration override = request.overrideConfiguration().orElse(null);
@@ -191,7 +190,6 @@ public final class DefaultS3CrtAsyncClient extends DelegatingS3AsyncClient imple
      * metric publishers, so the inner pipeline stays no-op while the CRT transport publishes telemetry to them. Used to
      * attach a copy's request-level publishers to each copy sub-request, which are otherwise built without them.
      */
-    @SdkTestInternalApi
     @SuppressWarnings("unchecked")
     static <T extends S3Request> T putRequestMetricPublishers(T request, List<MetricPublisher> publishers) {
         AwsRequestOverrideConfiguration override =

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/S3CrtAsyncHttpClient.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/S3CrtAsyncHttpClient.java
@@ -166,11 +166,6 @@ public final class S3CrtAsyncHttpClient implements SdkAsyncHttpClient {
         Path responseFilePath = httpExecutionAttributes.getAttribute(RESPONSE_FILE_PATH);
         S3MetaRequestOptions.ResponseFileOption responseFileOption = httpExecutionAttributes.getAttribute(RESPONSE_FILE_OPTION);
 
-        // The adapter reads its inputs from the execution attributes. METRIC_PUBLISHERS currently holds the
-        // request-level publishers (if any) the interceptor stashed; resolve them against the client-level publishers
-        // (request-level takes precedence) and attach the effective set here when there are any. toBuilder() preserves
-        // everything already in the bag (including CRT_PROGRESS_LISTENER); skip the copy entirely when no publishers
-        // are configured, to avoid rebuilding the bag on every request.
         List<MetricPublisher> requestMetricPublishers =
             httpExecutionAttributes.getAttribute(S3InternalSdkHttpExecutionAttribute.METRIC_PUBLISHERS);
         List<MetricPublisher> effectivePublishers = resolveEffectiveMetricPublishers(requestMetricPublishers,

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/S3CrtAsyncHttpClient.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/S3CrtAsyncHttpClient.java
@@ -166,14 +166,20 @@ public final class S3CrtAsyncHttpClient implements SdkAsyncHttpClient {
         Path responseFilePath = httpExecutionAttributes.getAttribute(RESPONSE_FILE_PATH);
         S3MetaRequestOptions.ResponseFileOption responseFileOption = httpExecutionAttributes.getAttribute(RESPONSE_FILE_OPTION);
 
-        // The adapter reads its inputs from the execution attributes, so attach the client-level publishers here when
-        // there are any. toBuilder() preserves everything already in the bag (including CRT_PROGRESS_LISTENER); skip the
-        // copy entirely when no publishers are configured, to avoid rebuilding the bag on every request.
+        // The adapter reads its inputs from the execution attributes. METRIC_PUBLISHERS currently holds the
+        // request-level publishers (if any) the interceptor stashed; resolve them against the client-level publishers
+        // (request-level takes precedence) and attach the effective set here when there are any. toBuilder() preserves
+        // everything already in the bag (including CRT_PROGRESS_LISTENER); skip the copy entirely when no publishers
+        // are configured, to avoid rebuilding the bag on every request.
+        List<MetricPublisher> requestMetricPublishers =
+            httpExecutionAttributes.getAttribute(S3InternalSdkHttpExecutionAttribute.METRIC_PUBLISHERS);
+        List<MetricPublisher> effectivePublishers = resolveEffectiveMetricPublishers(requestMetricPublishers,
+                                                                                     metricPublishers);
         SdkHttpExecutionAttributes adapterAttributes = httpExecutionAttributes;
-        if (!metricPublishers.isEmpty()) {
+        if (!effectivePublishers.isEmpty()) {
             adapterAttributes = httpExecutionAttributes.toBuilder()
                                                        .put(S3InternalSdkHttpExecutionAttribute.METRIC_PUBLISHERS,
-                                                            metricPublishers)
+                                                            effectivePublishers)
                                                        .build();
         }
 
@@ -230,6 +236,19 @@ public final class S3CrtAsyncHttpClient implements SdkAsyncHttpClient {
         }
 
         return executeFuture;
+    }
+
+    /**
+     * Request-level publishers (if any were set on the request override) take precedence over the client-level
+     * publishers; otherwise the client-level publishers are used.
+     */
+    @SdkTestInternalApi
+    static List<MetricPublisher> resolveEffectiveMetricPublishers(List<MetricPublisher> requestLevel,
+                                                                  List<MetricPublisher> clientLevel) {
+        if (requestLevel != null && !requestLevel.isEmpty()) {
+            return requestLevel;
+        }
+        return clientLevel;
     }
 
     private AwsSigningConfig awsSigningConfig(Region signingRegion, SdkHttpExecutionAttributes httpExecutionAttributes) {

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/S3CrtAsyncHttpClient.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/S3CrtAsyncHttpClient.java
@@ -242,7 +242,6 @@ public final class S3CrtAsyncHttpClient implements SdkAsyncHttpClient {
      * Request-level publishers (if any were set on the request override) take precedence over the client-level
      * publishers; otherwise the client-level publishers are used.
      */
-    @SdkTestInternalApi
     static List<MetricPublisher> resolveEffectiveMetricPublishers(List<MetricPublisher> requestLevel,
                                                                   List<MetricPublisher> clientLevel) {
         if (requestLevel != null && !requestLevel.isEmpty()) {

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/S3InternalSdkHttpExecutionAttribute.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/crt/S3InternalSdkHttpExecutionAttribute.java
@@ -70,11 +70,12 @@ public final class S3InternalSdkHttpExecutionAttribute<T> extends SdkHttpExecuti
         new S3InternalSdkHttpExecutionAttribute<>(CrtCredentialsProviderAdapter.class);
 
     /**
-     * Metric publishers that this request's CRT telemetry is published to.
+     * The metric publishers this request's CRT telemetry is published to: the request-level publishers if the request
+     * set any, otherwise the client-level publishers. The CRT transport resolves the two and folds the effective set in.
      */
     @SuppressWarnings("unchecked")
     public static final S3InternalSdkHttpExecutionAttribute<List<MetricPublisher>> METRIC_PUBLISHERS =
-            new S3InternalSdkHttpExecutionAttribute<>((Class<List<MetricPublisher>>) (Class<?>) List.class);
+        new S3InternalSdkHttpExecutionAttribute<>((Class<List<MetricPublisher>>) (Class<?>) List.class);
 
     private S3InternalSdkHttpExecutionAttribute(Class<T> valueClass) {
         super(valueClass);

--- a/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/CopyObjectHelper.java
+++ b/services/s3/src/main/java/software/amazon/awssdk/services/s3/internal/multipart/CopyObjectHelper.java
@@ -32,6 +32,7 @@ import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
 import software.amazon.awssdk.core.ResponseBytes;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
 import software.amazon.awssdk.core.async.AsyncResponseTransformer;
@@ -181,9 +182,11 @@ public final class CopyObjectHelper {
     }
 
     private CompletableFuture<List<Tag>> fetchSourceTagging(CopyObjectRequest copyObjectRequest, String sourceVersionId) {
+        AwsRequestOverrideConfiguration override = copyObjectRequest.overrideConfiguration().orElse(null);
         return s3AsyncClient.getObjectTagging(r -> r.bucket(copyObjectRequest.sourceBucket())
                                                     .key(copyObjectRequest.sourceKey())
-                                                    .versionId(sourceVersionId))
+                                                    .versionId(sourceVersionId)
+                                                    .overrideConfiguration(override))
                             .thenApply(response -> CollectionUtils.isNullOrEmpty(response.tagSet())
                                                    ? null : response.tagSet());
     }
@@ -197,10 +200,12 @@ public final class CopyObjectHelper {
         Map<String, byte[]> annotationBodies = new ConcurrentHashMap<>();
         Queue<CompletableFuture<Void>> fetchFutures = new ConcurrentLinkedQueue<>();
         CompletableFuture<Map<String, byte[]>> result = new CompletableFuture<>();
+        AwsRequestOverrideConfiguration override = copyObjectRequest.overrideConfiguration().orElse(null);
 
         s3AsyncClient.listObjectAnnotationsPaginator(r -> r.bucket(copyObjectRequest.sourceBucket())
                                                            .key(copyObjectRequest.sourceKey())
-                                                           .versionId(sourceVersionId))
+                                                           .versionId(sourceVersionId)
+                                                           .overrideConfiguration(override))
                      .subscribe(response -> fetchAnnotationBodies(copyObjectRequest, sourceVersionId, response, annotationBodies,
                                                                   fetchFutures))
                      .whenComplete((v, t) -> {
@@ -237,10 +242,12 @@ public final class CopyObjectHelper {
     private CompletableFuture<byte[]> fetchSingleAnnotation(CopyObjectRequest copyObjectRequest,
                                                             String sourceVersionId,
                                                             String annotationName) {
+        AwsRequestOverrideConfiguration override = copyObjectRequest.overrideConfiguration().orElse(null);
         return s3AsyncClient.getObjectAnnotation(r -> r.bucket(copyObjectRequest.sourceBucket())
                                                        .key(copyObjectRequest.sourceKey())
                                                        .versionId(sourceVersionId)
-                                                       .annotationName(annotationName),
+                                                       .annotationName(annotationName)
+                                                       .overrideConfiguration(override),
                                                  AsyncResponseTransformer.toBytes())
                             .thenApply(ResponseBytes::asByteArray);
     }
@@ -250,10 +257,12 @@ public final class CopyObjectHelper {
         CompleteMultipartUploadResponse completeResponse,
         List<Tag> tags) {
 
+        AwsRequestOverrideConfiguration override = copyObjectRequest.overrideConfiguration().orElse(null);
         return s3AsyncClient.putObjectTagging(r -> r.bucket(copyObjectRequest.destinationBucket())
                                                     .key(copyObjectRequest.destinationKey())
                                                     .versionId(completeResponse.versionId())
-                                                    .tagging(Tagging.builder().tagSet(tags).build()))
+                                                    .tagging(Tagging.builder().tagSet(tags).build())
+                                                    .overrideConfiguration(override))
                             .thenApply(r -> completeResponse);
     }
 
@@ -269,6 +278,7 @@ public final class CopyObjectHelper {
 
         String destVersionId = completeResponse.versionId();
         String destETag = completeResponse.eTag();
+        AwsRequestOverrideConfiguration override = copyObjectRequest.overrideConfiguration().orElse(null);
 
         log.debug(() -> String.format("Writing %d annotations to destination object", annotations.size()));
 
@@ -282,7 +292,8 @@ public final class CopyObjectHelper {
                                                                                   .key(copyObjectRequest.destinationKey())
                                                                                   .versionId(destVersionId)
                                                                                   .objectIfMatch(destETag)
-                                                                                  .annotationName(entry.getKey()),
+                                                                                  .annotationName(entry.getKey())
+                                                                                  .overrideConfiguration(override),
                                                                             AsyncRequestBody.fromBytes(entry.getValue()))
                                                        .thenRun(() -> succeededAnnotations.add(entry.getKey())));
         }

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crt/CopyObjectHelperTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crt/CopyObjectHelperTest.java
@@ -54,6 +54,7 @@ import software.amazon.awssdk.services.s3.model.CopyObjectResponse;
 import software.amazon.awssdk.services.s3.model.CopyPartResult;
 import software.amazon.awssdk.services.s3.model.CreateMultipartUploadRequest;
 import software.amazon.awssdk.services.s3.model.CreateMultipartUploadResponse;
+import software.amazon.awssdk.services.s3.model.GetObjectTaggingRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectTaggingResponse;
 import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
 import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
@@ -68,10 +69,13 @@ import software.amazon.awssdk.core.async.AsyncRequestBody;
 import software.amazon.awssdk.core.async.AsyncResponseTransformer;
 import software.amazon.awssdk.services.s3.model.AnnotationDirective;
 import software.amazon.awssdk.services.s3.model.AnnotationEntry;
+import software.amazon.awssdk.services.s3.model.GetObjectAnnotationRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectAnnotationResponse;
 import software.amazon.awssdk.services.s3.model.ListObjectAnnotationsRequest;
 import software.amazon.awssdk.services.s3.model.ListObjectAnnotationsResponse;
+import software.amazon.awssdk.services.s3.model.PutObjectAnnotationRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectAnnotationResponse;
+import software.amazon.awssdk.services.s3.model.PutObjectTaggingRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectTaggingResponse;
 import software.amazon.awssdk.services.s3.model.S3Exception;
 import software.amazon.awssdk.services.s3.paginators.ListObjectAnnotationsPublisher;
@@ -975,6 +979,85 @@ class CopyObjectHelperTest {
         future.cancel(true);
 
         assertThat(createMpuFuture).isCompletedExceptionally();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void multiPartCopy_taggingDirectiveCopy_propagatesOverrideToTaggingSubRequests() {
+        AwsRequestOverrideConfiguration override =
+            AwsRequestOverrideConfiguration.builder().putHeader("x-custom", "value").build();
+
+        stubSuccessfulHeadObjectCall(4000L);
+        when(s3AsyncClient.getObjectTagging(any(Consumer.class)))
+            .thenReturn(CompletableFuture.completedFuture(GetObjectTaggingResponse.builder()
+                .tagSet(Arrays.asList(Tag.builder().key("k").value("v").build())).build()));
+        stubSuccessfulCreateMulipartCall();
+        stubSuccessfulUploadPartCopyCalls();
+        stubSuccessfulCompleteMultipartCall();
+        when(s3AsyncClient.putObjectTagging(any(Consumer.class)))
+            .thenReturn(CompletableFuture.completedFuture(PutObjectTaggingResponse.builder().build()));
+
+        copyHelper.copyObject(copyRequestBuilder().taggingDirective(TaggingDirective.COPY)
+                                                  .overrideConfiguration(override)
+                                                  .build()).join();
+
+        ArgumentCaptor<Consumer<GetObjectTaggingRequest.Builder>> getCaptor = ArgumentCaptor.forClass(Consumer.class);
+        verify(s3AsyncClient).getObjectTagging(getCaptor.capture());
+        GetObjectTaggingRequest.Builder getBuilder = GetObjectTaggingRequest.builder();
+        getCaptor.getValue().accept(getBuilder);
+        assertThat(getBuilder.build().overrideConfiguration()).contains(override);
+
+        ArgumentCaptor<Consumer<PutObjectTaggingRequest.Builder>> putCaptor = ArgumentCaptor.forClass(Consumer.class);
+        verify(s3AsyncClient).putObjectTagging(putCaptor.capture());
+        PutObjectTaggingRequest.Builder putBuilder = PutObjectTaggingRequest.builder();
+        putCaptor.getValue().accept(putBuilder);
+        assertThat(putBuilder.build().overrideConfiguration()).contains(override);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void multiPartCopy_annotationDirectiveCopy_propagatesOverrideToAnnotationSubRequests() {
+        AwsRequestOverrideConfiguration override =
+            AwsRequestOverrideConfiguration.builder().putHeader("x-custom", "value").build();
+
+        stubSuccessfulHeadObjectCall(4000L);
+        // one source annotation so getObjectAnnotation (source) and putObjectAnnotation (dest) are actually invoked
+        when(s3AsyncClient.listObjectAnnotations(any(ListObjectAnnotationsRequest.class)))
+            .thenReturn(CompletableFuture.completedFuture(ListObjectAnnotationsResponse.builder()
+                .annotations(AnnotationEntry.builder().annotationName("anno1").build()).build()));
+        when(s3AsyncClient.getObjectAnnotation(any(Consumer.class), any(AsyncResponseTransformer.class)))
+            .thenReturn(CompletableFuture.completedFuture(
+                ResponseBytes.fromByteArray(GetObjectAnnotationResponse.builder().build(), "body".getBytes())));
+        stubSuccessfulCreateMulipartCall();
+        stubSuccessfulUploadPartCopyCalls();
+        stubSuccessfulCompleteMultipartCall();
+        when(s3AsyncClient.putObjectAnnotation(any(Consumer.class), any(AsyncRequestBody.class)))
+            .thenReturn(CompletableFuture.completedFuture(PutObjectAnnotationResponse.builder().build()));
+
+        copyHelper.copyObject(copyRequestBuilder().annotationDirective(AnnotationDirective.COPY)
+                                                  .overrideConfiguration(override)
+                                                  .build()).join();
+
+        // ListObjectAnnotations (source) carries the copy's override.
+        ArgumentCaptor<Consumer<ListObjectAnnotationsRequest.Builder>> listCaptor = ArgumentCaptor.forClass(Consumer.class);
+        verify(s3AsyncClient).listObjectAnnotationsPaginator(listCaptor.capture());
+        ListObjectAnnotationsRequest.Builder listBuilder = ListObjectAnnotationsRequest.builder();
+        listCaptor.getValue().accept(listBuilder);
+        assertThat(listBuilder.build().overrideConfiguration()).contains(override);
+
+        // GetObjectAnnotation (source) carries the copy's override.
+        ArgumentCaptor<Consumer<GetObjectAnnotationRequest.Builder>> getCaptor = ArgumentCaptor.forClass(Consumer.class);
+        verify(s3AsyncClient).getObjectAnnotation(getCaptor.capture(), any(AsyncResponseTransformer.class));
+        GetObjectAnnotationRequest.Builder getBuilder = GetObjectAnnotationRequest.builder();
+        getCaptor.getValue().accept(getBuilder);
+        assertThat(getBuilder.build().overrideConfiguration()).contains(override);
+
+        // PutObjectAnnotation (dest) carries the copy's override.
+        ArgumentCaptor<Consumer<PutObjectAnnotationRequest.Builder>> putCaptor = ArgumentCaptor.forClass(Consumer.class);
+        verify(s3AsyncClient).putObjectAnnotation(putCaptor.capture(), any(AsyncRequestBody.class));
+        PutObjectAnnotationRequest.Builder putBuilder = PutObjectAnnotationRequest.builder();
+        putCaptor.getValue().accept(putBuilder);
+        assertThat(putBuilder.build().overrideConfiguration()).contains(override);
     }
 
     private static CopyObjectRequest.Builder copyRequestBuilder() {

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crt/S3CrtClientWiremockTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crt/S3CrtClientWiremockTest.java
@@ -38,6 +38,10 @@ import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import com.github.tomakehurst.wiremock.stubbing.Scenario;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Executor;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -50,8 +54,11 @@ import software.amazon.awssdk.core.ResponseBytes;
 import software.amazon.awssdk.core.ResponseInputStream;
 import software.amazon.awssdk.core.async.AsyncResponseTransformer;
 import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.core.metrics.CoreMetric;
 import software.amazon.awssdk.crt.CrtResource;
 import software.amazon.awssdk.crt.Log;
+import software.amazon.awssdk.metrics.MetricCollection;
+import software.amazon.awssdk.metrics.MetricPublisher;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadResponse;
@@ -244,10 +251,58 @@ public class S3CrtClientWiremockTest {
         }
     }
 
+    @Test
+    void getObject_notFound_publishesUnsuccessfulApiCallMetrics(WireMockRuntimeInfo wiremock) throws InterruptedException {
+        stubFor(any(anyUrl()).willReturn(aResponse().withStatus(404).withBody(
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?><Error><Code>NoSuchKey</Code></Error>")));
+
+        CapturingMetricPublisher publisher = new CapturingMetricPublisher();
+        try (S3AsyncClient client = S3AsyncClient.crtBuilder()
+                                                 .region(Region.US_EAST_1)
+                                                 .endpointOverride(URI.create("http://localhost:" + wiremock.getHttpPort()))
+                                                 .credentialsProvider(
+                                                     StaticCredentialsProvider.create(AwsBasicCredentials.create("key", "secret")))
+                                                 .addMetricPublisher(publisher)
+                                                 .build()) {
+
+            assertThatThrownBy(() -> client.getObject(r -> r.bucket(BUCKET).key(KEY),
+                                                      AsyncResponseTransformer.toBytes()).join())
+                .hasRootCauseInstanceOf(S3Exception.class);
+
+            List<MetricCollection> collections = publisher.awaitAtLeast(1, Duration.ofSeconds(10));
+            assertThat(collections).anySatisfy(c -> {
+                assertThat(c.name()).isEqualTo("ApiCall");
+                assertThat(c.metricValues(CoreMetric.SERVICE_ID)).containsExactly("S3");
+                assertThat(c.metricValues(CoreMetric.API_CALL_SUCCESSFUL)).contains(false);
+            });
+        }
+    }
+
     private static class SpyableExecutor implements Executor {
         @Override
         public void execute(Runnable command) {
             command.run();
+        }
+    }
+
+    private static final class CapturingMetricPublisher implements MetricPublisher {
+        private final List<MetricCollection> collections = new CopyOnWriteArrayList<>();
+
+        @Override
+        public void publish(MetricCollection metricCollection) {
+            collections.add(metricCollection);
+        }
+
+        @Override
+        public void close() {
+        }
+
+        List<MetricCollection> awaitAtLeast(int min, Duration timeout) throws InterruptedException {
+            long deadlineNanos = System.nanoTime() + timeout.toNanos();
+            while (collections.size() < min && System.nanoTime() < deadlineNanos) {
+                Thread.sleep(50);
+            }
+            return new ArrayList<>(collections);
         }
     }
 }

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crt/S3CrtMetricPublisherResolutionTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crt/S3CrtMetricPublisherResolutionTest.java
@@ -1,0 +1,239 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.s3.internal.crt;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
+import software.amazon.awssdk.metrics.MetricCollection;
+import software.amazon.awssdk.metrics.MetricPublisher;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.internal.multipart.CopyObjectHelper;
+import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadRequest;
+import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadResponse;
+import software.amazon.awssdk.services.s3.model.CopyObjectRequest;
+import software.amazon.awssdk.services.s3.model.CopyObjectResponse;
+import software.amazon.awssdk.services.s3.model.CopyPartResult;
+import software.amazon.awssdk.services.s3.model.CreateMultipartUploadRequest;
+import software.amazon.awssdk.services.s3.model.CreateMultipartUploadResponse;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
+import software.amazon.awssdk.services.s3.model.UploadPartCopyRequest;
+import software.amazon.awssdk.services.s3.model.UploadPartCopyResponse;
+
+/**
+ * Unit tests for request-level metric-publisher support on the CRT client: publisher resolution, the transforms that
+ * move request-level publishers off the request, and copyObject-wrapper propagation.
+ */
+public class S3CrtMetricPublisherResolutionTest {
+
+    private static final long PART_SIZE = 1024L;
+    private static final long UPLOAD_THRESHOLD = PART_SIZE * 2;
+
+    private static MetricPublisher publisher(String name) {
+        return new MetricPublisher() {
+            @Override
+            public void publish(MetricCollection metricCollection) {
+            }
+
+            @Override
+            public void close() {
+            }
+
+            @Override
+            public String toString() {
+                return name;
+            }
+        };
+    }
+
+    // ---- effective-publisher resolution matrix ----
+
+    @Test
+    public void resolveEffectiveMetricPublishers_noPublishers_returnsEmpty() {
+        assertThat(S3CrtAsyncHttpClient.resolveEffectiveMetricPublishers(emptyList(), emptyList())).isEmpty();
+        assertThat(S3CrtAsyncHttpClient.resolveEffectiveMetricPublishers(null, emptyList())).isEmpty();
+    }
+
+    @Test
+    public void resolveEffectiveMetricPublishers_requestLevelOnly_usesRequestLevel() {
+        MetricPublisher request = publisher("request");
+        assertThat(S3CrtAsyncHttpClient.resolveEffectiveMetricPublishers(singletonList(request), emptyList()))
+            .containsExactly(request);
+    }
+
+    @Test
+    public void resolveEffectiveMetricPublishers_clientLevelOnly_usesClientLevel() {
+        MetricPublisher client = publisher("client");
+        assertThat(S3CrtAsyncHttpClient.resolveEffectiveMetricPublishers(emptyList(), singletonList(client)))
+            .containsExactly(client);
+        assertThat(S3CrtAsyncHttpClient.resolveEffectiveMetricPublishers(null, singletonList(client)))
+            .containsExactly(client);
+    }
+
+    @Test
+    public void resolveEffectiveMetricPublishers_requestAndClientLevel_requestTakesPrecedence() {
+        MetricPublisher client = publisher("client");
+        MetricPublisher request = publisher("request");
+        assertThat(S3CrtAsyncHttpClient.resolveEffectiveMetricPublishers(singletonList(request), singletonList(client)))
+            .containsExactly(request);
+    }
+
+    // ---- wrapper transform: request-level publishers are moved off the request (so the inner client stays no-op) ----
+
+    @Test
+    public void stash_movesRequestPublishersToExecutionAttributeAndStripsOverride() {
+        MetricPublisher request = publisher("request");
+        GetObjectRequest in = GetObjectRequest.builder()
+                                              .bucket("b").key("k")
+                                              .overrideConfiguration(o -> o.addMetricPublisher(request))
+                                              .build();
+
+        GetObjectRequest out = DefaultS3CrtAsyncClient.stashRequestMetricPublishers(in);
+
+        // stripped off the override so the inner standard client's resolveMetricPublishers() sees nothing
+        assertThat(out.overrideConfiguration().get().metricPublishers()).isEmpty();
+        // stashed in the execution attribute the CRT transport reads
+        assertThat(out.overrideConfiguration().get().executionAttributes()
+                      .getAttribute(DefaultS3CrtAsyncClient.REQUEST_METRIC_PUBLISHERS))
+            .containsExactly(request);
+    }
+
+    @Test
+    public void stash_noOverrideConfiguration_returnsSameRequest() {
+        GetObjectRequest in = GetObjectRequest.builder().bucket("b").key("k").build();
+        assertThat(DefaultS3CrtAsyncClient.stashRequestMetricPublishers(in)).isSameAs(in);
+    }
+
+    @Test
+    public void stash_overrideWithoutPublishers_returnsSameRequest() {
+        GetObjectRequest in = GetObjectRequest.builder()
+                                              .bucket("b").key("k")
+                                              .overrideConfiguration(o -> o.putRawQueryParameter("x", "y"))
+                                              .build();
+        assertThat(DefaultS3CrtAsyncClient.stashRequestMetricPublishers(in)).isSameAs(in);
+    }
+
+    // ---- putRequestMetricPublishers: attaches a copy's request-level publishers to each copy sub-request ----
+
+    @Test
+    public void put_addsAttributeAndClearsInlinePublishers_whenRequestHasNoOverride() {
+        MetricPublisher request = publisher("request");
+        GetObjectRequest in = GetObjectRequest.builder().bucket("b").key("k").build();
+
+        GetObjectRequest out = DefaultS3CrtAsyncClient.putRequestMetricPublishers(in, singletonList(request));
+
+        assertThat(out.overrideConfiguration()).isPresent();
+        assertThat(out.overrideConfiguration().get().metricPublishers()).isEmpty();
+        assertThat(out.overrideConfiguration().get().executionAttributes()
+                      .getAttribute(DefaultS3CrtAsyncClient.REQUEST_METRIC_PUBLISHERS))
+            .containsExactly(request);
+    }
+
+    @Test
+    public void put_stripsInlinePublishers_soInnerPipelineStaysNoOp() {
+        MetricPublisher inline = publisher("inline");
+        MetricPublisher request = publisher("request");
+        GetObjectRequest in = GetObjectRequest.builder()
+                                              .bucket("b").key("k")
+                                              .overrideConfiguration(o -> o.addMetricPublisher(inline))
+                                              .build();
+
+        GetObjectRequest out = DefaultS3CrtAsyncClient.putRequestMetricPublishers(in, singletonList(request));
+
+        // inline publishers removed so the inner standard client's resolveMetricPublishers() stays empty (no leak)
+        assertThat(out.overrideConfiguration().get().metricPublishers()).isEmpty();
+        // the transport reads these to publish CRT telemetry to the request-level publishers
+        assertThat(out.overrideConfiguration().get().executionAttributes()
+                      .getAttribute(DefaultS3CrtAsyncClient.REQUEST_METRIC_PUBLISHERS))
+            .containsExactly(request);
+    }
+
+    // ---- copyObject wrapper: the injecting client attaches the copy's publishers to every sub-request ----
+
+    @Test
+    public void injectingClient_multipartCopy_attachesRequestPublishersToEveryPartCopy() {
+        MetricPublisher request = publisher("request");
+        S3AsyncClient delegate = mock(S3AsyncClient.class);
+        // A 4000-byte source with a 1024 part size and 2048 threshold fans out into 4 UploadPartCopy sub-requests.
+        when(delegate.headObject(any(HeadObjectRequest.class)))
+            .thenReturn(CompletableFuture.completedFuture(HeadObjectResponse.builder().contentLength(4000L).build()));
+        when(delegate.createMultipartUpload(any(CreateMultipartUploadRequest.class)))
+            .thenReturn(CompletableFuture.completedFuture(CreateMultipartUploadResponse.builder().uploadId("mpu").build()));
+        when(delegate.uploadPartCopy(any(UploadPartCopyRequest.class)))
+            .thenReturn(CompletableFuture.completedFuture(
+                UploadPartCopyResponse.builder().copyPartResult(CopyPartResult.builder().build()).build()));
+        when(delegate.completeMultipartUpload(any(CompleteMultipartUploadRequest.class)))
+            .thenReturn(CompletableFuture.completedFuture(CompleteMultipartUploadResponse.builder().build()));
+
+        copyThrough(delegate, request);
+
+        ArgumentCaptor<UploadPartCopyRequest> captor = ArgumentCaptor.forClass(UploadPartCopyRequest.class);
+        verify(delegate, times(4)).uploadPartCopy(captor.capture());
+        assertThat(captor.getAllValues())
+            .allSatisfy(part -> assertCarriesRequestPublishers(part.overrideConfiguration().orElse(null), request));
+    }
+
+    @Test
+    public void injectingClient_singlePartCopy_attachesRequestPublishersToCopyRequest() {
+        MetricPublisher request = publisher("request");
+        S3AsyncClient delegate = mock(S3AsyncClient.class);
+        // A 500-byte source stays under the threshold, so it is a single CopyObject sub-request.
+        when(delegate.headObject(any(HeadObjectRequest.class)))
+            .thenReturn(CompletableFuture.completedFuture(HeadObjectResponse.builder().contentLength(500L).build()));
+        when(delegate.copyObject(any(CopyObjectRequest.class)))
+            .thenReturn(CompletableFuture.completedFuture(CopyObjectResponse.builder().build()));
+
+        copyThrough(delegate, request);
+
+        ArgumentCaptor<CopyObjectRequest> captor = ArgumentCaptor.forClass(CopyObjectRequest.class);
+        verify(delegate).copyObject(captor.capture());
+        assertCarriesRequestPublishers(captor.getValue().overrideConfiguration().orElse(null), request);
+    }
+
+    private static void copyThrough(S3AsyncClient delegate, MetricPublisher requestPublisher) {
+        S3AsyncClient injecting =
+            new DefaultS3CrtAsyncClient.RequestMetricPublisherInjectingClient(delegate, singletonList(requestPublisher));
+        new CopyObjectHelper(injecting, PART_SIZE, UPLOAD_THRESHOLD).copyObject(copyObjectRequest()).join();
+    }
+
+    private static void assertCarriesRequestPublishers(AwsRequestOverrideConfiguration override, MetricPublisher expected) {
+        assertThat(override).isNotNull();
+        // inline publishers are cleared so the inner standard client's pipeline stays no-op (no hollow ApiCall)
+        assertThat(override.metricPublishers()).isEmpty();
+        // and the request-level publishers ride the execution attribute the CRT transport reads
+        assertThat(override.executionAttributes().getAttribute(DefaultS3CrtAsyncClient.REQUEST_METRIC_PUBLISHERS))
+            .containsExactly(expected);
+    }
+
+    private static CopyObjectRequest copyObjectRequest() {
+        return CopyObjectRequest.builder()
+                                .sourceBucket("source").sourceKey("sourceKey")
+                                .destinationBucket("destination").destinationKey("destinationKey")
+                                .build();
+    }
+}

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crt/S3CrtMetricPublisherResolutionTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/internal/crt/S3CrtMetricPublisherResolutionTest.java
@@ -18,41 +18,17 @@ package software.amazon.awssdk.services.s3.internal.crt;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
-import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
-import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
 import software.amazon.awssdk.metrics.MetricCollection;
 import software.amazon.awssdk.metrics.MetricPublisher;
-import software.amazon.awssdk.services.s3.S3AsyncClient;
-import software.amazon.awssdk.services.s3.internal.multipart.CopyObjectHelper;
-import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadRequest;
-import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadResponse;
 import software.amazon.awssdk.services.s3.model.CopyObjectRequest;
-import software.amazon.awssdk.services.s3.model.CopyObjectResponse;
-import software.amazon.awssdk.services.s3.model.CopyPartResult;
-import software.amazon.awssdk.services.s3.model.CreateMultipartUploadRequest;
-import software.amazon.awssdk.services.s3.model.CreateMultipartUploadResponse;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
-import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
-import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
-import software.amazon.awssdk.services.s3.model.UploadPartCopyRequest;
-import software.amazon.awssdk.services.s3.model.UploadPartCopyResponse;
 
 /**
- * Unit tests for request-level metric-publisher support on the CRT client: publisher resolution, the transforms that
- * move request-level publishers off the request, and copyObject-wrapper propagation.
+ * Unit tests for request-level metric-publisher support on the CRT client.
  */
 public class S3CrtMetricPublisherResolutionTest {
-
-    private static final long PART_SIZE = 1024L;
-    private static final long UPLOAD_THRESHOLD = PART_SIZE * 2;
 
     private static MetricPublisher publisher(String name) {
         return new MetricPublisher() {
@@ -103,7 +79,7 @@ public class S3CrtMetricPublisherResolutionTest {
             .containsExactly(request);
     }
 
-    // ---- wrapper transform: request-level publishers are moved off the request (so the inner client stays no-op) ----
+    // ---- stashRequestMetricPublishers: move publishers off the request into the execution attribute ----
 
     @Test
     public void stash_movesRequestPublishersToExecutionAttributeAndStripsOverride() {
@@ -124,6 +100,23 @@ public class S3CrtMetricPublisherResolutionTest {
     }
 
     @Test
+    public void stash_copyObjectRequest_movesPublishersOffOverrideIntoAttribute() {
+        MetricPublisher request = publisher("request");
+        CopyObjectRequest in = CopyObjectRequest.builder()
+                                                .sourceBucket("src").sourceKey("k")
+                                                .destinationBucket("dst").destinationKey("k2")
+                                                .overrideConfiguration(o -> o.addMetricPublisher(request))
+                                                .build();
+
+        CopyObjectRequest out = DefaultS3CrtAsyncClient.stashRequestMetricPublishers(in);
+
+        assertThat(out.overrideConfiguration().get().metricPublishers()).isEmpty();
+        assertThat(out.overrideConfiguration().get().executionAttributes()
+                      .getAttribute(DefaultS3CrtAsyncClient.REQUEST_METRIC_PUBLISHERS))
+            .containsExactly(request);
+    }
+
+    @Test
     public void stash_noOverrideConfiguration_returnsSameRequest() {
         GetObjectRequest in = GetObjectRequest.builder().bucket("b").key("k").build();
         assertThat(DefaultS3CrtAsyncClient.stashRequestMetricPublishers(in)).isSameAs(in);
@@ -136,104 +129,5 @@ public class S3CrtMetricPublisherResolutionTest {
                                               .overrideConfiguration(o -> o.putRawQueryParameter("x", "y"))
                                               .build();
         assertThat(DefaultS3CrtAsyncClient.stashRequestMetricPublishers(in)).isSameAs(in);
-    }
-
-    // ---- putRequestMetricPublishers: attaches a copy's request-level publishers to each copy sub-request ----
-
-    @Test
-    public void put_addsAttributeAndClearsInlinePublishers_whenRequestHasNoOverride() {
-        MetricPublisher request = publisher("request");
-        GetObjectRequest in = GetObjectRequest.builder().bucket("b").key("k").build();
-
-        GetObjectRequest out = DefaultS3CrtAsyncClient.putRequestMetricPublishers(in, singletonList(request));
-
-        assertThat(out.overrideConfiguration()).isPresent();
-        assertThat(out.overrideConfiguration().get().metricPublishers()).isEmpty();
-        assertThat(out.overrideConfiguration().get().executionAttributes()
-                      .getAttribute(DefaultS3CrtAsyncClient.REQUEST_METRIC_PUBLISHERS))
-            .containsExactly(request);
-    }
-
-    @Test
-    public void put_stripsInlinePublishers_soInnerPipelineStaysNoOp() {
-        MetricPublisher inline = publisher("inline");
-        MetricPublisher request = publisher("request");
-        GetObjectRequest in = GetObjectRequest.builder()
-                                              .bucket("b").key("k")
-                                              .overrideConfiguration(o -> o.addMetricPublisher(inline))
-                                              .build();
-
-        GetObjectRequest out = DefaultS3CrtAsyncClient.putRequestMetricPublishers(in, singletonList(request));
-
-        // inline publishers removed so the inner standard client's resolveMetricPublishers() stays empty (no leak)
-        assertThat(out.overrideConfiguration().get().metricPublishers()).isEmpty();
-        // the transport reads these to publish CRT telemetry to the request-level publishers
-        assertThat(out.overrideConfiguration().get().executionAttributes()
-                      .getAttribute(DefaultS3CrtAsyncClient.REQUEST_METRIC_PUBLISHERS))
-            .containsExactly(request);
-    }
-
-    // ---- copyObject wrapper: the injecting client attaches the copy's publishers to every sub-request ----
-
-    @Test
-    public void injectingClient_multipartCopy_attachesRequestPublishersToEveryPartCopy() {
-        MetricPublisher request = publisher("request");
-        S3AsyncClient delegate = mock(S3AsyncClient.class);
-        // A 4000-byte source with a 1024 part size and 2048 threshold fans out into 4 UploadPartCopy sub-requests.
-        when(delegate.headObject(any(HeadObjectRequest.class)))
-            .thenReturn(CompletableFuture.completedFuture(HeadObjectResponse.builder().contentLength(4000L).build()));
-        when(delegate.createMultipartUpload(any(CreateMultipartUploadRequest.class)))
-            .thenReturn(CompletableFuture.completedFuture(CreateMultipartUploadResponse.builder().uploadId("mpu").build()));
-        when(delegate.uploadPartCopy(any(UploadPartCopyRequest.class)))
-            .thenReturn(CompletableFuture.completedFuture(
-                UploadPartCopyResponse.builder().copyPartResult(CopyPartResult.builder().build()).build()));
-        when(delegate.completeMultipartUpload(any(CompleteMultipartUploadRequest.class)))
-            .thenReturn(CompletableFuture.completedFuture(CompleteMultipartUploadResponse.builder().build()));
-
-        copyThrough(delegate, request);
-
-        ArgumentCaptor<UploadPartCopyRequest> captor = ArgumentCaptor.forClass(UploadPartCopyRequest.class);
-        verify(delegate, times(4)).uploadPartCopy(captor.capture());
-        assertThat(captor.getAllValues())
-            .allSatisfy(part -> assertCarriesRequestPublishers(part.overrideConfiguration().orElse(null), request));
-    }
-
-    @Test
-    public void injectingClient_singlePartCopy_attachesRequestPublishersToCopyRequest() {
-        MetricPublisher request = publisher("request");
-        S3AsyncClient delegate = mock(S3AsyncClient.class);
-        // A 500-byte source stays under the threshold, so it is a single CopyObject sub-request.
-        when(delegate.headObject(any(HeadObjectRequest.class)))
-            .thenReturn(CompletableFuture.completedFuture(HeadObjectResponse.builder().contentLength(500L).build()));
-        when(delegate.copyObject(any(CopyObjectRequest.class)))
-            .thenReturn(CompletableFuture.completedFuture(CopyObjectResponse.builder().build()));
-
-        copyThrough(delegate, request);
-
-        ArgumentCaptor<CopyObjectRequest> captor = ArgumentCaptor.forClass(CopyObjectRequest.class);
-        verify(delegate).copyObject(captor.capture());
-        assertCarriesRequestPublishers(captor.getValue().overrideConfiguration().orElse(null), request);
-    }
-
-    private static void copyThrough(S3AsyncClient delegate, MetricPublisher requestPublisher) {
-        S3AsyncClient injecting =
-            new DefaultS3CrtAsyncClient.RequestMetricPublisherInjectingClient(delegate, singletonList(requestPublisher));
-        new CopyObjectHelper(injecting, PART_SIZE, UPLOAD_THRESHOLD).copyObject(copyObjectRequest()).join();
-    }
-
-    private static void assertCarriesRequestPublishers(AwsRequestOverrideConfiguration override, MetricPublisher expected) {
-        assertThat(override).isNotNull();
-        // inline publishers are cleared so the inner standard client's pipeline stays no-op (no hollow ApiCall)
-        assertThat(override.metricPublishers()).isEmpty();
-        // and the request-level publishers ride the execution attribute the CRT transport reads
-        assertThat(override.executionAttributes().getAttribute(DefaultS3CrtAsyncClient.REQUEST_METRIC_PUBLISHERS))
-            .containsExactly(expected);
-    }
-
-    private static CopyObjectRequest copyObjectRequest() {
-        return CopyObjectRequest.builder()
-                                .sourceBucket("source").sourceKey("sourceKey")
-                                .destinationBucket("destination").destinationKey("destinationKey")
-                                .build();
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Follow-up to the client-level MetricPublisher support (#7299). This adds request-level metric publishers to the S3 CRT-based client: a publisher attached to a single request via `overrideConfiguration(o -> o.addMetricPublisher(...))` now receives that request's CRT telemetry, matching the standard S3 client. When a request sets its own publishers, they take precedence over the client-level ones for that request; an empty request-level list falls back to the client-level publishers, same as the standard client.

## Modifications
Request-level publishers are moved off the request's override configuration and routed to the CRT
transport, so the inner standard client stays publisher-free (no hollow, duplicate ApiCall metric) and
telemetry is published from `onTelemetry`, once per underlying CRT request.
- `DefaultS3CrtAsyncClient`
  - `invokeOperation` strips the request-level publishers off the override via`stashRequestMetricPublishers` and stashes them in a request execution attribute; an interceptor bridges that to the transport's SDK-HTTP attribute.
  - `copyObject` stashes once at the entry point. `copyObject`'s sub-requests bypass `invokeOperation`, so a single stash there plus the copy helper's existing override propagation carries the publishers to every sub-request, with no per-sub-request wrapper.
  - Removed the interceptor guard that rejected request-level metric publishers.
- `S3CrtAsyncHttpClient` resolves request-level vs client-level publishers (request-level takes precedence) and folds the effective set back into the execution attributes for the response adapter.
- `CopyObjectHelper` now propagates the copy request's override configuration to the tagging and annotation sub-requests (`GetObjectTagging` / `PutObjectTagging` / annotation reads and writes), which were previously built without it. This was a pre-existing gap: an override set on a copy was silently dropped for those sub-requests, so their CRT telemetry never reached a request-level publisher. All copy sub-requests (head / create / part-copies / complete, and now tagging / annotation) inherit the copy's override.

## Testing

- Unit (`S3CrtMetricPublisherResolutionTest`): the resolution matrix (none / client-only / request-only / request-overrides-client) and the stash transform (for a normal operation and for `copyObject`).
- Integration (`S3CrtClientMetricPublisherIntegrationTest`): client-level single-part / multipart get, put, and failed paths; request-level `getObject` and `copyObject` publish to the request-level publisher while the client-level one is bypassed; and a tagging-directive copy verifies its`GetObjectTagging` and `PutObjectTagging` sub-requests publish to the request-level publisher, exercising the `CopyObjectHelper` propagation fix end to end.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
