### PR TITLE
[Default Read/Write Timeout 2/N] Apply the read/write timeout in the CRT HTTP client

### DIFF
--- a/http-client-spi/src/main/java/software/amazon/awssdk/http/SdkHttpConfigurationOption.java
+++ b/http-client-spi/src/main/java/software/amazon/awssdk/http/SdkHttpConfigurationOption.java
@@ -42,6 +42,16 @@ public final class SdkHttpConfigurationOption<T> extends AttributeMap.Key<T> {
             new SdkHttpConfigurationOption<>("WriteTimeout", Duration.class);
 
     /**
+     * SDK-internal. A fallback read/write timeout that is honored only by HTTP client implementations which do not
+     * enforce a read/write timeout of their own (currently the AWS CRT-based clients); implementations that already
+     * apply one, such as the Apache and Netty clients, ignore it. Unlike {@link #READ_TIMEOUT}/{@link #WRITE_TIMEOUT},
+     * which carry a caller-configured socket timeout, this value is resolved by the SDK and is not intended to be set by
+     * end users. {@link Duration#ZERO} means no timeout is applied (the service is fully exempt, or the rollout gate is off).
+     */
+    public static final SdkHttpConfigurationOption<Duration> SDK_INTERNAL_FALLBACK_READ_WRITE_TIMEOUT =
+            new SdkHttpConfigurationOption<>("SdkInternalFallbackReadWriteTimeout", Duration.class);
+
+    /**
      * Timeout for establishing a connection to a remote service.
      */
     public static final SdkHttpConfigurationOption<Duration> CONNECTION_TIMEOUT =

--- a/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/AwsCrtAsyncHttpClient.java
+++ b/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/AwsCrtAsyncHttpClient.java
@@ -165,17 +165,19 @@ public final class AwsCrtAsyncHttpClient extends AwsCrtHttpClientBase implements
         AwsCrtAsyncHttpClient.Builder proxyConfiguration(Consumer<ProxyConfiguration.Builder> proxyConfigurationBuilderConsumer);
 
         /**
-         * Configure the health checks for all connections established by this client.
+         * Configure the health checks for all connections established by this client. This is the CRT client's knob for a
+         * read/write inactivity timeout: a connection whose throughput stays below
+         * {@link ConnectionHealthConfiguration#minimumThroughputInBps()} for
+         * {@link ConnectionHealthConfiguration#minimumThroughputTimeout()} is considered unhealthy and shut down, failing the
+         * in-flight request with a retryable {@code IOException}.
          *
-         * <p>
-         * You can set a throughput threshold for a connection to be considered healthy.
-         * If a connection falls below this threshold ({@link ConnectionHealthConfiguration#minimumThroughputInBps()
-         * }) for the configurable amount
-         * of time ({@link ConnectionHealthConfiguration#minimumThroughputTimeout()}),
-         * then the connection is considered unhealthy and will be shut down.
+         * <p>To set a read/write inactivity timeout, use {@code minimumThroughputInBps(1L)} with
+         * {@code minimumThroughputTimeout(yourDuration)}: any byte moved in either direction resets the window, so the connection
+         * is shut down only after {@code yourDuration} elapses with no bytes transferred. The timeout has whole-second
+         * granularity and must be at least two seconds.
          *
-         * <p>
-         * Disabled by default.
+         * <p>Absent an explicit configuration here, a default read/write inactivity timeout may apply; a configuration set here
+         * always takes precedence over that default.
          *
          * @param healthChecksConfiguration The health checks config to use
          * @return The builder of the method chaining.

--- a/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/AwsCrtHttpClient.java
+++ b/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/AwsCrtHttpClient.java
@@ -221,17 +221,19 @@ public final class AwsCrtHttpClient extends AwsCrtHttpClientBase implements SdkH
         AwsCrtHttpClient.Builder proxyConfiguration(Consumer<ProxyConfiguration.Builder> proxyConfigurationBuilderConsumer);
 
         /**
-         * Configure the health checks for all connections established by this client.
+         * Configure the health checks for all connections established by this client. This is the CRT client's knob for a
+         * read/write inactivity timeout: a connection whose throughput stays below
+         * {@link ConnectionHealthConfiguration#minimumThroughputInBps()} for
+         * {@link ConnectionHealthConfiguration#minimumThroughputTimeout()} is considered unhealthy and shut down, failing the
+         * in-flight request with a retryable {@code IOException}.
          *
-         * <p>
-         * You can set a throughput threshold for a connection to be considered healthy.
-         * If a connection falls below this threshold ({@link ConnectionHealthConfiguration#minimumThroughputInBps()
-         * }) for the configurable amount
-         * of time ({@link ConnectionHealthConfiguration#minimumThroughputTimeout()}),
-         * then the connection is considered unhealthy and will be shut down.
+         * <p>To set a read/write inactivity timeout, use {@code minimumThroughputInBps(1L)} with
+         * {@code minimumThroughputTimeout(yourDuration)}: any byte moved in either direction resets the window, so the connection
+         * is shut down only after {@code yourDuration} elapses with no bytes transferred. The timeout has whole-second
+         * granularity and must be at least two seconds.
          *
-         * <p>
-         * Disabled by default.
+         * <p>Absent an explicit configuration here, a default read/write inactivity timeout may apply; a configuration set here
+         * always takes precedence over that default.
          *
          * @param healthChecksConfiguration The health checks config to use
          * @return The builder of the method chaining.

--- a/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/AwsCrtHttpClientBase.java
+++ b/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/AwsCrtHttpClientBase.java
@@ -15,13 +15,13 @@
 
 package software.amazon.awssdk.http.crt;
 
-import static software.amazon.awssdk.crtcore.CrtConfigurationUtils.resolveHttpMonitoringOptions;
 import static software.amazon.awssdk.crtcore.CrtConfigurationUtils.resolveProxy;
 import static software.amazon.awssdk.http.SdkHttpConfigurationOption.PROTOCOL;
 import static software.amazon.awssdk.http.crt.internal.AwsCrtConfigurationUtils.buildSocketOptions;
 import static software.amazon.awssdk.http.crt.internal.AwsCrtConfigurationUtils.buildTlsConnectionOptions;
 import static software.amazon.awssdk.http.crt.internal.AwsCrtConfigurationUtils.resolveCipherPreference;
 import static software.amazon.awssdk.http.crt.internal.AwsCrtConfigurationUtils.resolveMinTlsVersion;
+import static software.amazon.awssdk.http.crt.internal.AwsCrtConfigurationUtils.resolveMonitoringOptions;
 import static software.amazon.awssdk.utils.FunctionalUtils.invokeSafely;
 
 import java.net.URI;
@@ -136,9 +136,9 @@ abstract class AwsCrtHttpClientBase implements SdkAutoCloseable {
             this.readBufferSize = builder.getReadBufferSizeInBytes() == null ?
                                   DEFAULT_STREAM_WINDOW_SIZE : builder.getReadBufferSizeInBytes();
             this.maxStreamsPerEndpoint = config.get(SdkHttpConfigurationOption.MAX_CONNECTIONS);
-            this.monitoringOptions =
-                resolveHttpMonitoringOptions(builder.getConnectionHealthConfiguration())
-                    .orElse(null);
+            this.monitoringOptions = resolveMonitoringOptions(
+                builder.getConnectionHealthConfiguration(),
+                config.get(SdkHttpConfigurationOption.SDK_INTERNAL_FALLBACK_READ_WRITE_TIMEOUT));
             this.maxConnectionIdleInMilliseconds = config.get(SdkHttpConfigurationOption.CONNECTION_MAX_IDLE_TIMEOUT).toMillis();
             this.connectionAcquisitionTimeout = config.get(SdkHttpConfigurationOption.CONNECTION_ACQUIRE_TIMEOUT).toMillis();
             this.proxyOptions = resolveProxy(builder.getProxyConfiguration(), tlsContext).orElse(null);

--- a/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/AwsCrtConfigurationUtils.java
+++ b/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/AwsCrtConfigurationUtils.java
@@ -18,11 +18,14 @@ package software.amazon.awssdk.http.crt.internal;
 
 import java.time.Duration;
 import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.crt.http.HttpMonitoringOptions;
 import software.amazon.awssdk.crt.io.SocketOptions;
 import software.amazon.awssdk.crt.io.TlsCipherPreference;
 import software.amazon.awssdk.crt.io.TlsConnectionOptions;
 import software.amazon.awssdk.crt.io.TlsContext;
 import software.amazon.awssdk.crt.io.TlsContextOptions;
+import software.amazon.awssdk.crtcore.CrtConfigurationUtils;
+import software.amazon.awssdk.http.crt.ConnectionHealthConfiguration;
 import software.amazon.awssdk.http.crt.TcpKeepAliveConfiguration;
 import software.amazon.awssdk.http.crt.TlsVersion;
 import software.amazon.awssdk.utils.Logger;
@@ -32,7 +35,56 @@ import software.amazon.awssdk.utils.NumericUtils;
 public final class AwsCrtConfigurationUtils {
     private static final Logger log = Logger.loggerFor(AwsCrtConfigurationUtils.class);
 
+    // CRT rejects a throughput-failure interval below two seconds (HttpMonitoringOptions).
+    private static final int MIN_MONITORING_FAILURE_INTERVAL_SECONDS = 2;
+
+    // The default read/write inactivity timeout applied on the standalone path (a CRT client not built by a service client)
+    // when the rollout gate is on. On the service-client path this default is supplied above the transport, in aws-core.
+    private static final Duration STANDALONE_DEFAULT_READ_WRITE_TIMEOUT = Duration.ofMinutes(5);
+
     private AwsCrtConfigurationUtils() {
+    }
+
+    /**
+     * Resolves the throughput monitor that enforces a connection's read/write inactivity timeout, highest precedence first:
+     * <ol>
+     *   <li>an explicit {@link ConnectionHealthConfiguration} always wins;</li>
+     *   <li>on the service-client path, the {@code fallbackTimeout}, which aws-core has already resolved against the rollout
+     *   gate, so a present value is post-gate: {@link Duration#ZERO} applies nothing, a positive value is mapped;</li>
+     *   <li>on the standalone path ({@code fallbackTimeout} null, no aws-core resolution ran), the rollout gate is read
+     *   directly, applying the default timeout when it is on and nothing otherwise.</li>
+     * </ol>
+     */
+    public static HttpMonitoringOptions resolveMonitoringOptions(ConnectionHealthConfiguration healthConfiguration,
+                                                                 Duration fallbackTimeout) {
+        if (healthConfiguration != null) {
+            return CrtConfigurationUtils.resolveHttpMonitoringOptions(healthConfiguration).orElse(null);
+        }
+
+        if (fallbackTimeout != null) {
+            return fallbackTimeout.isZero() ? null : mapReadWriteTimeout(fallbackTimeout);
+        }
+
+        if (AwsCrtDefaultReadTimeoutSetting.ENABLE_DEFAULT_READ_TIMEOUT_2026.getBooleanValue().orElse(false)) {
+            return mapReadWriteTimeout(STANDALONE_DEFAULT_READ_WRITE_TIMEOUT);
+        }
+        return null;
+    }
+
+    /**
+     * Maps a read/write inactivity timeout onto the CRT throughput monitor that enforces it: a minimum throughput of one byte
+     * per second measured over a failure interval of {@code readWriteTimeout}. Because the threshold is a single byte, any byte
+     * moved while a stream is pending resets the interval, so the connection is shut down only after {@code readWriteTimeout} of
+     * continuous zero-byte progress. The interval has whole-second granularity, and CRT rejects an interval below two seconds, so
+     * a shorter timeout is raised to that floor.
+     */
+    public static HttpMonitoringOptions mapReadWriteTimeout(Duration readWriteTimeout) {
+        HttpMonitoringOptions httpMonitoringOptions = new HttpMonitoringOptions();
+        httpMonitoringOptions.setMinThroughputBytesPerSecond(1);
+        int seconds = Math.max(MIN_MONITORING_FAILURE_INTERVAL_SECONDS,
+                               NumericUtils.saturatedCast(readWriteTimeout.getSeconds()));
+        httpMonitoringOptions.setAllowableThroughputFailureIntervalSeconds(seconds);
+        return httpMonitoringOptions;
     }
 
     public static SocketOptions buildSocketOptions(TcpKeepAliveConfiguration tcpKeepAliveConfiguration,

--- a/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/AwsCrtDefaultReadTimeoutSetting.java
+++ b/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/internal/AwsCrtDefaultReadTimeoutSetting.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.http.crt.internal;
+
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.utils.SystemSetting;
+
+/**
+ * The rollout gate the standalone (non-service-client) CRT HTTP Client reads to decide whether to apply the default read/write
+ * inactivity timeout. It mirrors {@code SdkSystemSetting.AWS_ENABLE_DEFAULT_READ_TIMEOUT_2026} in sdk-core, using the same
+ * environment variable and system property; the CRT client reads them directly because it cannot depend on sdk-core. This is
+ * needed to ensure a timeout is configured when a standalone HTTP client is created.
+ */
+@SdkInternalApi
+public enum AwsCrtDefaultReadTimeoutSetting implements SystemSetting {
+    ENABLE_DEFAULT_READ_TIMEOUT_2026;
+
+    @Override
+    public String property() {
+        return "aws.enableDefaultReadTimeout2026";
+    }
+
+    @Override
+    public String environmentVariable() {
+        return "AWS_ENABLE_DEFAULT_READ_TIMEOUT_2026";
+    }
+
+    @Override
+    public String defaultValue() {
+        return null;
+    }
+}

--- a/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/AwsCrtAsyncHttpClientLongRunningRequestTest.java
+++ b/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/AwsCrtAsyncHttpClientLongRunningRequestTest.java
@@ -15,9 +15,21 @@
 
 package software.amazon.awssdk.http.crt;
 
+import static software.amazon.awssdk.http.LongRunningRequestTestSupport.CONFIGURED_TIMEOUT;
+import static software.amazon.awssdk.http.LongRunningRequestTestSupport.assertFailsWithIoExceptionWithinTimeBound;
+import static software.amazon.awssdk.http.LongRunningRequestTestSupport.stubLongPolling;
+import static software.amazon.awssdk.http.LongRunningRequestTestSupport.stubStreamingWithPauses;
+
+import java.net.URI;
+import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.crt.Log;
+import software.amazon.awssdk.http.HttpTestUtils;
 import software.amazon.awssdk.http.SdkAsyncHttpClientLongRunningRequestTestSuite;
+import software.amazon.awssdk.http.SdkHttpConfigurationOption;
+import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.http.SdkHttpMethod;
 import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
 import software.amazon.awssdk.utils.AttributeMap;
 
@@ -34,15 +46,47 @@ public class AwsCrtAsyncHttpClientLongRunningRequestTest extends SdkAsyncHttpCli
         return AwsCrtAsyncHttpClient.builder().buildWithDefaults(config);
     }
 
-    // Empty test; the CRT async client does not currently enforce READ_TIMEOUT. Delete this
-    // override when connection health monitoring is re-added.
+    // The CRT client enforces a read/write inactivity timeout through SDK_INTERNAL_FALLBACK_READ_WRITE_TIMEOUT rather than
+    // READ_TIMEOUT (which it ignores), so these two suite cases are re-implemented to configure that option. A stalled or
+    // paused response then trips the CRT throughput monitor (AWS_ERROR_HTTP_CHANNEL_THROUGHPUT_FAILURE, a retryable
+    // IOException) and fails the request within the bound instead of hanging.
+    @Test
     @Override
     public void executeWhenReadTimeoutAndServerDelaysResponseFailsWithinTimeoutBound() {
+        stubLongPolling(mockServer);
+        SdkAsyncHttpClient client = createSdkAsyncHttpClient(fallbackTimeoutConfig());
+        try {
+            assertFailsWithIoExceptionWithinTimeBound(sendRequest(client), CONFIGURED_TIMEOUT);
+        } finally {
+            client.close();
+        }
     }
 
-    // Empty test; the CRT async client does not currently enforce READ_TIMEOUT. Delete this
-    // override when connection health monitoring is re-added.
+    @Test
     @Override
     public void executeWhenReadTimeoutAndStreamingResponsePausesFailsWithinTimeoutBound() {
+        stubStreamingWithPauses(mockServer);
+        SdkAsyncHttpClient client = createSdkAsyncHttpClient(fallbackTimeoutConfig());
+        try {
+            assertFailsWithIoExceptionWithinTimeBound(sendRequest(client), CONFIGURED_TIMEOUT);
+        } finally {
+            client.close();
+        }
+    }
+
+    private static AttributeMap fallbackTimeoutConfig() {
+        return AttributeMap.builder()
+                           .put(SdkHttpConfigurationOption.SDK_INTERNAL_FALLBACK_READ_WRITE_TIMEOUT, CONFIGURED_TIMEOUT)
+                           .build();
+    }
+
+    private CompletableFuture<byte[]> sendRequest(SdkAsyncHttpClient client) {
+        URI uri = URI.create("http://localhost:" + mockServer.getPort());
+        SdkHttpFullRequest request = SdkHttpFullRequest.builder()
+                                                       .uri(uri)
+                                                       .method(SdkHttpMethod.GET)
+                                                       .putHeader("Host", uri.getHost())
+                                                       .build();
+        return HttpTestUtils.sendRequest(client, request);
     }
 }

--- a/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/AwsCrtHttpClientLongRunningRequestTest.java
+++ b/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/AwsCrtHttpClientLongRunningRequestTest.java
@@ -15,10 +15,27 @@
 
 package software.amazon.awssdk.http.crt;
 
+import static software.amazon.awssdk.http.LongRunningRequestTestSupport.CONFIGURED_TIMEOUT;
+import static software.amazon.awssdk.http.LongRunningRequestTestSupport.assertFailsWithIoExceptionWithinTimeBound;
+import static software.amazon.awssdk.http.LongRunningRequestTestSupport.stubLongPolling;
+import static software.amazon.awssdk.http.LongRunningRequestTestSupport.stubStreamingWithPauses;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.crt.Log;
+import software.amazon.awssdk.http.HttpExecuteRequest;
+import software.amazon.awssdk.http.HttpExecuteResponse;
 import software.amazon.awssdk.http.SdkHttpClient;
 import software.amazon.awssdk.http.SdkHttpClientLongRunningRequestTestSuite;
+import software.amazon.awssdk.http.SdkHttpConfigurationOption;
+import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.http.SdkHttpMethod;
 import software.amazon.awssdk.utils.AttributeMap;
 
 public class AwsCrtHttpClientLongRunningRequestTest extends SdkHttpClientLongRunningRequestTestSuite {
@@ -34,15 +51,77 @@ public class AwsCrtHttpClientLongRunningRequestTest extends SdkHttpClientLongRun
         return AwsCrtHttpClient.builder().buildWithDefaults(config);
     }
 
-    // Empty test; the CRT sync client does not currently enforce READ_TIMEOUT. Delete this
-    // override when connection health monitoring is re-added.
+    // The CRT client enforces a read/write inactivity timeout through SDK_INTERNAL_FALLBACK_READ_WRITE_TIMEOUT rather than
+    // READ_TIMEOUT (which it ignores), so these two suite cases are re-implemented to configure that option. A stalled or
+    // paused response then trips the CRT throughput monitor (AWS_ERROR_HTTP_CHANNEL_THROUGHPUT_FAILURE, a retryable
+    // IOException) and fails the request within the bound instead of hanging.
+    @Test
     @Override
     public void executeWhenReadTimeoutAndServerDelaysResponseFailsWithinTimeoutBound() {
+        stubLongPolling(mockServer);
+        SdkHttpClient client = createSdkHttpClient(fallbackTimeoutConfig());
+        try {
+            assertFailsWithIoExceptionWithinTimeBound(executeAsync(client), CONFIGURED_TIMEOUT);
+        } finally {
+            client.close();
+        }
     }
 
-    // Empty test; the CRT sync client does not currently enforce READ_TIMEOUT. Delete this
-    // override when connection health monitoring is re-added.
+    @Test
     @Override
     public void executeWhenReadTimeoutAndStreamingResponsePausesFailsWithinTimeoutBound() {
+        stubStreamingWithPauses(mockServer);
+        SdkHttpClient client = createSdkHttpClient(fallbackTimeoutConfig());
+        try {
+            assertFailsWithIoExceptionWithinTimeBound(executeAsync(client), CONFIGURED_TIMEOUT);
+        } finally {
+            client.close();
+        }
+    }
+
+    private static AttributeMap fallbackTimeoutConfig() {
+        return AttributeMap.builder()
+                           .put(SdkHttpConfigurationOption.SDK_INTERNAL_FALLBACK_READ_WRITE_TIMEOUT, CONFIGURED_TIMEOUT)
+                           .build();
+    }
+
+    private CompletableFuture<Void> executeAsync(SdkHttpClient client) {
+        return CompletableFuture.supplyAsync(() -> {
+            executeRequest(client);
+            return null;
+        });
+    }
+
+    private void executeRequest(SdkHttpClient client) {
+        URI uri = URI.create("http://localhost:" + mockServer.getPort());
+        SdkHttpFullRequest request = SdkHttpFullRequest.builder()
+                                                       .uri(uri)
+                                                       .method(SdkHttpMethod.POST)
+                                                       .putHeader("Host", uri.getHost())
+                                                       .putHeader("Content-Length", "4")
+                                                       .contentStreamProvider(() -> new ByteArrayInputStream(
+                                                           "Body".getBytes(StandardCharsets.UTF_8)))
+                                                       .build();
+        try {
+            HttpExecuteResponse response = client.prepareRequest(HttpExecuteRequest.builder()
+                                                                                   .request(request)
+                                                                                   .contentStreamProvider(
+                                                                                       request.contentStreamProvider()
+                                                                                              .orElse(null))
+                                                                                   .build())
+                                                 .call();
+            response.responseBody().ifPresent(body -> {
+                try {
+                    while (body.read() != -1) {
+                        // drain body so mid-body timeouts surface
+                    }
+                    body.close();
+                } catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                }
+            });
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
     }
 }

--- a/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/internal/AwsCrtConfigurationUtilsTest.java
+++ b/http-clients/aws-crt-client/src/test/java/software/amazon/awssdk/http/crt/internal/AwsCrtConfigurationUtilsTest.java
@@ -21,6 +21,8 @@ import static software.amazon.awssdk.crt.io.TlsCipherPreference.TLS_CIPHER_SYSTE
 
 import java.time.Duration;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -30,11 +32,21 @@ import software.amazon.awssdk.crt.io.SocketOptions;
 import software.amazon.awssdk.crt.io.TlsCipherPreference;
 import software.amazon.awssdk.crt.io.TlsContextOptions;
 import software.amazon.awssdk.http.SdkHttpConfigurationOption;
+import software.amazon.awssdk.http.crt.ConnectionHealthConfiguration;
 import software.amazon.awssdk.http.crt.TcpKeepAliveConfiguration;
 import software.amazon.awssdk.http.crt.TlsVersion;
 import software.amazon.awssdk.utils.AttributeMap;
 
 class AwsCrtConfigurationUtilsTest {
+
+    private static final String GATE_PROPERTY = "aws.enableDefaultReadTimeout2026";
+
+    @BeforeEach
+    @AfterEach
+    void clearGateProperty() {
+        System.clearProperty(GATE_PROPERTY);
+    }
+
     @ParameterizedTest
     @MethodSource("cipherPreferences")
     void resolveCipherPreference_shouldResolveCorrectly(Boolean postQuantumTlsEnabled,
@@ -118,6 +130,96 @@ class AwsCrtConfigurationUtilsTest {
     void resolveMinTlsVersion_tls13_returnsTLSv1_3() {
         assertThat(AwsCrtConfigurationUtils.resolveMinTlsVersion(TlsVersion.TLS_1_3))
             .isEqualTo(TlsContextOptions.TlsVersions.TLSv1_3);
+    }
+
+    @ParameterizedTest(name = "{0} inactivity timeout -> {1}s failure interval")
+    @MethodSource("readWriteTimeoutMappings")
+    void mapReadWriteTimeout_mapsToOneBytePerSecondMonitor(Duration readWriteTimeout, int expectedIntervalSeconds) {
+        HttpMonitoringOptions options = AwsCrtConfigurationUtils.mapReadWriteTimeout(readWriteTimeout);
+        assertThat(options.getMinThroughputBytesPerSecond()).isEqualTo(1L);
+        assertThat(options.getAllowableThroughputFailureIntervalSeconds()).isEqualTo(expectedIntervalSeconds);
+    }
+
+    private static Stream<Arguments> readWriteTimeoutMappings() {
+        return Stream.of(
+            Arguments.of(Duration.ofMinutes(5), 300),
+            Arguments.of(Duration.ofMinutes(15), 900),
+            Arguments.of(Duration.ofSeconds(2), 2),
+            Arguments.of(Duration.ofSeconds(1), 2),
+            Arguments.of(Duration.ZERO, 2),
+            Arguments.of(Duration.ofMillis(2999), 2),
+            Arguments.of(Duration.ofMillis(3999), 3)
+        );
+    }
+
+    @Test
+    void resolveMonitoringOptions_explicitConnectionHealthConfiguration_winsOverFallback() {
+        HttpMonitoringOptions options = AwsCrtConfigurationUtils.resolveMonitoringOptions(healthConfiguration(),
+                                                                                          Duration.ofMinutes(15));
+        assertThat(options.getMinThroughputBytesPerSecond()).isEqualTo(500L);
+        assertThat(options.getAllowableThroughputFailureIntervalSeconds()).isEqualTo(10);
+    }
+
+    @Test
+    void resolveMonitoringOptions_serviceFallbackZero_appliesNothing() {
+        assertThat(AwsCrtConfigurationUtils.resolveMonitoringOptions(null, Duration.ZERO)).isNull();
+    }
+
+    @Test
+    void resolveMonitoringOptions_serviceFallbackZeroWithGateOn_appliesNothing() {
+        System.setProperty(GATE_PROPERTY, "true");
+        assertThat(AwsCrtConfigurationUtils.resolveMonitoringOptions(null, Duration.ZERO)).isNull();
+    }
+
+    @Test
+    void resolveMonitoringOptions_serviceFallbackPositive_mapped() {
+        HttpMonitoringOptions options = AwsCrtConfigurationUtils.resolveMonitoringOptions(null, Duration.ofMinutes(15));
+        assertThat(options.getMinThroughputBytesPerSecond()).isEqualTo(1L);
+        assertThat(options.getAllowableThroughputFailureIntervalSeconds()).isEqualTo(900);
+    }
+
+    @Test
+    void resolveMonitoringOptions_serviceFallbackPositive_ignoresGate() {
+        System.setProperty(GATE_PROPERTY, "false");
+        HttpMonitoringOptions options = AwsCrtConfigurationUtils.resolveMonitoringOptions(null, Duration.ofMinutes(15));
+        assertThat(options.getMinThroughputBytesPerSecond()).isEqualTo(1L);
+        assertThat(options.getAllowableThroughputFailureIntervalSeconds()).isEqualTo(900);
+    }
+
+    @Test
+    void resolveMonitoringOptions_standaloneGateOn_appliesDefault() {
+        System.setProperty(GATE_PROPERTY, "true");
+        HttpMonitoringOptions options = AwsCrtConfigurationUtils.resolveMonitoringOptions(null, null);
+        assertThat(options.getMinThroughputBytesPerSecond()).isEqualTo(1L);
+        assertThat(options.getAllowableThroughputFailureIntervalSeconds()).isEqualTo(300);
+    }
+
+    @Test
+    void resolveMonitoringOptions_standaloneGateOff_appliesNothing() {
+        assertThat(AwsCrtConfigurationUtils.resolveMonitoringOptions(null, null)).isNull();
+    }
+
+    @Test
+    void resolveMonitoringOptions_standaloneGateOnWithExplicitConfig_usesExplicitConfig() {
+        System.setProperty(GATE_PROPERTY, "true");
+        HttpMonitoringOptions options = AwsCrtConfigurationUtils.resolveMonitoringOptions(healthConfiguration(), null);
+        assertThat(options.getMinThroughputBytesPerSecond()).isEqualTo(500L);
+        assertThat(options.getAllowableThroughputFailureIntervalSeconds()).isEqualTo(10);
+    }
+
+    @Test
+    void standaloneGateSetting_matchesRolloutGateNames() {
+        assertThat(AwsCrtDefaultReadTimeoutSetting.ENABLE_DEFAULT_READ_TIMEOUT_2026.environmentVariable())
+            .isEqualTo("AWS_ENABLE_DEFAULT_READ_TIMEOUT_2026");
+        assertThat(AwsCrtDefaultReadTimeoutSetting.ENABLE_DEFAULT_READ_TIMEOUT_2026.property())
+            .isEqualTo("aws.enableDefaultReadTimeout2026");
+    }
+
+    private static ConnectionHealthConfiguration healthConfiguration() {
+        return ConnectionHealthConfiguration.builder()
+                                            .minimumThroughputInBps(500L)
+                                            .minimumThroughputTimeout(Duration.ofSeconds(10))
+                                            .build();
     }
 
 


### PR DESCRIPTION
## Motivation and Context

The AWS CRT-based HTTP clients (`AwsCrtHttpClient`, `AwsCrtAsyncHttpClient`) apply no default socket read/write timeout, so a request on an established connection can wait indefinitely if the peer stops sending bytes. The Apache, Netty, and URL-connection clients already cap this through `READ_TIMEOUT`/`WRITE_TIMEOUT`; the CRT clients do not honor those options. This change makes the CRT clients apply a read/write inactivity timeout, expressed through CRT's `HttpMonitoringOptions` (a minimum-throughput monitor), which is the mechanism CRT provides for detecting a stalled in-flight request.

This is increment 2 of the default read/write timeout series. It builds atop increment 1 (the rollout gate: the `AWS_ENABLE_DEFAULT_READ_TIMEOUT_2026` system setting, its resolver, and the client option), which is already merged into this feature branch. The base of this PR is the feature branch `feature/master/2026-enable-default-read-timeout`, not `master`.

Scope note: this increment defines the transport option and wires the CRT client to consume it, plus the standalone (non-service-client) opt-in. Resolving the option on the service-client path (in `aws-core`) is a later increment; until then the option is exercised directly, and standalone CRT usage is covered by the direct environment-variable read.

The feature is off by default. A consumer opts in by setting the environment variable `AWS_ENABLE_DEFAULT_READ_TIMEOUT_2026` (or the system property `aws.enableDefaultReadTimeout2026`). When it is off, behavior is unchanged: no monitoring is applied unless the caller configured `ConnectionHealthConfiguration` themselves.

## Modifications

`http-client-spi`:
- Add `SdkHttpConfigurationOption.SDK_INTERNAL_FALLBACK_READ_WRITE_TIMEOUT` (a `Duration`). It is SDK-resolved and not intended to be set by end users; it is honored only by HTTP clients that do not enforce a read/write timeout of their own (currently the CRT-based clients) and ignored by the others. It is deliberately not part of `GLOBAL_HTTP_DEFAULTS`; its absence signals the standalone path. `Duration.ZERO` means "apply nothing".

`http-clients/aws-crt-client`:
- `AwsCrtConfigurationUtils.mapReadWriteTimeout(Duration)`: maps an inactivity timeout onto `HttpMonitoringOptions` with a minimum throughput of 1 byte/second over a failure interval equal to the timeout. Any byte moved while a stream is pending resets the interval, so the connection is shut down only after the timeout of continuous zero-byte progress. The interval is whole-second granular and floored at CRT's 2-second minimum.
- `AwsCrtConfigurationUtils.resolveMonitoringOptions(ConnectionHealthConfiguration, Duration)`: applies the precedence, highest first: (1) an explicit `ConnectionHealthConfiguration` on the builder always wins; (2) the resolved fallback timeout, where `Duration.ZERO` applies nothing and a positive value is mapped; (3) on the standalone path (fallback absent) the rollout gate is read directly, applying a 5-minute default when set and nothing otherwise.
- `AwsCrtDefaultReadTimeoutSetting`: the standalone rollout gate, read directly from the environment variable / system property because the CRT module cannot depend on `sdk-core`. Its names match increment 1 exactly.
- `AwsCrtHttpClientBase`: feeds the resolved value into the existing `monitoringOptions` field; the connection-pool creation path is unchanged.
- `AwsCrtHttpClient.Builder` and `AwsCrtAsyncHttpClient.Builder`: the `connectionHealthConfiguration(...)` Javadoc is reframed to document it as the CRT client's read/write inactivity timeout knob (`minimumThroughputInBps(1L)` with `minimumThroughputTimeout(duration)`), noting that an explicit configuration always takes precedence over the default.

No new public type is added to the CRT builders, and the shared `crt-core` `CrtConfigurationUtils` is unchanged.

A monitor trip surfaces as a retryable `IOException` (from `AWS_ERROR_HTTP_CHANNEL_THROUGHPUT_FAILURE`), which the SDK retry layer already retries; no new exception type or retry wiring is introduced.

## Testing

- `AwsCrtConfigurationUtilsTest`: the mapping (5 min -> 300s, 15 min -> 900s, the 2-second floor, and whole-second truncation) and the `resolveMonitoringOptions` precedence table (explicit config wins over the fallback and over the standalone gate; a `Duration.ZERO` fallback applies nothing even with the gate on; a positive fallback is mapped and is not re-gated; standalone on applies the default, standalone off applies nothing). Also asserts the standalone setting's environment-variable and system-property names.
- `AwsCrtHttpClientLongRunningRequestTest` and `AwsCrtAsyncHttpClientLongRunningRequestTest`: behavioral fail-fast tests (sync and async). With the fallback timeout configured, a stalled full response and a mid-stream pause each trip the throughput monitor and fail the request within the timeout bound with a retryable `IOException`, rather than hanging. Confirmed to genuinely trip (a control with no timeout configured lets the request complete instead).
- Built the affected modules (`http-client-spi`, `aws-crt-client`); all module tests pass (328 in `aws-crt-client`). A full-repo `mvn install` was not run.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] I have added a changelog entry. (Deferred: a single changelog entry for this multi-increment feature is added at feature finalization, matching increment 1.)

## License
- [x] I confirm that this pull request can be released under the Apache 2 license
