### PR TITLE
[Default Read/Write Timeout 1/N] Add the rollout gate

### DIFF
--- a/codegen/src/main/java/software/amazon/awssdk/codegen/model/config/customization/CustomizationConfig.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/model/config/customization/CustomizationConfig.java
@@ -231,6 +231,11 @@ public class CustomizationConfig {
     private Boolean defaultNewRetries2026;
 
     /**
+     * Whether the client will apply a default read/write timeout by default.
+     */
+    private Boolean defaultEnableReadTimeout2026;
+
+    /**
      * Whether to generate an abstract decorator class that delegates to the async service client
      */
     private boolean delegateAsyncClientClass;
@@ -735,6 +740,14 @@ public class CustomizationConfig {
 
     public void setDefaultNewRetries2026(Boolean defaultNewRetries2026) {
         this.defaultNewRetries2026 = defaultNewRetries2026;
+    }
+
+    public Boolean getDefaultEnableReadTimeout2026() {
+        return defaultEnableReadTimeout2026;
+    }
+
+    public void setDefaultEnableReadTimeout2026(Boolean defaultEnableReadTimeout2026) {
+        this.defaultEnableReadTimeout2026 = defaultEnableReadTimeout2026;
     }
 
     public ServiceConfig getServiceConfig() {

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/builder/BaseClientBuilderClass.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/builder/BaseClientBuilderClass.java
@@ -48,6 +48,7 @@ import software.amazon.awssdk.awscore.client.builder.AwsDefaultClientBuilder;
 import software.amazon.awssdk.awscore.client.config.AwsClientOption;
 import software.amazon.awssdk.awscore.endpoint.AwsClientEndpointProvider;
 import software.amazon.awssdk.codegen.internal.Utils;
+import software.amazon.awssdk.codegen.model.config.customization.CustomizationConfig;
 import software.amazon.awssdk.codegen.model.intermediate.IntermediateModel;
 import software.amazon.awssdk.codegen.model.intermediate.OperationModel;
 import software.amazon.awssdk.codegen.model.rules.endpoints.BuiltInParameter;
@@ -330,9 +331,10 @@ public class BaseClientBuilderClass implements ClassSpec {
         String userAgent = model.getCustomizationConfig().getUserAgent();
         RetryMode defaultRetryMode = model.getCustomizationConfig().getDefaultRetryMode();
         Boolean defaultNewRetries2026 = model.getCustomizationConfig().getDefaultNewRetries2026();
+        Boolean defaultEnableReadTimeout2026 = model.getCustomizationConfig().getDefaultEnableReadTimeout2026();
 
         // If none of the options are customized, then we do not need to bother overriding the method
-        if (userAgent == null && defaultRetryMode == null && defaultNewRetries2026 == null) {
+        if (!hasInternalDefaults()) {
             return Optional.empty();
         }
 
@@ -354,8 +356,20 @@ public class BaseClientBuilderClass implements ClassSpec {
             builder.addCode("c.option($T.DEFAULT_NEW_RETRIES_2026, $L);\n",
                             SdkClientOption.class, defaultNewRetries2026);
         }
+        if (defaultEnableReadTimeout2026 != null) {
+            builder.addCode("c.option($T.DEFAULT_ENABLE_READ_TIMEOUT_2026, $L);\n",
+                            SdkClientOption.class, defaultEnableReadTimeout2026);
+        }
         builder.addCode("});\n");
         return Optional.of(builder.build());
+    }
+
+    private boolean hasInternalDefaults() {
+        CustomizationConfig customizationConfig = model.getCustomizationConfig();
+        return customizationConfig.getUserAgent() != null
+               || customizationConfig.getDefaultRetryMode() != null
+               || customizationConfig.getDefaultNewRetries2026() != null
+               || customizationConfig.getDefaultEnableReadTimeout2026() != null;
     }
 
     private MethodSpec finalizeServiceConfigurationMethod() {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-client-builder-internal-defaults-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-client-builder-internal-defaults-class.java
@@ -77,6 +77,7 @@ abstract class DefaultJsonBaseClientBuilder<B extends JsonBaseClientBuilder<B, C
             c.option(SdkClientOption.INTERNAL_USER_AGENT, "md/foobar");
             c.option(SdkClientOption.DEFAULT_RETRY_MODE, RetryMode.STANDARD);
             c.option(SdkClientOption.DEFAULT_NEW_RETRIES_2026, true);
+            c.option(SdkClientOption.DEFAULT_ENABLE_READ_TIMEOUT_2026, true);
         });
     }
 

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/internalconfig/customization.config
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/internalconfig/customization.config
@@ -4,5 +4,6 @@
     },
     "userAgent": "md/foobar",
     "defaultRetryMode": "STANDARD",
-    "defaultNewRetries2026": "true"
+    "defaultNewRetries2026": "true",
+    "defaultEnableReadTimeout2026": "true"
 }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/SdkSystemSetting.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/SdkSystemSetting.java
@@ -276,7 +276,17 @@ public enum SdkSystemSetting implements SystemSetting {
      * defaults including STANDARD as the default retry mode, reduced base backoff delays, differentiated token bucket
      * costs, and other v2.1 retry specification changes. When {@code false} (the default), the SDK uses v2.0 retry behavior.
      */
-    AWS_NEW_RETRIES_2026("aws.newRetries2026", null);
+    AWS_NEW_RETRIES_2026("aws.newRetries2026", null),
+
+    /**
+     * Configure whether a default read/write inactivity timeout is applied to HTTP clients that do not enforce one of their
+     * own (currently the AWS CRT-based clients). When {@code true}, such clients shut down a connection that transfers no
+     * bytes for the resolved timeout window. When {@code false} (the default), no default read/write timeout is applied.
+     *
+     * <p>This setting is not intended to be used by end users. It gates an interim rollout and is subject to removal in a
+     * future release.
+     */
+    AWS_ENABLE_DEFAULT_READ_TIMEOUT_2026("aws.enableDefaultReadTimeout2026", null);
 
     private final String systemProperty;
     private final String defaultValue;

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/config/SdkClientOption.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/config/SdkClientOption.java
@@ -312,6 +312,13 @@ public final class SdkClientOption<T> extends ClientOption<T> {
     public static final SdkClientOption<Boolean> DEFAULT_NEW_RETRIES_2026 = new SdkClientOption<>(Boolean.class);
 
     /**
+     * Option to specify the default for the {@code AWS_ENABLE_DEFAULT_READ_TIMEOUT_2026} feature gate for the SDK client.
+     * This option is not intended to be set by end users. It gates an interim rollout and is subject to removal in a future
+     * release.
+     */
+    public static final SdkClientOption<Boolean> DEFAULT_ENABLE_READ_TIMEOUT_2026 = new SdkClientOption<>(Boolean.class);
+
+    /**
      * Whether retries 2.1 behavior is enabled.
      */
     public static final SdkClientOption<Boolean> NEW_RETRIES_2026_ENABLED = new SdkClientOption<>(Boolean.class);

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/http/EnableDefaultReadTimeout2026Resolver.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/http/EnableDefaultReadTimeout2026Resolver.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.http;
+
+import java.util.Optional;
+import software.amazon.awssdk.annotations.SdkProtectedApi;
+import software.amazon.awssdk.core.SdkSystemSetting;
+
+/**
+ * Resolver for the {@link SdkSystemSetting#AWS_ENABLE_DEFAULT_READ_TIMEOUT_2026} that supports setting a fallback value if not
+ * defined in the environment or system properties.
+ */
+@SdkProtectedApi
+public final class EnableDefaultReadTimeout2026Resolver {
+    private Boolean defaultEnableReadTimeout2026;
+
+    /**
+     * The default value for {@code AWS_ENABLE_DEFAULT_READ_TIMEOUT_2026} if not configured via
+     * {@link SdkSystemSetting#AWS_ENABLE_DEFAULT_READ_TIMEOUT_2026}.
+     *
+     * @return This resolver for method chaining.
+     */
+    public EnableDefaultReadTimeout2026Resolver defaultEnableReadTimeout2026(Boolean defaultEnableReadTimeout2026) {
+        this.defaultEnableReadTimeout2026 = defaultEnableReadTimeout2026;
+        return this;
+    }
+
+    /**
+     * Resolve whether a default read/write timeout is applied.
+     */
+    public boolean resolve() {
+        Optional<Boolean> envConfig = SdkSystemSetting.AWS_ENABLE_DEFAULT_READ_TIMEOUT_2026.getBooleanValue();
+
+        if (envConfig.isPresent()) {
+            return envConfig.get();
+        }
+
+        if (defaultEnableReadTimeout2026 != null) {
+            return defaultEnableReadTimeout2026;
+        }
+
+        return false;
+    }
+}

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/http/EnableDefaultReadTimeout2026ResolverTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/http/EnableDefaultReadTimeout2026ResolverTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.http;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import software.amazon.awssdk.core.SdkSystemSetting;
+import software.amazon.awssdk.testutils.EnvironmentVariableHelper;
+
+public class EnableDefaultReadTimeout2026ResolverTest {
+    private static String enableDefaultReadTimeout2026Save;
+
+    @BeforeAll
+    static void setup() {
+        enableDefaultReadTimeout2026Save = System.getProperty(SdkSystemSetting.AWS_ENABLE_DEFAULT_READ_TIMEOUT_2026.property());
+    }
+
+    @AfterAll
+    static void teardown() {
+        if (enableDefaultReadTimeout2026Save != null) {
+            System.setProperty(SdkSystemSetting.AWS_ENABLE_DEFAULT_READ_TIMEOUT_2026.property(),
+                               enableDefaultReadTimeout2026Save);
+        } else {
+            System.clearProperty(SdkSystemSetting.AWS_ENABLE_DEFAULT_READ_TIMEOUT_2026.property());
+        }
+    }
+
+    @BeforeEach
+    void methodSetup() {
+        System.clearProperty(SdkSystemSetting.AWS_ENABLE_DEFAULT_READ_TIMEOUT_2026.property());
+    }
+
+    @Test
+    void systemSetting_usesExpectedEnvironmentVariableAndSystemPropertyNames() {
+        assertThat(SdkSystemSetting.AWS_ENABLE_DEFAULT_READ_TIMEOUT_2026.environmentVariable())
+            .isEqualTo("AWS_ENABLE_DEFAULT_READ_TIMEOUT_2026");
+        assertThat(SdkSystemSetting.AWS_ENABLE_DEFAULT_READ_TIMEOUT_2026.property())
+            .isEqualTo("aws.enableDefaultReadTimeout2026");
+    }
+
+    @ParameterizedTest
+    @MethodSource("params")
+    void resolve_behavesCorrectly(TestParams params) {
+        EnvironmentVariableHelper.run((env) -> {
+            if (params.systemProperty != null) {
+                System.setProperty(SdkSystemSetting.AWS_ENABLE_DEFAULT_READ_TIMEOUT_2026.property(), params.systemProperty);
+            }
+
+            if (params.envVar != null) {
+                env.set(SdkSystemSetting.AWS_ENABLE_DEFAULT_READ_TIMEOUT_2026.environmentVariable(), params.envVar);
+            }
+
+            EnableDefaultReadTimeout2026Resolver resolver =
+                new EnableDefaultReadTimeout2026Resolver().defaultEnableReadTimeout2026(params.defaultEnableReadTimeout2026);
+
+            assertThat(resolver.resolve()).isEqualTo(params.expected);
+        });
+    }
+
+    private static Stream<TestParams> params() {
+        return Stream.of(
+            // default
+            new TestParams().expected(false),
+
+            // precedence testing
+            new TestParams().systemProperty("true").defaultEnableReadTimeout2026(true).expected(true),
+            new TestParams().systemProperty("false").defaultEnableReadTimeout2026(true).expected(false),
+            new TestParams().envVar("true").defaultEnableReadTimeout2026(true).expected(true),
+            new TestParams().envVar("false").defaultEnableReadTimeout2026(true).expected(false),
+            new TestParams().defaultEnableReadTimeout2026(true).expected(true),
+            new TestParams().defaultEnableReadTimeout2026(false).expected(false)
+        );
+    }
+
+    private static class TestParams {
+        private String systemProperty;
+        private String envVar;
+        private Boolean defaultEnableReadTimeout2026;
+        private boolean expected;
+
+        public TestParams systemProperty(String systemProperty) {
+            this.systemProperty = systemProperty;
+            return this;
+        }
+
+        public TestParams envVar(String envVar) {
+            this.envVar = envVar;
+            return this;
+        }
+
+        public TestParams defaultEnableReadTimeout2026(Boolean defaultEnableReadTimeout2026) {
+            this.defaultEnableReadTimeout2026 = defaultEnableReadTimeout2026;
+            return this;
+        }
+
+        public TestParams expected(boolean expected) {
+            this.expected = expected;
+            return this;
+        }
+    }
+}


### PR DESCRIPTION
## Motivation and Context

The AWS CRT-based HTTP clients apply no default socket read/write timeout, so there is currently no upper bound on how long a read waits when a peer stops sending: a slow or unresponsive peer can cause a request to wait longer than intended. The broader effort adds a default read/write inactivity timeout to those clients, introduced behind a feature gate that is off by default and opt-in via an environment variable, so the behavior change can be introduced gradually.

This PR is the first increment and adds only the rollout-gate plumbing: the gate symbols and the code-generation hook. Nothing consumes the gate yet; the HTTP client behavior (mapping an inactivity timeout onto the CRT throughput monitor), the `aws-core` gate application, and the per-service exemptions follow in later increments.

The gate mirrors the existing `AWS_NEW_RETRIES_2026` mechanism end to end (system setting + resolver + `DEFAULT_*` client option + codegen customization field), reusing the same rollout pattern the SDK already ships.

Base branch: this is an incremental PR and targets `feature/master/2026-enable-default-read-timeout`, not `master`.

## Modifications

`core/sdk-core`:
- `SdkSystemSetting.AWS_ENABLE_DEFAULT_READ_TIMEOUT_2026` — environment variable `AWS_ENABLE_DEFAULT_READ_TIMEOUT_2026`, system property `aws.enableDefaultReadTimeout2026`. Javadoc notes it is not intended for end users and is subject to removal.
- `SdkClientOption.DEFAULT_ENABLE_READ_TIMEOUT_2026` (Boolean) — the client-option fallback the resolver reads, with the same not-for-end-users / subject-to-removal note.
- `EnableDefaultReadTimeout2026Resolver` (`@SdkProtectedApi`, in `software.amazon.awssdk.core.http`) — resolves the gate: environment/system value if present, else the client-option default, else `false`. Structural mirror of `NewRetries2026Resolver`.

`codegen`:
- `CustomizationConfig.defaultEnableReadTimeout2026` field (getter/setter), mirroring `defaultNewRetries2026`.
- `BaseClientBuilderClass` emits `c.option(SdkClientOption.DEFAULT_ENABLE_READ_TIMEOUT_2026, <value>)` into the generated `mergeInternalDefaults` only when the customization field is set, populating the client-option default. The "should we override `mergeInternalDefaults`" guard was extracted into a small `hasInternalDefaults()` helper. The field is unset everywhere in this repository, so the option is never emitted and the gate resolves to off.

No public type is added or changed, and no existing behavior changes: with the field unset everywhere in this repository, the option is never populated and the gate resolves to off.

## Testing

- `EnableDefaultReadTimeout2026ResolverTest` — resolver precedence (environment variable and system property each override the client-option default; the default is used when no environment/system value is present; `false` when nothing is set) plus a check pinning the environment variable and system property names as a rename change-detector.
- `codegen` `BaseClientBuilderClassTest` — the internal-defaults fixture now asserts the generated `mergeInternalDefaults` emits `DEFAULT_ENABLE_READ_TIMEOUT_2026` when the customization field is set.
- Module builds: `core/sdk-core` BUILD SUCCESS; `codegen` BUILD SUCCESS. A full-repo `mvn install` was not run.
- No changelog entry: this increment is gate plumbing with no consumer yet, so there is no customer-observable change to describe. A changelog will accompany the increment that enables the behavior.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
- [x] I confirm that this pull request can be released under the Apache 2 license
