### PR TITLE
Improve exception handling for missing converters

### DIFF
--- a/.changes/next-release/feature-AmazonDynamoDBEnhancedClient-8fb589b.json
+++ b/.changes/next-release/feature-AmazonDynamoDBEnhancedClient-8fb589b.json
@@ -1,0 +1,6 @@
+{
+    "type": "feature",
+    "category": "Amazon DynamoDB Enhanced Client",
+    "contributor": "",
+    "description": "Improve missing converter error handling in DynamoDB Enhanced Client"
+}

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/DefaultAttributeConverterProvider.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/DefaultAttributeConverterProvider.java
@@ -72,6 +72,7 @@ import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.Uui
 import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.ZoneIdAttributeConverter;
 import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.ZoneOffsetAttributeConverter;
 import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.ZonedDateTimeAsStringAttributeConverter;
+import software.amazon.awssdk.utils.CollectionUtils;
 import software.amazon.awssdk.utils.Logger;
 import software.amazon.awssdk.utils.Validate;
 
@@ -157,17 +158,21 @@ public final class DefaultAttributeConverterProvider implements AttributeConvert
             return Optional.of(converter);
         }
 
-        if (type.rawClass().isAssignableFrom(Map.class)) {
-            converter = createMapConverter(type);
-        } else if (type.rawClass().isAssignableFrom(Set.class)) {
-            converter = createSetConverter(type);
-        } else if (type.rawClass().isAssignableFrom(List.class)) {
-            EnhancedType<T> innerType = (EnhancedType<T>) type.rawClassParameters().get(0);
-            AttributeConverter<?> innerConverter = findConverter(innerType)
-                .orElseThrow(() -> new IllegalStateException("Converter not found for " + type));
-            return Optional.of((AttributeConverter<T>) ListAttributeConverter.create(innerConverter));
-        } else if (type.rawClass().isEnum()) {
-            return Optional.of(EnumAttributeConverter.create(((EnhancedType<? extends Enum>) type).rawClass()));
+        if (!Object.class.equals(type.rawClass())) {
+            if (type.rawClass().isAssignableFrom(Map.class)) {
+                requireTypeParameters(type);
+                converter = createMapConverter(type);
+            } else if (type.rawClass().isAssignableFrom(Set.class)) {
+                requireTypeParameters(type);
+                converter = createSetConverter(type);
+            } else if (type.rawClass().isAssignableFrom(List.class)) {
+                requireTypeParameters(type);
+                EnhancedType<T> innerType = (EnhancedType<T>) type.rawClassParameters().get(0);
+                AttributeConverter<?> innerConverter = converterFor(innerType);
+                return Optional.of((AttributeConverter<T>) ListAttributeConverter.create(innerConverter));
+            } else if (type.rawClass().isEnum()) {
+                return Optional.of(EnumAttributeConverter.create(((EnhancedType<? extends Enum>) type).rawClass()));
+            }
         }
 
         if (type.tableSchema().isPresent()) {
@@ -186,14 +191,19 @@ public final class DefaultAttributeConverterProvider implements AttributeConvert
         return !type.isAnonymousClass();
     }
 
+    private static void requireTypeParameters(EnhancedType<?> type) {
+        if (CollectionUtils.isNullOrEmpty(type.rawClassParameters())) {
+            throw new IllegalStateException("Converter not found for " + type + ". Type parameters are required for this type.");
+        }
+    }
+
     @SuppressWarnings("unchecked")
     private <T> AttributeConverter<T> createMapConverter(EnhancedType<T> type) {
         EnhancedType<?> keyType = type.rawClassParameters().get(0);
         EnhancedType<T> valueType = (EnhancedType<T>) type.rawClassParameters().get(1);
 
         StringConverter<?> keyConverter = StringConverterProvider.defaultProvider().converterFor(keyType);
-        AttributeConverter<?> valueConverter = findConverter(valueType)
-            .orElseThrow(() -> new IllegalStateException("Converter not found for " + type));
+        AttributeConverter<?> valueConverter = converterFor(valueType);
 
         return (AttributeConverter<T>) MapAttributeConverter.mapConverter(keyConverter, valueConverter);
     }
@@ -201,8 +211,7 @@ public final class DefaultAttributeConverterProvider implements AttributeConvert
     @SuppressWarnings("unchecked")
     private <T> AttributeConverter<T> createSetConverter(EnhancedType<T> type) {
         EnhancedType<T> innerType = (EnhancedType<T>) type.rawClassParameters().get(0);
-        AttributeConverter<?> innerConverter = findConverter(innerType)
-            .orElseThrow(() -> new IllegalStateException("Converter not found for " + type));
+        AttributeConverter<?> innerConverter = converterFor(innerType);
 
         return (AttributeConverter<T>) SetAttributeConverter.setConverter(innerConverter);
     }

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/document/DefaultEnhancedDocument.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/document/DefaultEnhancedDocument.java
@@ -45,6 +45,7 @@ import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.Map
 import software.amazon.awssdk.protocols.jsoncore.JsonNode;
 import software.amazon.awssdk.protocols.jsoncore.JsonNodeParser;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.utils.CollectionUtils;
 import software.amazon.awssdk.utils.Lazy;
 import software.amazon.awssdk.utils.StringUtils;
 import software.amazon.awssdk.utils.Validate;
@@ -89,15 +90,22 @@ public class DefaultEnhancedDocument implements EnhancedDocument {
     public static <T> AttributeConverter<T> converterForClass(EnhancedType<T> type,
                                                               ChainConverterProvider chainConverterProvider) {
 
-        if (type.rawClass().isAssignableFrom(List.class)) {
-            return (AttributeConverter<T>) ListAttributeConverter
-                .create(converterForClass(type.rawClassParameters().get(0), chainConverterProvider));
+        if (!Object.class.equals(type.rawClass())) {
+            if (type.rawClass().isAssignableFrom(List.class)) {
+                requireTypeParameters(type);
+                return (AttributeConverter<T>) ListAttributeConverter
+                    .create(converterForClass(type.rawClassParameters().get(0), chainConverterProvider));
+            }
+            if (type.rawClass().isAssignableFrom(Map.class)) {
+                requireTypeParameters(type);
+                return (AttributeConverter<T>) MapAttributeConverter.mapConverter(
+                    StringConverterProvider.defaultProvider().converterFor(type.rawClassParameters().get(0)),
+                    converterForClass(type.rawClassParameters().get(1), chainConverterProvider));
+            }
         }
-        if (type.rawClass().isAssignableFrom(Map.class)) {
-            return (AttributeConverter<T>) MapAttributeConverter.mapConverter(
-                StringConverterProvider.defaultProvider().converterFor(type.rawClassParameters().get(0)),
-                converterForClass(type.rawClassParameters().get(1), chainConverterProvider));
-        }
+        // TODO: what about the case when type.rawClass() is Object or Unsupported type
+        // and we have overridden the default converter provider with a custom one that can / cannot handle this type?
+        // We should check for that case here.
         return Optional.ofNullable(chainConverterProvider.converterFor(type))
                        .orElseThrow(() -> new IllegalStateException(
                            "AttributeConverter not found for class " + type
@@ -495,5 +503,11 @@ public class DefaultEnhancedDocument implements EnhancedDocument {
         Validate.isTrue(!type.isAssignableFrom(Map.class),
                         String.format(VALIDATE_TYPE_ERROR, "Map", isPut ? "put" : "get", "Map"));
 
+    }
+
+    private static void requireTypeParameters(EnhancedType<?> type) {
+        if (CollectionUtils.isNullOrEmpty(type.rawClassParameters())) {
+            throw new IllegalStateException("Converter not found for " + type + ". Type parameters are required for this type.");
+        }
     }
 }

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/BeanSchemaConverterTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/BeanSchemaConverterTest.java
@@ -1,0 +1,1251 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.DocumentAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.ListAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.MapAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.SetAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.StringAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.BeanTableSchema;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.ImmutableTableSchema;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbConvertedBy;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+
+/**
+ * Tests converter selection and item conversion for bean based table schemas.
+ * <p>
+ * The tests cover scalar, enumeration, collection, map, and nested bean attributes. They also verify null handling,
+ * schema caching, declared converter providers, attribute converters, provider precedence, and unsupported attribute
+ * types during schema creation and item conversion.
+ */
+public class BeanSchemaConverterTest {
+
+    @BeforeEach
+    void setUp() {
+        clearSchemaCache(BeanTableSchema.class);
+        clearSchemaCache(ImmutableTableSchema.class);
+        RecordingCustomProvider.reset();
+        ReturningNullProvider.reset();
+        ThrowingProvider.reset();
+        ObjectProvider.reset();
+        UnsupportedTypeOnlyProvider.reset();
+    }
+
+    private static void clearSchemaCache(Class<?> schemaClass) {
+        try {
+            Method method = schemaClass.getDeclaredMethod("clearSchemaCache");
+            method.setAccessible(true);
+            method.invoke(null);
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @Test
+    @DisplayName("A nonnull string property selects StringAttributeConverter and round-trips")
+    void fromBean_whenNonnullString_selectsStringConverterAndRoundTrips() {
+        TableSchema<StringBean> schema = TableSchema.fromBean(StringBean.class);
+        StringBean model = new StringBean();
+        model.setId("id-1");
+        model.setValue("hello");
+
+        Map<String, AttributeValue> map = schema.itemToMap(model, true);
+        StringBean read = schema.mapToItem(map);
+
+        AttributeConverter<?> converter = schema.converterForAttribute("value");
+        assertThat(converter).isInstanceOf(StringAttributeConverter.class);
+        assertThat(converter.attributeValueType()).isEqualTo(AttributeValueType.S);
+        assertThat(map.get("value").s()).isEqualTo("hello");
+        assertThat(read.getValue()).isEqualTo("hello");
+    }
+
+    @Test
+    @DisplayName("A string list with a duplicate is stored as L and read as an ArrayList")
+    void fromBean_whenStringListWithDuplicate_preservesOrderAndDuplicateAsArrayList() {
+        TableSchema<StringListBean> schema = TableSchema.fromBean(StringListBean.class);
+        StringListBean model = new StringListBean();
+        model.setId("id-1");
+        List<String> input = new ArrayList<>();
+        input.add("a");
+        input.add("b");
+        input.add("a");
+        model.setValue(input);
+
+        Map<String, AttributeValue> map = schema.itemToMap(model, true);
+        StringListBean read = schema.mapToItem(map);
+
+        AttributeConverter<?> converter = schema.converterForAttribute("value");
+        assertThat(converter).isInstanceOf(ListAttributeConverter.class);
+        assertThat(converter.attributeValueType()).isEqualTo(AttributeValueType.L);
+        assertThat(read.getValue()).isInstanceOf(ArrayList.class)
+                                   .containsExactly("a", "b", "a");
+    }
+
+    @Test
+    @DisplayName("A nested bean property selects DocumentAttributeConverter and is reconstructed")
+    void fromBean_whenNestedBean_selectsDocumentConverterAndReconstructsNestedValue() {
+        TableSchema<NestedOuterBean> schema = TableSchema.fromBean(NestedOuterBean.class);
+        NestedInnerBean nested = new NestedInnerBean();
+        nested.setNestedValue("inner");
+        NestedOuterBean model = new NestedOuterBean();
+        model.setId("id-1");
+        model.setValue(nested);
+
+        Map<String, AttributeValue> map = schema.itemToMap(model, true);
+        NestedOuterBean read = schema.mapToItem(map);
+
+        AttributeConverter<?> converter = schema.converterForAttribute("value");
+        assertThat(converter).isInstanceOf(DocumentAttributeConverter.class);
+        assertThat(converter.attributeValueType()).isEqualTo(AttributeValueType.M);
+        assertThat(read.getValue().getNestedValue()).isEqualTo("inner");
+    }
+
+    @Test
+    @DisplayName("itemToMap with ignoreNulls false stores a null string as DynamoDB NULL")
+    void itemToMap_whenNullStringIgnoreNullsFalse_includesNulValue() {
+        TableSchema<StringBean> schema = TableSchema.fromBean(StringBean.class);
+        StringBean model = new StringBean();
+        model.setId("id-1");
+
+        Map<String, AttributeValue> map = schema.itemToMap(model, false);
+
+        assertThat(map).containsEntry("value", AttributeValue.fromNul(true));
+    }
+
+    @Test
+    @DisplayName("itemToMap with ignoreNulls true omits a null string property")
+    void itemToMap_whenNullStringIgnoreNullsTrue_omitsValue() {
+        TableSchema<StringBean> schema = TableSchema.fromBean(StringBean.class);
+        StringBean model = new StringBean();
+        model.setId("id-1");
+
+        Map<String, AttributeValue> map = schema.itemToMap(model, true);
+
+        assertThat(map).doesNotContainKey("value");
+    }
+
+    @Test
+    @DisplayName("mapToItem skips the setter for a DynamoDB NULL string property")
+    void mapToItem_whenNulString_doesNotCallSetterAndLeavesValueNull() {
+        TableSchema<NullReadBean> schema = TableSchema.fromBean(NullReadBean.class);
+        Map<String, AttributeValue> map = new HashMap<>();
+        map.put("id", AttributeValue.fromS("id-1"));
+        map.put("value", AttributeValue.fromNul(true));
+
+        NullReadBean read = schema.mapToItem(map);
+
+        assertThat(read).isNotNull();
+        assertThat(read.valueSetterCalls).isZero();
+        assertThat(read.getValue()).isNull();
+    }
+
+    @Test
+    @DisplayName("An unconverted Object property fails converter lookup")
+    void fromBean_whenUnconvertedObject_throwsConverterNotFound() {
+        assertThatThrownBy(() -> TableSchema.fromBean(ObjectBean.class))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + EnhancedType.of(Object.class));
+    }
+
+    @Test
+    @DisplayName("An unconverted UnsupportedType property fails converter lookup")
+    void fromBean_whenUnconvertedUnsupportedType_throwsIllegalStateException() {
+        EnhancedType<UnsupportedType> type = EnhancedType.of(UnsupportedType.class);
+
+        assertThatThrownBy(() -> TableSchema.fromBean(UnsupportedBean.class))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + type);
+    }
+
+    @Test
+    @DisplayName("A custom provider listed first is consulted twice and supplies CustomTypeConverter")
+    void fromBean_whenCustomProviderFirst_invokesCustomTwiceAndRoundTrips() {
+        TableSchema<CustomFirstBean> schema = TableSchema.fromBean(CustomFirstBean.class);
+        CustomFirstBean model = new CustomFirstBean();
+        CustomType input = new CustomType("x");
+        model.setValue(input);
+
+        Map<String, AttributeValue> map = schema.itemToMap(model, true);
+        CustomFirstBean read = schema.mapToItem(map);
+
+        assertThat(RecordingCustomProvider.current().requestedTypes())
+            .hasSize(2)
+            .containsExactly(EnhancedType.of(CustomType.class), EnhancedType.of(CustomType.class));
+        AttributeConverter<?> converter = schema.converterForAttribute("value");
+        assertThat(converter).isInstanceOf(CustomTypeConverter.class);
+        assertThat(converter.attributeValueType()).isEqualTo(AttributeValueType.S);
+        assertThat(read.getValue()).isEqualTo(input);
+    }
+
+    @Test
+    @DisplayName("A null-returning provider is consulted once then the default string converter is used")
+    void fromBean_whenNullReturningProviderThenDefault_invokesProviderOnceAndSelectsStringConverter() {
+        TableSchema<NullThenDefaultBean> schema = TableSchema.fromBean(NullThenDefaultBean.class);
+
+        assertThat(ReturningNullProvider.current().requestedTypes())
+            .containsExactly(EnhancedType.of(String.class));
+        AttributeConverter<?> converter = schema.converterForAttribute("value");
+        assertThat(converter).isInstanceOf(StringAttributeConverter.class);
+        assertThat(converter.attributeValueType()).isEqualTo(AttributeValueType.S);
+    }
+
+    @Test
+    @DisplayName("Default-first ordering throws before a later custom provider is consulted")
+    void fromBean_whenDefaultProviderFirst_throwsAndDoesNotInvokeCustomProvider() {
+        EnhancedType<CustomType> type = EnhancedType.of(CustomType.class);
+
+        assertThatThrownBy(() -> TableSchema.fromBean(DefaultThenCustomBean.class))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + type);
+        RecordingCustomProvider custom = RecordingCustomProvider.current();
+        assertThat(custom == null || custom.requestedTypes().isEmpty()).isTrue();
+    }
+
+    @Test
+    @DisplayName("A throwing provider failure is propagated without consulting the default provider")
+    void fromBean_whenThrowingProviderThenDefault_propagatesProviderFailure() {
+        EnhancedType<CustomType> type = EnhancedType.of(CustomType.class);
+
+        assertThatThrownBy(() -> TableSchema.fromBean(ThrowingThenDefaultBean.class))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Attribute converter provider failed while looking up " + type);
+    }
+
+    @Test
+    @DisplayName("Bean schema factory caches by model class")
+    void fromBean_whenSameClassTwice_returnsSameBeanTableSchemaReference() {
+        BeanTableSchema<StringBean> first = TableSchema.fromBean(StringBean.class);
+        BeanTableSchema<StringBean> second = TableSchema.fromBean(StringBean.class);
+
+        assertThat(first).isSameAs(second);
+        assertThat(first).isInstanceOf(BeanTableSchema.class);
+    }
+
+    @Test
+    @DisplayName("Generic schema factory dispatches a bean class")
+    void fromClass_whenBeanModel_returnsBeanTableSchemaWithStringConverter() {
+        StringBean item = new StringBean();
+        item.setId("id-1");
+        item.setValue("text");
+
+        TableSchema<StringBean> schema = TableSchema.fromClass(StringBean.class);
+        Map<String, AttributeValue> map = schema.itemToMap(item, true);
+
+        assertThat(schema).isInstanceOf(BeanTableSchema.class);
+        assertThat(schema.converterForAttribute("value")).isInstanceOf(StringAttributeConverter.class);
+        assertThat(map.get("value").s()).isEqualTo("text");
+    }
+
+    @Test
+    @DisplayName("Bean ObjectProvider before default selects ObjectStringConverter")
+    void fromBean_whenObjectProviderBeforeDefault_selectsObjectStringConverter() {
+        ObjectProviderBean item = new ObjectProviderBean();
+        item.setValue(new Object());
+
+        TableSchema<ObjectProviderBean> schema = TableSchema.fromBean(ObjectProviderBean.class);
+        Map<String, AttributeValue> map = schema.itemToMap(item, true);
+        ObjectProviderBean read = schema.mapToItem(map);
+
+        int objectRequestCount = 0;
+        for (EnhancedType<?> requestedType : ObjectProvider.current().requestedTypes()) {
+            if (EnhancedType.of(Object.class).equals(requestedType)) {
+                objectRequestCount++;
+            }
+        }
+        assertThat(objectRequestCount).isEqualTo(2);
+        assertThat(schema.converterForAttribute("value")).isInstanceOf(ObjectStringConverter.class);
+        assertThat(schema.converterForAttribute("value").attributeValueType()).isEqualTo(AttributeValueType.S);
+        assertThat(read.getValue()).isEqualTo("custom");
+    }
+
+    @Test
+    @DisplayName("ConvertedBy intercepts Object and does not consult the schema provider for that type")
+    void fromBean_whenObjectConvertedBy_selectsObjectStringConverterAndSkipsProvider() {
+        TableSchema<ConvertedObjectBean> schema = TableSchema.fromBean(ConvertedObjectBean.class);
+        ConvertedObjectBean model = new ConvertedObjectBean();
+        model.setValue(new Object());
+
+        Map<String, AttributeValue> map = schema.itemToMap(model, true);
+        ConvertedObjectBean read = schema.mapToItem(map);
+
+        AttributeConverter<?> converter = schema.converterForAttribute("value");
+        assertThat(converter).isInstanceOf(ObjectStringConverter.class);
+        assertThat(converter.attributeValueType()).isEqualTo(AttributeValueType.S);
+        assertThat(ObjectProvider.current().requestedTypes()).doesNotContain(EnhancedType.of(Object.class));
+        assertThat(read.getValue()).isEqualTo("custom");
+    }
+
+    @Test
+    @DisplayName("ConvertedBy intercepts UnsupportedType with UnsupportedStringConverter")
+    void fromBean_whenUnsupportedConvertedBy_selectsUnsupportedStringConverterAndRoundTrips() {
+        TableSchema<ConvertedUnsupportedBean> schema = TableSchema.fromBean(ConvertedUnsupportedBean.class);
+        ConvertedUnsupportedBean model = new ConvertedUnsupportedBean();
+        UnsupportedType input = new UnsupportedType();
+        model.setValue(input);
+
+        Map<String, AttributeValue> map = schema.itemToMap(model, true);
+        ConvertedUnsupportedBean read = schema.mapToItem(map);
+
+        AttributeConverter<?> converter = schema.converterForAttribute("value");
+        assertThat(converter).isInstanceOf(UnsupportedStringConverter.class);
+        assertThat(converter.attributeValueType()).isEqualTo(AttributeValueType.S);
+        assertThat(read.getValue()).isEqualTo(input);
+    }
+
+    @Test
+    @DisplayName("ConvertedBy intercepts ArrayList and the setter receives an ArrayList")
+    void fromBean_whenArrayListConvertedBy_selectsArrayListConverterAndSetterReceivesArrayList() {
+        TableSchema<ConvertedArrayListBean> schema = TableSchema.fromBean(ConvertedArrayListBean.class);
+        ConvertedArrayListBean model = new ConvertedArrayListBean();
+        ArrayList<String> input = new ArrayList<>();
+        input.add("a");
+        input.add("b");
+        model.setValue(input);
+
+        Map<String, AttributeValue> map = schema.itemToMap(model, true);
+        ConvertedArrayListBean read = schema.mapToItem(map);
+
+        AttributeConverter<?> converter = schema.converterForAttribute("value");
+        assertThat(converter).isInstanceOf(ArrayListConverter.class);
+        assertThat(converter.attributeValueType()).isEqualTo(AttributeValueType.L);
+        assertThat(map.get("value").hasL()).isTrue();
+        assertThat(read.getValue()).isInstanceOf(ArrayList.class)
+                                   .containsExactly("a", "b");
+    }
+
+    @Test
+    @DisplayName("An empty provider list fails with NPE when no attribute converter is present")
+    void fromBean_whenEmptyProvidersWithoutConvertedBy_throwsNullPointerException() {
+        assertThatThrownBy(() -> TableSchema.fromBean(EmptyProvidersBean.class))
+            .isInstanceOf(NullPointerException.class)
+            .satisfies(ex -> assertThat(ex.getMessage() == null || ex.getMessage().contains("null")).isTrue());
+    }
+
+    @Test
+    @DisplayName("ConvertedBy still works when the bean declares an empty provider list")
+    void fromBean_whenEmptyProvidersWithConvertedBy_usesCustomStringConverter() {
+        TableSchema<EmptyProvidersConvertedBean> schema =
+            TableSchema.fromBean(EmptyProvidersConvertedBean.class);
+        EmptyProvidersConvertedBean model = new EmptyProvidersConvertedBean();
+        model.setValue("text");
+
+        Map<String, AttributeValue> map = schema.itemToMap(model, true);
+        EmptyProvidersConvertedBean read = schema.mapToItem(map);
+
+        AttributeConverter<?> converter = schema.converterForAttribute("value");
+        assertThat(converter).isInstanceOf(CustomStringConverter.class);
+        assertThat(converter.attributeValueType()).isEqualTo(AttributeValueType.S);
+        assertThat(map.get("value").s()).isEqualTo("custom:text");
+        assertThat(read.getValue()).isEqualTo("text");
+    }
+
+    @Test
+    @DisplayName("An unconverted ArrayList property fails lookup before mapToItem")
+    void fromBean_whenUnconvertedArrayList_throwsIllegalStateException() {
+        EnhancedType<ArrayList<String>> type = new EnhancedType<ArrayList<String>>() {
+        };
+
+        assertThatThrownBy(() -> TableSchema.fromBean(ArrayListBean.class))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + type);
+    }
+
+    @Test
+    @DisplayName("A custom provider is not consulted for list members during default fallback")
+    void fromBean_whenUnsupportedListWithCustomMemberProvider_throwsForMemberType() {
+
+        assertThatThrownBy(() -> TableSchema.fromBean(UnsupportedListBean.class))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + EnhancedType.of(UnsupportedType.class));
+        assertThat(UnsupportedTypeOnlyProvider.current().requestedTypes()).hasSize(1);
+        EnhancedType<?> requestedType = UnsupportedTypeOnlyProvider.current().requestedTypes().get(0);
+        assertThat(requestedType.rawClass()).isEqualTo(List.class);
+        assertThat(requestedType.rawClassParameters()).containsExactly(EnhancedType.of(UnsupportedType.class));
+    }
+
+    @Test
+    @DisplayName("A Collection of String is stored as SS and read as a LinkedHashSet")
+    void fromBean_whenStringCollection_selectsSetConverterAndReadsLinkedHashSet() {
+        TableSchema<StringCollectionBean> schema = TableSchema.fromBean(StringCollectionBean.class);
+        StringCollectionBean model = new StringCollectionBean();
+        Collection<String> input = new LinkedHashSet<>();
+        input.add("a");
+        input.add("b");
+        model.setValue(input);
+
+        Map<String, AttributeValue> map = schema.itemToMap(model, true);
+        StringCollectionBean read = schema.mapToItem(map);
+
+        AttributeConverter<?> converter = schema.converterForAttribute("value");
+        assertThat(converter).isInstanceOf(SetAttributeConverter.class);
+        assertThat(converter.attributeValueType()).isEqualTo(AttributeValueType.SS);
+        assertThat(read.getValue()).isInstanceOf(LinkedHashSet.class)
+                                   .containsExactly("a", "b");
+    }
+
+    @Test
+    @DisplayName("A string set is stored as SS and read as a LinkedHashSet")
+    void fromBean_whenStringSet_selectsSetConverterAndReadsLinkedHashSet() {
+        TableSchema<StringSetBean> schema = TableSchema.fromBean(StringSetBean.class);
+        StringSetBean model = new StringSetBean();
+        model.setId("id-1");
+        Set<String> input = new LinkedHashSet<>();
+        input.add("a");
+        input.add("b");
+        model.setValue(input);
+
+        Map<String, AttributeValue> map = schema.itemToMap(model, true);
+        StringSetBean read = schema.mapToItem(map);
+
+        AttributeConverter<?> converter = schema.converterForAttribute("value");
+        assertThat(converter).isInstanceOf(SetAttributeConverter.class);
+        assertThat(converter.attributeValueType()).isEqualTo(AttributeValueType.SS);
+        assertThat(read.getValue()).isInstanceOf(LinkedHashSet.class)
+                                   .containsExactly("a", "b");
+    }
+
+    @Test
+    @DisplayName("A string-to-integer map is stored as M and read as a LinkedHashMap")
+    void fromBean_whenStringIntegerMap_selectsMapConverterAndReadsLinkedHashMap() {
+        TableSchema<StringIntegerMapBean> schema = TableSchema.fromBean(StringIntegerMapBean.class);
+        StringIntegerMapBean model = new StringIntegerMapBean();
+        model.setId("id-1");
+        Map<String, Integer> input = new LinkedHashMap<>();
+        input.put("a", 1);
+        input.put("b", 2);
+        model.setValue(input);
+
+        Map<String, AttributeValue> map = schema.itemToMap(model, true);
+        StringIntegerMapBean read = schema.mapToItem(map);
+
+        AttributeConverter<?> converter = schema.converterForAttribute("value");
+        assertThat(converter).isInstanceOf(MapAttributeConverter.class);
+        assertThat(converter.attributeValueType()).isEqualTo(AttributeValueType.M);
+        assertThat(read.getValue()).isEqualTo(input).isInstanceOf(LinkedHashMap.class);
+    }
+
+    @Test
+    @DisplayName("An enum property selects EnumAttributeConverter and round-trips")
+    void fromBean_whenEnumProperty_selectsEnumConverterAndRoundTrips() {
+        TableSchema<EnumBean> schema = TableSchema.fromBean(EnumBean.class);
+        EnumBean model = new EnumBean();
+        model.setId("id-1");
+        model.setValue(TestEnum.OPEN);
+
+        Map<String, AttributeValue> map = schema.itemToMap(model, true);
+        EnumBean read = schema.mapToItem(map);
+
+        AttributeConverter<?> converter = schema.converterForAttribute("value");
+        assertThat(converter).isInstanceOf(EnumAttributeConverter.class);
+        assertThat(converter.attributeValueType()).isEqualTo(AttributeValueType.S);
+        assertThat(map.get("value").s()).isEqualTo("OPEN");
+        assertThat(read.getValue()).isEqualTo(TestEnum.OPEN);
+    }
+
+    @Test
+    @DisplayName("An unconverted HashSet property fails lookup before mapToItem")
+    void fromBean_whenUnconvertedHashSet_throwsIllegalStateException() {
+        EnhancedType<HashSet<String>> type = new EnhancedType<HashSet<String>>() {
+        };
+
+        assertThatThrownBy(() -> TableSchema.fromBean(HashSetBean.class))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + type);
+    }
+
+    @Test
+    @DisplayName("An unconverted HashMap property fails lookup before mapToItem")
+    void fromBean_whenUnconvertedHashMap_throwsIllegalStateException() {
+        EnhancedType<HashMap<String, Integer>> type = new EnhancedType<HashMap<String, Integer>>() {
+        };
+
+        assertThatThrownBy(() -> TableSchema.fromBean(HashMapBean.class))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + type);
+    }
+
+    @DynamoDbBean
+    public static class StringBean {
+        private String id;
+        private String value;
+
+        @DynamoDbPartitionKey
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        public String getValue() {
+            return value;
+        }
+
+        public void setValue(String value) {
+            this.value = value;
+        }
+    }
+
+    @DynamoDbBean
+    public static class StringListBean {
+        private String id;
+        private List<String> value;
+
+        @DynamoDbPartitionKey
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        public List<String> getValue() {
+            return value;
+        }
+
+        public void setValue(List<String> value) {
+            this.value = value;
+        }
+    }
+
+    @DynamoDbBean
+    public static class NestedInnerBean {
+        private String nestedValue;
+
+        public String getNestedValue() {
+            return nestedValue;
+        }
+
+        public void setNestedValue(String nestedValue) {
+            this.nestedValue = nestedValue;
+        }
+    }
+
+    @DynamoDbBean
+    public static class NestedOuterBean {
+        private String id;
+        private NestedInnerBean value;
+
+        @DynamoDbPartitionKey
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        public NestedInnerBean getValue() {
+            return value;
+        }
+
+        public void setValue(NestedInnerBean value) {
+            this.value = value;
+        }
+    }
+
+    @DynamoDbBean
+    public static class NullReadBean {
+        private String id;
+        private String value;
+        public int valueSetterCalls;
+
+        @DynamoDbPartitionKey
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        public String getValue() {
+            return value;
+        }
+
+        public void setValue(String value) {
+            valueSetterCalls++;
+            this.value = value;
+        }
+    }
+
+    @DynamoDbBean
+    public static class ObjectBean {
+        private Object value;
+
+        public Object getValue() {
+            return value;
+        }
+
+        public void setValue(Object value) {
+            this.value = value;
+        }
+    }
+
+    @DynamoDbBean
+    public static class UnsupportedBean {
+        private UnsupportedType value;
+
+        public UnsupportedType getValue() {
+            return value;
+        }
+
+        public void setValue(UnsupportedType value) {
+            this.value = value;
+        }
+    }
+
+    @DynamoDbBean(converterProviders = {
+        RecordingCustomProvider.class,
+        DefaultAttributeConverterProvider.class
+    })
+    public static class CustomFirstBean {
+        private CustomType value;
+
+        public CustomType getValue() {
+            return value;
+        }
+
+        public void setValue(CustomType value) {
+            this.value = value;
+        }
+    }
+
+    @DynamoDbBean(converterProviders = {
+        ReturningNullProvider.class,
+        DefaultAttributeConverterProvider.class
+    })
+    public static class NullThenDefaultBean {
+        private String value;
+
+        public String getValue() {
+            return value;
+        }
+
+        public void setValue(String value) {
+            this.value = value;
+        }
+    }
+
+    @DynamoDbBean(converterProviders = {
+        DefaultAttributeConverterProvider.class,
+        RecordingCustomProvider.class
+    })
+    public static class DefaultThenCustomBean {
+        private CustomType value;
+
+        public CustomType getValue() {
+            return value;
+        }
+
+        public void setValue(CustomType value) {
+            this.value = value;
+        }
+    }
+
+    @DynamoDbBean(converterProviders = {
+        ThrowingProvider.class,
+        DefaultAttributeConverterProvider.class
+    })
+    public static class ThrowingThenDefaultBean {
+        private CustomType value;
+
+        public CustomType getValue() {
+            return value;
+        }
+
+        public void setValue(CustomType value) {
+            this.value = value;
+        }
+    }
+
+    @DynamoDbBean(converterProviders = {
+        ObjectProvider.class,
+        DefaultAttributeConverterProvider.class
+    })
+    public static class ObjectProviderBean {
+        private Object value;
+
+        @DynamoDbPartitionKey
+        public Object getValue() {
+            return value;
+        }
+
+        public void setValue(Object value) {
+            this.value = value;
+        }
+    }
+
+    @DynamoDbBean(converterProviders = {
+        ObjectProvider.class,
+        DefaultAttributeConverterProvider.class
+    })
+    public static class ConvertedObjectBean {
+        private Object value;
+
+        @DynamoDbConvertedBy(ObjectStringConverter.class)
+        public Object getValue() {
+            return value;
+        }
+
+        public void setValue(Object value) {
+            this.value = value;
+        }
+    }
+
+    @DynamoDbBean
+    public static class ConvertedUnsupportedBean {
+        private UnsupportedType value;
+
+        @DynamoDbConvertedBy(UnsupportedStringConverter.class)
+        public UnsupportedType getValue() {
+            return value;
+        }
+
+        public void setValue(UnsupportedType value) {
+            this.value = value;
+        }
+    }
+
+    @DynamoDbBean
+    public static class ConvertedArrayListBean {
+        private ArrayList<String> value;
+
+        @DynamoDbConvertedBy(ArrayListConverter.class)
+        public ArrayList<String> getValue() {
+            return value;
+        }
+
+        public void setValue(ArrayList<String> value) {
+            this.value = value;
+        }
+    }
+
+    @DynamoDbBean(converterProviders = {})
+    public static class EmptyProvidersBean {
+        private String value;
+
+        public String getValue() {
+            return value;
+        }
+
+        public void setValue(String value) {
+            this.value = value;
+        }
+    }
+
+    @DynamoDbBean(converterProviders = {})
+    public static class EmptyProvidersConvertedBean {
+        private String value;
+
+        @DynamoDbConvertedBy(CustomStringConverter.class)
+        public String getValue() {
+            return value;
+        }
+
+        public void setValue(String value) {
+            this.value = value;
+        }
+    }
+
+    @DynamoDbBean
+    public static class ArrayListBean {
+        private ArrayList<String> value;
+
+        public ArrayList<String> getValue() {
+            return value;
+        }
+
+        public void setValue(ArrayList<String> value) {
+            this.value = value;
+        }
+    }
+
+    @DynamoDbBean(converterProviders = {
+        UnsupportedTypeOnlyProvider.class,
+        DefaultAttributeConverterProvider.class
+    })
+    public static class UnsupportedListBean {
+        private List<UnsupportedType> value;
+
+        public List<UnsupportedType> getValue() {
+            return value;
+        }
+
+        public void setValue(List<UnsupportedType> value) {
+            this.value = value;
+        }
+    }
+
+    @DynamoDbBean
+    public static class StringCollectionBean {
+        private Collection<String> value;
+
+        public Collection<String> getValue() {
+            return value;
+        }
+
+        public void setValue(Collection<String> value) {
+            this.value = value;
+        }
+    }
+
+    @DynamoDbBean
+    public static class StringSetBean {
+        private String id;
+        private Set<String> value;
+
+        @DynamoDbPartitionKey
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        public Set<String> getValue() {
+            return value;
+        }
+
+        public void setValue(Set<String> value) {
+            this.value = value;
+        }
+    }
+
+    @DynamoDbBean
+    public static class StringIntegerMapBean {
+        private String id;
+        private Map<String, Integer> value;
+
+        @DynamoDbPartitionKey
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        public Map<String, Integer> getValue() {
+            return value;
+        }
+
+        public void setValue(Map<String, Integer> value) {
+            this.value = value;
+        }
+    }
+
+    @DynamoDbBean
+    public static class EnumBean {
+        private String id;
+        private TestEnum value;
+
+        @DynamoDbPartitionKey
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        public TestEnum getValue() {
+            return value;
+        }
+
+        public void setValue(TestEnum value) {
+            this.value = value;
+        }
+    }
+
+    @DynamoDbBean
+    public static class HashSetBean {
+        private HashSet<String> value;
+
+        public HashSet<String> getValue() {
+            return value;
+        }
+
+        public void setValue(HashSet<String> value) {
+            this.value = value;
+        }
+    }
+
+    @DynamoDbBean
+    public static class HashMapBean {
+        private HashMap<String, Integer> value;
+
+        public HashMap<String, Integer> getValue() {
+            return value;
+        }
+
+        public void setValue(HashMap<String, Integer> value) {
+            this.value = value;
+        }
+    }
+
+    public enum TestEnum {
+        OPEN,
+        CLOSED
+    }
+
+    public static final class CustomType {
+        private final String value;
+
+        public CustomType(String value) {
+            this.value = value;
+        }
+
+        public String value() {
+            return value;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof CustomType)) {
+                return false;
+            }
+            CustomType that = (CustomType) o;
+            return Objects.equals(value, that.value);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(value);
+        }
+    }
+
+    public static final class UnsupportedType {
+        @Override
+        public boolean equals(Object o) {
+            return o instanceof UnsupportedType;
+        }
+
+        @Override
+        public int hashCode() {
+            return 1;
+        }
+    }
+
+    public static class CustomTypeConverter implements AttributeConverter<CustomType> {
+        public CustomTypeConverter() {
+        }
+
+        @Override
+        public AttributeValue transformFrom(CustomType input) {
+            return AttributeValue.fromS("custom:" + input.value());
+        }
+
+        @Override
+        public CustomType transformTo(AttributeValue input) {
+            String stored = input.s();
+            return new CustomType(stored.substring("custom:".length()));
+        }
+
+        @Override
+        public EnhancedType<CustomType> type() {
+            return EnhancedType.of(CustomType.class);
+        }
+
+        @Override
+        public AttributeValueType attributeValueType() {
+            return AttributeValueType.S;
+        }
+    }
+
+    public static class CustomStringConverter implements AttributeConverter<String> {
+        public CustomStringConverter() {
+        }
+
+        @Override
+        public AttributeValue transformFrom(String input) {
+            return AttributeValue.fromS("custom:" + input);
+        }
+
+        @Override
+        public String transformTo(AttributeValue input) {
+            String stored = input.s();
+            if (stored != null && stored.startsWith("custom:")) {
+                return stored.substring("custom:".length());
+            }
+            return stored;
+        }
+
+        @Override
+        public EnhancedType<String> type() {
+            return EnhancedType.of(String.class);
+        }
+
+        @Override
+        public AttributeValueType attributeValueType() {
+            return AttributeValueType.S;
+        }
+    }
+
+    public static class ObjectStringConverter implements AttributeConverter<Object> {
+        public ObjectStringConverter() {
+        }
+
+        @Override
+        public AttributeValue transformFrom(Object input) {
+            return AttributeValue.fromS("custom");
+        }
+
+        @Override
+        public Object transformTo(AttributeValue input) {
+            return "custom";
+        }
+
+        @Override
+        public EnhancedType<Object> type() {
+            return EnhancedType.of(Object.class);
+        }
+
+        @Override
+        public AttributeValueType attributeValueType() {
+            return AttributeValueType.S;
+        }
+    }
+
+    public static class UnsupportedStringConverter implements AttributeConverter<UnsupportedType> {
+        public UnsupportedStringConverter() {
+        }
+
+        @Override
+        public AttributeValue transformFrom(UnsupportedType input) {
+            return AttributeValue.fromS("custom");
+        }
+
+        @Override
+        public UnsupportedType transformTo(AttributeValue input) {
+            return new UnsupportedType();
+        }
+
+        @Override
+        public EnhancedType<UnsupportedType> type() {
+            return EnhancedType.of(UnsupportedType.class);
+        }
+
+        @Override
+        public AttributeValueType attributeValueType() {
+            return AttributeValueType.S;
+        }
+    }
+
+    public static class ArrayListConverter implements AttributeConverter<ArrayList<String>> {
+        public ArrayListConverter() {
+        }
+
+        @Override
+        public AttributeValue transformFrom(ArrayList<String> input) {
+            List<AttributeValue> values = new ArrayList<>();
+            for (String member : input) {
+                values.add(AttributeValue.fromS(member));
+            }
+            return AttributeValue.fromL(values);
+        }
+
+        @Override
+        public ArrayList<String> transformTo(AttributeValue input) {
+            ArrayList<String> result = new ArrayList<>();
+            for (AttributeValue member : input.l()) {
+                result.add(member.s());
+            }
+            return result;
+        }
+
+        @Override
+        public EnhancedType<ArrayList<String>> type() {
+            return new EnhancedType<ArrayList<String>>() {
+            };
+        }
+
+        @Override
+        public AttributeValueType attributeValueType() {
+            return AttributeValueType.L;
+        }
+    }
+
+    public static class RecordingCustomProvider implements AttributeConverterProvider {
+        private static final ThreadLocal<RecordingCustomProvider> CURRENT =
+            new ThreadLocal<>();
+        private final List<EnhancedType<?>> requestedTypes = new ArrayList<>();
+
+        public RecordingCustomProvider() {
+            CURRENT.set(this);
+        }
+
+        public static RecordingCustomProvider current() {
+            return CURRENT.get();
+        }
+
+        public static void reset() {
+            CURRENT.remove();
+        }
+
+        public List<EnhancedType<?>> requestedTypes() {
+            return requestedTypes;
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> AttributeConverter<T> converterFor(EnhancedType<T> enhancedType) {
+            requestedTypes.add(enhancedType);
+            if (EnhancedType.of(CustomType.class).equals(enhancedType)) {
+                return (AttributeConverter<T>) new CustomTypeConverter();
+            }
+            return null;
+        }
+    }
+
+    public static class ReturningNullProvider implements AttributeConverterProvider {
+        private static final ThreadLocal<ReturningNullProvider> CURRENT =
+            new ThreadLocal<>();
+        private final List<EnhancedType<?>> requestedTypes = new ArrayList<>();
+
+        public ReturningNullProvider() {
+            CURRENT.set(this);
+        }
+
+        public static ReturningNullProvider current() {
+            return CURRENT.get();
+        }
+
+        public static void reset() {
+            CURRENT.remove();
+        }
+
+        public List<EnhancedType<?>> requestedTypes() {
+            return requestedTypes;
+        }
+
+        @Override
+        public <T> AttributeConverter<T> converterFor(EnhancedType<T> enhancedType) {
+            requestedTypes.add(enhancedType);
+            return null;
+        }
+    }
+
+    public static class ThrowingProvider implements AttributeConverterProvider {
+        private static final ThreadLocal<ThrowingProvider> CURRENT = new ThreadLocal<>();
+
+        public ThrowingProvider() {
+            CURRENT.set(this);
+        }
+
+        public static ThrowingProvider current() {
+            return CURRENT.get();
+        }
+
+        public static void reset() {
+            CURRENT.remove();
+        }
+
+        @Override
+        public <T> AttributeConverter<T> converterFor(EnhancedType<T> enhancedType) {
+            throw new IllegalArgumentException("Attribute converter provider failed while looking up " + enhancedType);
+        }
+    }
+
+    public static class ObjectProvider implements AttributeConverterProvider {
+        private static final ThreadLocal<ObjectProvider> CURRENT = new ThreadLocal<>();
+        private final List<EnhancedType<?>> requestedTypes = new ArrayList<>();
+
+        public ObjectProvider() {
+            CURRENT.set(this);
+        }
+
+        public static ObjectProvider current() {
+            return CURRENT.get();
+        }
+
+        public static void reset() {
+            CURRENT.remove();
+        }
+
+        public List<EnhancedType<?>> requestedTypes() {
+            return requestedTypes;
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> AttributeConverter<T> converterFor(EnhancedType<T> enhancedType) {
+            requestedTypes.add(enhancedType);
+            if (EnhancedType.of(Object.class).equals(enhancedType)) {
+                return (AttributeConverter<T>) new ObjectStringConverter();
+            }
+            return null;
+        }
+    }
+
+    public static class UnsupportedTypeOnlyProvider implements AttributeConverterProvider {
+        private static final ThreadLocal<UnsupportedTypeOnlyProvider> CURRENT =
+            new ThreadLocal<>();
+        private final List<EnhancedType<?>> requestedTypes = new ArrayList<>();
+
+        public UnsupportedTypeOnlyProvider() {
+            CURRENT.set(this);
+        }
+
+        public static UnsupportedTypeOnlyProvider current() {
+            return CURRENT.get();
+        }
+
+        public static void reset() {
+            CURRENT.remove();
+        }
+
+        public List<EnhancedType<?>> requestedTypes() {
+            return requestedTypes;
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> AttributeConverter<T> converterFor(EnhancedType<T> enhancedType) {
+            requestedTypes.add(enhancedType);
+            if (EnhancedType.of(UnsupportedType.class).equals(enhancedType)) {
+                return (AttributeConverter<T>) new UnsupportedStringConverter();
+            }
+            return null;
+        }
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/DefaultAttributeConverterProviderCollectionTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/DefaultAttributeConverterProviderCollectionTest.java
@@ -1,0 +1,1331 @@
+package software.amazon.awssdk.enhanced.dynamodb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import java.time.Instant;
+import java.time.Year;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.Stack;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import java.util.UUID;
+import java.util.Vector;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.ListAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.MapAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.SetAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.StringAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.StaticTableSchema;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+
+/**
+ * Consolidated coverage for the supported collection declarations.
+ */
+public class DefaultAttributeConverterProviderCollectionTest {
+
+    // List declarations and nested list values.
+    @Test
+    @DisplayName("List conversion preserves order and duplicates as an ArrayList")
+    void converterFor_whenStringList_preservesOrderAndDuplicatesAsArrayList() {
+        DefaultAttributeConverterProvider listProvider = new DefaultAttributeConverterProvider();
+        EnhancedType<List<String>> type = EnhancedType.listOf(String.class);
+        List<String> input = new ArrayList<>();
+        input.add("a");
+        input.add("b");
+        input.add("a");
+
+        AttributeConverter<List<String>> converter = listProvider.converterFor(type);
+        AttributeValue stored = converter.transformFrom(input);
+        List<String> read = converter.transformTo(stored);
+
+        assertThat(converter).isInstanceOf(ListAttributeConverter.class);
+        assertThat(converter.attributeValueType()).isEqualTo(AttributeValueType.L);
+        assertThat(read).isInstanceOf(ArrayList.class)
+                        .isEqualTo(input)
+                        .containsExactly("a", "b", "a");
+    }
+
+    @Test
+    @DisplayName("Empty list conversion stores an empty L and reads an empty ArrayList")
+    void converterFor_whenEmptyStringList_convertsToEmptyLAndReadsEmptyArrayList() {
+        DefaultAttributeConverterProvider listProvider = new DefaultAttributeConverterProvider();
+        EnhancedType<List<String>> type = EnhancedType.listOf(String.class);
+        List<String> input = new ArrayList<>();
+
+        AttributeConverter<List<String>> converter = listProvider.converterFor(type);
+        AttributeValue stored = converter.transformFrom(input);
+        List<String> read = converter.transformTo(stored);
+
+        assertThat(converter).isInstanceOf(ListAttributeConverter.class);
+        assertThat(converter.attributeValueType()).isEqualTo(AttributeValueType.L);
+        assertThat(stored.l()).isEmpty();
+        assertThat(read).isInstanceOf(ArrayList.class)
+                        .isEmpty();
+    }
+
+    @Test
+    @DisplayName("A null string list member is stored as DynamoDB NULL and read back as null")
+    void converterFor_whenStringListWithNullMember_storesNulAndReadsNullMember() {
+        DefaultAttributeConverterProvider listProvider = new DefaultAttributeConverterProvider();
+        EnhancedType<List<String>> type = EnhancedType.listOf(String.class);
+        List<String> input = new ArrayList<>();
+        input.add("a");
+        input.add(null);
+        input.add("b");
+
+        AttributeConverter<List<String>> converter = listProvider.converterFor(type);
+        AttributeValue stored = converter.transformFrom(input);
+        List<String> read = converter.transformTo(stored);
+
+        assertThat(converter).isInstanceOf(ListAttributeConverter.class);
+        assertThat(converter.attributeValueType()).isEqualTo(AttributeValueType.L);
+        assertThat(stored.l()).hasSize(3);
+        assertThat(stored.l().get(1).nul()).isTrue();
+        assertThat(read).isInstanceOf(ArrayList.class)
+                        .containsExactly("a", null, "b");
+        assertThat(read.get(1)).isNull();
+    }
+
+    @Test
+    @DisplayName("An Instant list member is stored as S and read as an equal ArrayList")
+    void converterFor_whenInstantList_convertsMemberAsSAndReadsEqualArrayList() {
+        DefaultAttributeConverterProvider listProvider = new DefaultAttributeConverterProvider();
+        EnhancedType<List<Instant>> type = EnhancedType.listOf(Instant.class);
+        Instant instant = Instant.parse("2020-01-02T03:04:05Z");
+        List<Instant> input = new ArrayList<>();
+        input.add(instant);
+
+        AttributeConverter<List<Instant>> converter = listProvider.converterFor(type);
+        AttributeValue stored = converter.transformFrom(input);
+        List<Instant> read = converter.transformTo(stored);
+
+        assertThat(converter).isInstanceOf(ListAttributeConverter.class);
+        assertThat(converter.attributeValueType()).isEqualTo(AttributeValueType.L);
+        assertThat(stored.l()).hasSize(1);
+        assertThat(stored.l().get(0).s()).isNotNull();
+        assertThat(read).isInstanceOf(ArrayList.class)
+                        .isEqualTo(input)
+                        .containsExactly(instant);
+    }
+
+    @Test
+    @DisplayName("An enum list member is stored as S and read as the same constant")
+    void converterFor_whenEnumList_convertsMemberAsSAndReadsSameConstant() {
+        DefaultAttributeConverterProvider listProvider = new DefaultAttributeConverterProvider();
+        EnhancedType<List<ListTestEnum>> type = EnhancedType.listOf(ListTestEnum.class);
+        List<ListTestEnum> input = new ArrayList<>();
+        input.add(ListTestEnum.OPEN);
+
+        AttributeConverter<List<ListTestEnum>> converter = listProvider.converterFor(type);
+        AttributeValue stored = converter.transformFrom(input);
+        List<ListTestEnum> read = converter.transformTo(stored);
+
+        assertThat(converter).isInstanceOf(ListAttributeConverter.class);
+        assertThat(converter.attributeValueType()).isEqualTo(AttributeValueType.L);
+        assertThat(stored.l()).hasSize(1);
+        assertThat(stored.l().get(0).s()).isEqualTo(ListTestEnum.OPEN.toString());
+        assertThat(read).isInstanceOf(ArrayList.class)
+                        .containsExactly(ListTestEnum.OPEN);
+    }
+
+    @Test
+    @DisplayName("A document list member is stored as M and reconstructed through the table schema")
+    void converterFor_whenDocumentList_recordsBothConversionsAndReadsReconstructedDocument() {
+        DefaultAttributeConverterProvider listProvider = new DefaultAttributeConverterProvider();
+        TableSchema<ListDocumentType> schema = listDocumentSchema();
+        EnhancedType<List<ListDocumentType>> type =
+            EnhancedType.listOf(EnhancedType.documentOf(ListDocumentType.class, schema));
+        ListDocumentType document = new ListDocumentType();
+        document.setName("doc");
+        List<ListDocumentType> input = new ArrayList<>();
+        input.add(document);
+
+        AttributeConverter<List<ListDocumentType>> converter = listProvider.converterFor(type);
+        AttributeValue stored = converter.transformFrom(input);
+        List<ListDocumentType> read = converter.transformTo(stored);
+
+        assertThat(converter).isInstanceOf(ListAttributeConverter.class);
+        assertThat(converter.attributeValueType()).isEqualTo(AttributeValueType.L);
+        assertThat(stored.l()).hasSize(1);
+        assertThat(stored.l().get(0).m()).containsEntry("name", AttributeValue.fromS("doc"));
+        assertThat(read).isInstanceOf(ArrayList.class);
+        assertThat(read.get(0).getName()).isEqualTo("doc");
+    }
+
+    @Test
+    @DisplayName("A nested list uses L at both levels and reads ArrayList at both levels")
+    void converterFor_whenNestedStringList_usesLAtBothLevelsAndReadsArrayLists() {
+        DefaultAttributeConverterProvider listProvider = new DefaultAttributeConverterProvider();
+        EnhancedType<List<List<String>>> type = EnhancedType.listOf(EnhancedType.listOf(String.class));
+        List<String> inner = new ArrayList<>();
+        inner.add("a");
+        inner.add("b");
+        List<List<String>> input = new ArrayList<>();
+        input.add(inner);
+
+        AttributeConverter<List<List<String>>> converter = listProvider.converterFor(type);
+        AttributeValue stored = converter.transformFrom(input);
+        List<List<String>> read = converter.transformTo(stored);
+
+        assertThat(converter).isInstanceOf(ListAttributeConverter.class);
+        assertThat(converter.attributeValueType()).isEqualTo(AttributeValueType.L);
+        assertThat(stored.l()).hasSize(1);
+        assertThat(stored.l().get(0).l()).containsExactly(AttributeValue.fromS("a"),
+                                                          AttributeValue.fromS("b"));
+        assertThat(read).isInstanceOf(ArrayList.class);
+        assertThat(read.get(0)).isInstanceOf(ArrayList.class)
+                               .containsExactly("a", "b");
+    }
+
+    @Test
+    @DisplayName("A map list member uses L then M and reads ArrayList then LinkedHashMap")
+    void converterFor_whenMapListMember_usesLThenMAndReadsArrayListThenLinkedHashMap() {
+        DefaultAttributeConverterProvider listProvider = new DefaultAttributeConverterProvider();
+        EnhancedType<List<Map<String, Integer>>> type =
+            EnhancedType.listOf(EnhancedType.mapOf(String.class, Integer.class));
+        Map<String, Integer> inner = new LinkedHashMap<>();
+        inner.put("one", 1);
+        List<Map<String, Integer>> input = new ArrayList<>();
+        input.add(inner);
+
+        AttributeConverter<List<Map<String, Integer>>> converter = listProvider.converterFor(type);
+        AttributeValue stored = converter.transformFrom(input);
+        List<Map<String, Integer>> read = converter.transformTo(stored);
+
+        assertThat(converter).isInstanceOf(ListAttributeConverter.class);
+        assertThat(converter.attributeValueType()).isEqualTo(AttributeValueType.L);
+        assertThat(stored.l()).hasSize(1);
+        assertThat(stored.l().get(0).m()).isNotNull();
+        assertThat(read).isInstanceOf(ArrayList.class);
+        assertThat(read.get(0)).isInstanceOf(LinkedHashMap.class)
+                               .containsEntry("one", 1);
+    }
+
+    @Test
+    @DisplayName("A set list member uses L then SS and reads ArrayList then LinkedHashSet")
+    void converterFor_whenSetListMember_usesLThenSsAndReadsArrayListThenLinkedHashSet() {
+        DefaultAttributeConverterProvider listProvider = new DefaultAttributeConverterProvider();
+        EnhancedType<List<Set<String>>> type = EnhancedType.listOf(EnhancedType.setOf(String.class));
+        Set<String> inner = new LinkedHashSet<>();
+        inner.add("a");
+        inner.add("b");
+        List<Set<String>> input = new ArrayList<>();
+        input.add(inner);
+
+        AttributeConverter<List<Set<String>>> converter = listProvider.converterFor(type);
+        AttributeValue stored = converter.transformFrom(input);
+        List<Set<String>> read = converter.transformTo(stored);
+
+        assertThat(converter).isInstanceOf(ListAttributeConverter.class);
+        assertThat(converter.attributeValueType()).isEqualTo(AttributeValueType.L);
+        assertThat(stored.l()).hasSize(1);
+        assertThat(stored.l().get(0).ss()).containsExactly("a", "b");
+        assertThat(read).isInstanceOf(ArrayList.class);
+        assertThat(read.get(0)).isInstanceOf(LinkedHashSet.class)
+                               .containsExactly("a", "b");
+    }
+
+    @Test
+    @DisplayName("A list of maps of documents uses L, M, then M and reconstructs the document")
+    void converterFor_whenListOfMapsOfDocuments_usesLThenMThenMAndReadsReconstructedDocument() {
+        DefaultAttributeConverterProvider listProvider = new DefaultAttributeConverterProvider();
+        TableSchema<ListDocumentType> schema = listDocumentSchema();
+        EnhancedType<List<Map<String, ListDocumentType>>> type =
+            EnhancedType.listOf(EnhancedType.mapOf(EnhancedType.of(String.class),
+                                                   EnhancedType.documentOf(ListDocumentType.class, schema)));
+        ListDocumentType nested = new ListDocumentType();
+        nested.setName("doc");
+        Map<String, ListDocumentType> inner = new LinkedHashMap<>();
+        inner.put("doc", nested);
+        List<Map<String, ListDocumentType>> input = new ArrayList<>();
+        input.add(inner);
+
+        AttributeConverter<List<Map<String, ListDocumentType>>> converter = listProvider.converterFor(type);
+        AttributeValue stored = converter.transformFrom(input);
+        List<Map<String, ListDocumentType>> read = converter.transformTo(stored);
+
+        assertThat(converter).isInstanceOf(ListAttributeConverter.class);
+        assertThat(converter.attributeValueType()).isEqualTo(AttributeValueType.L);
+        assertThat(stored.l()).hasSize(1);
+        assertThat(stored.l().get(0).m()).isNotNull();
+        assertThat(stored.l().get(0).m().get("doc").m()).containsEntry("name", AttributeValue.fromS("doc"));
+        assertThat(read).isInstanceOf(ArrayList.class);
+        assertThat(read.get(0)).isInstanceOf(LinkedHashMap.class);
+        assertThat(read.get(0).get("doc").getName()).isEqualTo("doc");
+    }
+
+    @Test
+    @DisplayName("An Object list member fails converter lookup")
+    void converterFor_whenObjectListMember_throwsConverterNotFound() {
+        DefaultAttributeConverterProvider listProvider = new DefaultAttributeConverterProvider();
+        EnhancedType<List<Object>> type = EnhancedType.listOf(Object.class);
+
+        assertThatThrownBy(() -> listProvider.converterFor(type))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + EnhancedType.of(Object.class));
+    }
+
+    @Test
+    @DisplayName("A document class without a schema is an unsupported list member")
+    void converterFor_whenDocumentClassWithoutSchemaList_throwsIllegalStateException() {
+        DefaultAttributeConverterProvider listProvider = new DefaultAttributeConverterProvider();
+        EnhancedType<List<ListDocumentType>> type = EnhancedType.listOf(ListDocumentType.class);
+
+        assertThatThrownBy(() -> listProvider.converterFor(type))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + EnhancedType.of(ListDocumentType.class));
+    }
+
+    @Test
+    @DisplayName("A wildcard list member fails while reading the raw class")
+    void converterFor_whenWildcardListMember_throwsIllegalArgumentException() {
+        DefaultAttributeConverterProvider listProvider = new DefaultAttributeConverterProvider();
+        EnhancedType<List<?>> type = new EnhancedType<List<?>>() {
+        };
+
+        assertThatThrownBy(() -> listProvider.converterFor(type))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("A wildcard type is not expected here.");
+    }
+
+    @Test
+    @DisplayName("A nested Object list fails converter lookup for the inner Object")
+    void converterFor_whenNestedObjectList_throwsConverterNotFoundForInnerObject() {
+        DefaultAttributeConverterProvider listProvider = new DefaultAttributeConverterProvider();
+        EnhancedType<List<Object>> innerType = EnhancedType.listOf(Object.class);
+        EnhancedType<List<List<Object>>> type = EnhancedType.listOf(innerType);
+
+        assertThatThrownBy(() -> listProvider.converterFor(type))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + EnhancedType.of(Object.class));
+    }
+
+    @Test
+    @DisplayName("A nested Boolean set rejects a BOOL member converter")
+    void converterFor_whenNestedBooleanSetList_throwsIllegalArgumentException() {
+        DefaultAttributeConverterProvider listProvider = new DefaultAttributeConverterProvider();
+        EnhancedType<List<Set<Boolean>>> type = EnhancedType.listOf(EnhancedType.setOf(Boolean.class));
+
+        assertThatThrownBy(() -> listProvider.converterFor(type))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("SetAttributeConverter cannot be created with a parameterized type of 'class java.lang.Boolean'. "
+                        + "Supported parameterized types must convert to B, S or N DynamoDB AttributeValues.");
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("unsupportedListImplementationTypes")
+    @DisplayName("Unsupported List implementations fail converter lookup")
+    void converterFor_whenUnsupportedListImplementation_throwsIllegalStateException(EnhancedType<?> type) {
+        DefaultAttributeConverterProvider listProvider = new DefaultAttributeConverterProvider();
+
+        assertThatThrownBy(() -> listProvider.converterFor(type))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + type);
+    }
+
+    private static Stream<EnhancedType<?>> unsupportedListImplementationTypes() {
+        return Stream.of(new EnhancedType<LinkedList<String>>() {
+        }, new EnhancedType<ListCustomList<String>>() {
+        }, new EnhancedType<Vector<String>>() {
+        }, new EnhancedType<CopyOnWriteArrayList<String>>() {
+        }, new EnhancedType<Stack<String>>() {
+        });
+    }
+
+    private static TableSchema<ListDocumentType> listDocumentSchema() {
+        return StaticTableSchema.builder(ListDocumentType.class)
+                                .newItemSupplier(ListDocumentType::new)
+                                .addAttribute(String.class, a -> a.name("name")
+                                                                  .getter(ListDocumentType::getName)
+                                                                  .setter(ListDocumentType::setName))
+                                .build();
+    }
+
+    static class ListDocumentType {
+        private String name;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+
+    enum ListTestEnum {
+        OPEN,
+        CLOSED
+    }
+
+    static final class ListCustomList<T> extends ArrayList<T> {
+    }
+
+    private static final String UNSUPPORTED_SET_MEMBER_SUFFIX =
+        "'. Supported parameterized types must convert to B, S or N DynamoDB AttributeValues.";
+
+    // Set declarations, including Collection and Iterable routing.
+    @Test
+    @DisplayName("String set conversion preserves insertion order as SS and reads a LinkedHashSet")
+    void converterFor_whenStringSet_convertsToInsertionOrderedSsAndReadsLinkedHashSet() {
+        DefaultAttributeConverterProvider setProvider = new DefaultAttributeConverterProvider();
+        EnhancedType<Set<String>> type = EnhancedType.setOf(String.class);
+        Set<String> input = linkedSet("a", "b");
+
+        AttributeConverter<Set<String>> converter = setProvider.converterFor(type);
+        AttributeValue stored = converter.transformFrom(input);
+        Set<String> read = converter.transformTo(stored);
+
+        assertThat(converter).isInstanceOf(SetAttributeConverter.class);
+        assertThat(converter.attributeValueType()).isEqualTo(AttributeValueType.SS);
+        assertThat(stored.ss()).containsExactly("a", "b");
+        assertThat(read).isInstanceOf(LinkedHashSet.class)
+                        .isEqualTo(linkedSet("a", "b"))
+                        .containsExactly("a", "b");
+    }
+
+    @Test
+    @DisplayName("Number set conversion preserves insertion order as NS and reads a LinkedHashSet")
+    void converterFor_whenIntegerSet_convertsToInsertionOrderedNsAndReadsLinkedHashSet() {
+        DefaultAttributeConverterProvider setProvider = new DefaultAttributeConverterProvider();
+        EnhancedType<Set<Integer>> type = EnhancedType.setOf(Integer.class);
+        Set<Integer> input = linkedSet(1, 2);
+
+        AttributeConverter<Set<Integer>> converter = setProvider.converterFor(type);
+        AttributeValue stored = converter.transformFrom(input);
+        Set<Integer> read = converter.transformTo(stored);
+
+        assertThat(converter).isInstanceOf(SetAttributeConverter.class);
+        assertThat(converter.attributeValueType()).isEqualTo(AttributeValueType.NS);
+        assertThat(stored.ns()).containsExactly("1", "2");
+        assertThat(read).isInstanceOf(LinkedHashSet.class)
+                        .isEqualTo(linkedSet(1, 2))
+                        .containsExactly(1, 2);
+    }
+
+    @Test
+    @DisplayName("Binary set conversion stores BS and reads a LinkedHashSet")
+    void converterFor_whenSdkBytesSet_convertsToBsAndReadsLinkedHashSet() {
+        DefaultAttributeConverterProvider setProvider = new DefaultAttributeConverterProvider();
+        EnhancedType<Set<SdkBytes>> type = EnhancedType.setOf(SdkBytes.class);
+        SdkBytes bytes = SdkBytes.fromUtf8String("a");
+        Set<SdkBytes> input = linkedSet(bytes);
+
+        AttributeConverter<Set<SdkBytes>> converter = setProvider.converterFor(type);
+        AttributeValue stored = converter.transformFrom(input);
+        Set<SdkBytes> read = converter.transformTo(stored);
+
+        assertThat(converter).isInstanceOf(SetAttributeConverter.class);
+        assertThat(converter.attributeValueType()).isEqualTo(AttributeValueType.BS);
+        assertThat(stored.bs()).containsExactly(SdkBytes.fromUtf8String("a"));
+        assertThat(read).isInstanceOf(LinkedHashSet.class)
+                        .isEqualTo(linkedSet(bytes))
+                        .containsExactly(bytes);
+    }
+
+    @Test
+    @DisplayName("Enum set conversion stores toString() member text as SS")
+    void converterFor_whenEnumSet_convertsToSsUsingToStringAndReadsLinkedHashSet() {
+        DefaultAttributeConverterProvider setProvider = new DefaultAttributeConverterProvider();
+        EnhancedType<Set<SetTestEnum>> type = EnhancedType.setOf(SetTestEnum.class);
+        Set<SetTestEnum> input = linkedSet(SetTestEnum.OPEN);
+
+        AttributeConverter<Set<SetTestEnum>> converter = setProvider.converterFor(type);
+        AttributeValue stored = converter.transformFrom(input);
+        Set<SetTestEnum> read = converter.transformTo(stored);
+
+        assertThat(converter).isInstanceOf(SetAttributeConverter.class);
+        assertThat(converter.attributeValueType()).isEqualTo(AttributeValueType.SS);
+        assertThat(stored.ss()).containsExactly(SetTestEnum.OPEN.toString());
+        assertThat(read).isInstanceOf(LinkedHashSet.class)
+                        .containsExactly(SetTestEnum.OPEN);
+    }
+
+    @Test
+    @DisplayName("Empty set conversion stores empty SS and reads an empty LinkedHashSet")
+    void converterFor_whenEmptyStringSet_convertsToEmptySsAndReadsEmptyLinkedHashSet() {
+        DefaultAttributeConverterProvider setProvider = new DefaultAttributeConverterProvider();
+        EnhancedType<Set<String>> type = EnhancedType.setOf(String.class);
+        Set<String> input = new LinkedHashSet<>();
+
+        AttributeConverter<Set<String>> converter = setProvider.converterFor(type);
+        AttributeValue stored = converter.transformFrom(input);
+        Set<String> read = converter.transformTo(stored);
+
+        assertThat(converter).isInstanceOf(SetAttributeConverter.class);
+        assertThat(converter.attributeValueType()).isEqualTo(AttributeValueType.SS);
+        assertThat(stored.ss()).isEmpty();
+        assertThat(read).isInstanceOf(LinkedHashSet.class)
+                        .isEmpty();
+    }
+
+    @Test
+    @DisplayName("A null string set member produces a non-string attribute and is rejected")
+    void converterFor_whenStringSetWithNullMember_throwsIllegalArgumentException() {
+        DefaultAttributeConverterProvider setProvider = new DefaultAttributeConverterProvider();
+        EnhancedType<Set<String>> type = EnhancedType.setOf(String.class);
+        Set<String> input = new LinkedHashSet<>();
+        input.add(null);
+
+        assertThatThrownBy(() -> setProvider.converterFor(type).transformFrom(input))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Attribute value must be S.");
+    }
+
+    @Test
+    @DisplayName("A list member converter declaring L is rejected as a set member")
+    void converterFor_whenListMemberSet_throwsIllegalArgumentException() {
+        DefaultAttributeConverterProvider setProvider = new DefaultAttributeConverterProvider();
+        EnhancedType<Set<List<String>>> type = EnhancedType.setOf(EnhancedType.listOf(String.class));
+
+        assertThatThrownBy(() -> setProvider.converterFor(type))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage(unsupportedSetMemberMessage(List.class));
+    }
+
+    @Test
+    @DisplayName("A map member converter declaring M is rejected as a set member")
+    void converterFor_whenMapMemberSet_throwsIllegalArgumentException() {
+        DefaultAttributeConverterProvider setProvider = new DefaultAttributeConverterProvider();
+        EnhancedType<Set<Map<String, String>>> type =
+            EnhancedType.setOf(EnhancedType.mapOf(String.class, String.class));
+
+        assertThatThrownBy(() -> setProvider.converterFor(type))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage(unsupportedSetMemberMessage(Map.class));
+    }
+
+    @Test
+    @DisplayName("A document member converter declaring M is rejected as a set member")
+    void converterFor_whenDocumentMemberSet_throwsIllegalArgumentException() {
+        DefaultAttributeConverterProvider setProvider = new DefaultAttributeConverterProvider();
+        TableSchema<SetDocumentType> documentSchema =
+            StaticTableSchema.builder(SetDocumentType.class).newItemSupplier(SetDocumentType::new).build();
+        EnhancedType<Set<SetDocumentType>> type =
+            EnhancedType.setOf(EnhancedType.documentOf(SetDocumentType.class, documentSchema));
+
+        assertThatThrownBy(() -> setProvider.converterFor(type))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage(unsupportedSetMemberMessage(SetDocumentType.class));
+    }
+
+    @Test
+    @DisplayName("A custom NULL member converter is rejected as a set member")
+    void converterFor_whenNullAttributeTypeMemberSet_throwsIllegalArgumentException() {
+        DefaultAttributeConverterProvider setProvider = providerWithDeclaredMemberConverter(
+            NullSetMember.class, AttributeValueType.NULL);
+        EnhancedType<Set<NullSetMember>> type = EnhancedType.setOf(NullSetMember.class);
+
+        assertThatThrownBy(() -> setProvider.converterFor(type))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage(unsupportedSetMemberMessage(NullSetMember.class));
+    }
+
+    @Test
+    @DisplayName("A custom SS member converter is rejected as a set member")
+    void converterFor_whenSsAttributeTypeMemberSet_throwsIllegalArgumentException() {
+        DefaultAttributeConverterProvider setProvider = providerWithDeclaredMemberConverter(
+            StringSetMember.class, AttributeValueType.SS);
+        EnhancedType<Set<StringSetMember>> type = EnhancedType.setOf(StringSetMember.class);
+
+        assertThatThrownBy(() -> setProvider.converterFor(type))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage(unsupportedSetMemberMessage(StringSetMember.class));
+    }
+
+    @Test
+    @DisplayName("A custom NS member converter is rejected as a set member")
+    void converterFor_whenNsAttributeTypeMemberSet_throwsIllegalArgumentException() {
+        DefaultAttributeConverterProvider setProvider = providerWithDeclaredMemberConverter(
+            NumberSetMember.class, AttributeValueType.NS);
+        EnhancedType<Set<NumberSetMember>> type = EnhancedType.setOf(NumberSetMember.class);
+
+        assertThatThrownBy(() -> setProvider.converterFor(type))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage(unsupportedSetMemberMessage(NumberSetMember.class));
+    }
+
+    @Test
+    @DisplayName("A custom BS member converter is rejected as a set member")
+    void converterFor_whenBsAttributeTypeMemberSet_throwsIllegalArgumentException() {
+        DefaultAttributeConverterProvider setProvider = providerWithDeclaredMemberConverter(
+            BinarySetMember.class, AttributeValueType.BS);
+        EnhancedType<Set<BinarySetMember>> type = EnhancedType.setOf(BinarySetMember.class);
+
+        assertThatThrownBy(() -> setProvider.converterFor(type))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage(unsupportedSetMemberMessage(BinarySetMember.class));
+    }
+
+    @Test
+    @DisplayName("An Object set member fails converter lookup")
+    void converterFor_whenObjectMemberSet_throwsConverterNotFound() {
+        DefaultAttributeConverterProvider setProvider = new DefaultAttributeConverterProvider();
+        EnhancedType<Set<Object>> type = EnhancedType.setOf(Object.class);
+
+        assertThatThrownBy(() -> setProvider.converterFor(type))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + EnhancedType.of(Object.class));
+    }
+
+    @Test
+    @DisplayName("A document class without a schema is an unsupported set member")
+    void converterFor_whenDocumentClassWithoutSchemaSet_throwsIllegalStateException() {
+        DefaultAttributeConverterProvider setProvider = new DefaultAttributeConverterProvider();
+        EnhancedType<Set<SetDocumentType>> type = EnhancedType.setOf(SetDocumentType.class);
+
+        assertThatThrownBy(() -> setProvider.converterFor(type))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + EnhancedType.of(SetDocumentType.class));
+    }
+
+    @Test
+    @DisplayName("A wildcard set member fails while reading the raw class")
+    void converterFor_whenWildcardSetMember_throwsIllegalArgumentException() {
+        DefaultAttributeConverterProvider setProvider = new DefaultAttributeConverterProvider();
+        EnhancedType<Set<?>> type = new EnhancedType<Set<?>>() {
+        };
+
+        assertThatThrownBy(() -> setProvider.converterFor(type))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("A wildcard type is not expected here.");
+    }
+
+    @Test
+    @DisplayName("Collection of String uses set semantics and reads a LinkedHashSet")
+    void converterFor_whenStringCollection_convertsToSsAndReadsLinkedHashSet() {
+        DefaultAttributeConverterProvider setProvider = new DefaultAttributeConverterProvider();
+        EnhancedType<Collection<String>> type = EnhancedType.collectionOf(String.class);
+        Collection<String> input = new ArrayList<>();
+        input.add("a");
+        input.add("b");
+
+        AttributeConverter<Collection<String>> converter = setProvider.converterFor(type);
+        AttributeValue stored = converter.transformFrom(input);
+        Collection<String> read = converter.transformTo(stored);
+
+        assertThat(converter).isInstanceOf(SetAttributeConverter.class);
+        assertThat(converter.attributeValueType()).isEqualTo(AttributeValueType.SS);
+        assertThat(stored.ss()).containsExactly("a", "b");
+        assertThat(read).isInstanceOf(LinkedHashSet.class)
+                        .containsExactly("a", "b");
+    }
+
+    @Test
+    @DisplayName("Iterable of String uses set semantics when the value is a LinkedHashSet")
+    void converterFor_whenStringIterableWithLinkedHashSet_convertsToSsAndReadsLinkedHashSet() {
+        DefaultAttributeConverterProvider setProvider = new DefaultAttributeConverterProvider();
+        EnhancedType<Iterable<String>> type = new EnhancedType<Iterable<String>>() {
+        };
+        Iterable<String> input = linkedSet("a", "b");
+
+        AttributeConverter<Iterable<String>> converter = setProvider.converterFor(type);
+        AttributeValue stored = converter.transformFrom(input);
+        Iterable<String> read = converter.transformTo(stored);
+
+        assertThat(converter).isInstanceOf(SetAttributeConverter.class);
+        assertThat(converter.attributeValueType()).isEqualTo(AttributeValueType.SS);
+        assertThat(stored.ss()).containsExactly("a", "b");
+        assertThat(read).isInstanceOf(LinkedHashSet.class)
+                        .isEqualTo(linkedSet("a", "b"));
+    }
+
+    @Test
+    @DisplayName("A non-Collection Iterable is selected as a set converter and fails while converting")
+    void converterFor_whenNonCollectionIterable_throwsClassCastException() {
+        DefaultAttributeConverterProvider setProvider = new DefaultAttributeConverterProvider();
+        EnhancedType<Iterable<String>> type = new EnhancedType<Iterable<String>>() {
+        };
+        Iterable<String> input = new NonCollectionIterable();
+
+        AttributeConverter<Iterable<String>> converter = setProvider.converterFor(type);
+
+        assertThat(converter).isInstanceOf(SetAttributeConverter.class);
+        assertThatThrownBy(() -> converter.transformFrom(input))
+            .isInstanceOf(ClassCastException.class);
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("unsupportedSetImplementationTypes")
+    @DisplayName("Unsupported Set implementations fail converter lookup")
+    void converterFor_whenUnsupportedSetImplementation_throwsIllegalStateException(EnhancedType<?> type) {
+        DefaultAttributeConverterProvider setProvider = new DefaultAttributeConverterProvider();
+
+        assertThatThrownBy(() -> setProvider.converterFor(type))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + type);
+    }
+
+    private static Stream<EnhancedType<?>> unsupportedSetImplementationTypes() {
+        return Stream.of(EnhancedType.sortedSetOf(String.class), EnhancedType.navigableSetOf(String.class),
+                         new EnhancedType<SetCustomSet<String>>() {
+                         }, new EnhancedType<LinkedHashSet<String>>() {
+            }, new EnhancedType<TreeSet<String>>() {
+            }, new EnhancedType<CopyOnWriteArraySet<String>>() {
+            });
+    }
+
+    private static <T> DefaultAttributeConverterProvider providerWithDeclaredMemberConverter(
+        Class<T> memberClass, AttributeValueType attributeValueType) {
+        return DefaultAttributeConverterProvider.builder()
+                                                .addConverter(new DeclaredTypeConverter<>(memberClass, attributeValueType))
+                                                .build();
+    }
+
+    private static String unsupportedSetMemberMessage(Class<?> rawClass) {
+        return "SetAttributeConverter cannot be created with a parameterized type of '" + rawClass
+               + UNSUPPORTED_SET_MEMBER_SUFFIX;
+    }
+
+    @SafeVarargs
+    private static <T> LinkedHashSet<T> linkedSet(T... values) {
+        LinkedHashSet<T> result = new LinkedHashSet<>();
+        result.addAll(Arrays.asList(values));
+        return result;
+    }
+
+    private static final class DeclaredTypeConverter<T> implements AttributeConverter<T> {
+        private final EnhancedType<T> type;
+        private final AttributeValueType attributeValueType;
+
+        DeclaredTypeConverter(Class<T> rawClass, AttributeValueType attributeValueType) {
+            this.type = EnhancedType.of(rawClass);
+            this.attributeValueType = attributeValueType;
+        }
+
+        @Override
+        public AttributeValue transformFrom(T input) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public T transformTo(AttributeValue input) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public EnhancedType<T> type() {
+            return type;
+        }
+
+        @Override
+        public AttributeValueType attributeValueType() {
+            return attributeValueType;
+        }
+    }
+
+    static class SetDocumentType {
+    }
+
+    static class NullSetMember {
+    }
+
+    static class StringSetMember {
+    }
+
+    static class NumberSetMember {
+    }
+
+    static class BinarySetMember {
+    }
+
+    enum SetTestEnum {
+        OPEN,
+        CLOSED
+    }
+
+    static final class SetCustomSet<T> extends HashSet<T> {
+    }
+
+    static final class NonCollectionIterable implements Iterable<String> {
+        @Override
+        public Iterator<String> iterator() {
+            return Collections.singletonList("a").iterator();
+        }
+    }
+
+    // Map declarations, keys, values, and nested map values.
+    @Test
+    @DisplayName("String-to-Integer map round-trips as a LinkedHashMap")
+    void converterFor_whenStringIntegerMap_roundTripsLinkedHashMap() {
+        DefaultAttributeConverterProvider mapProvider = new DefaultAttributeConverterProvider();
+        EnhancedType<Map<String, Integer>> type = EnhancedType.mapOf(String.class, Integer.class);
+        Map<String, Integer> input = new LinkedHashMap<>();
+        input.put("one", 1);
+
+        AttributeConverter<Map<String, Integer>> converter = mapProvider.converterFor(type);
+        AttributeValue stored = converter.transformFrom(input);
+        Map<String, Integer> read = converter.transformTo(stored);
+
+        assertThat(converter).isInstanceOf(MapAttributeConverter.class);
+        assertThat(converter.attributeValueType()).isEqualTo(AttributeValueType.M);
+        assertThat(stored.m().get("one").n()).isEqualTo("1");
+        assertThat(read).isInstanceOf(LinkedHashMap.class).isEqualTo(input);
+    }
+
+    @Test
+    @DisplayName("An empty String-to-Integer map round-trips as an empty LinkedHashMap")
+    void converterFor_whenEmptyStringIntegerMap_roundTripsEmptyLinkedHashMap() {
+        DefaultAttributeConverterProvider mapProvider = new DefaultAttributeConverterProvider();
+        EnhancedType<Map<String, Integer>> type = EnhancedType.mapOf(String.class, Integer.class);
+        Map<String, Integer> input = Collections.emptyMap();
+
+        AttributeConverter<Map<String, Integer>> converter = mapProvider.converterFor(type);
+        AttributeValue stored = converter.transformFrom(input);
+        Map<String, Integer> read = converter.transformTo(stored);
+
+        assertThat(converter).isInstanceOf(MapAttributeConverter.class);
+        assertThat(converter.attributeValueType()).isEqualTo(AttributeValueType.M);
+        assertThat(stored.m()).isEmpty();
+        assertThat(read).isInstanceOf(LinkedHashMap.class).isEmpty();
+    }
+
+    @Test
+    @DisplayName("UUID keys and Instant values convert independently through the map converter")
+    void converterFor_whenUuidToInstantMap_roundTripsLinkedHashMap() {
+        DefaultAttributeConverterProvider mapProvider = new DefaultAttributeConverterProvider();
+        EnhancedType<Map<UUID, Instant>> type = EnhancedType.mapOf(UUID.class, Instant.class);
+        UUID uuid = UUID.fromString("123e4567-e89b-12d3-a456-426614174000");
+        Instant instant = Instant.parse("2020-01-02T03:04:05Z");
+        Map<UUID, Instant> input = new LinkedHashMap<>();
+        input.put(uuid, instant);
+
+        AttributeConverter<Map<UUID, Instant>> converter = mapProvider.converterFor(type);
+        AttributeValue stored = converter.transformFrom(input);
+        Map<UUID, Instant> read = converter.transformTo(stored);
+
+        assertThat(converter).isInstanceOf(MapAttributeConverter.class);
+        assertThat(converter.attributeValueType()).isEqualTo(AttributeValueType.M);
+        assertThat(stored.m()).hasSize(1);
+        assertThat(stored.m().get(uuid.toString()).s()).isEqualTo("2020-01-02T03:04:05Z");
+        assertThat(read).isInstanceOf(LinkedHashMap.class).isEqualTo(input);
+    }
+
+    @Test
+    @DisplayName("Year is a valid map key through the string-converter registry")
+    void converterFor_whenYearToStringMap_roundTripsLinkedHashMapWithYearKey() {
+        DefaultAttributeConverterProvider mapProvider = new DefaultAttributeConverterProvider();
+        EnhancedType<Map<Year, String>> type = EnhancedType.mapOf(Year.class, String.class);
+        Year year = Year.of(2026);
+        Map<Year, String> input = new LinkedHashMap<>();
+        input.put(year, "value");
+
+        AttributeConverter<Map<Year, String>> converter = mapProvider.converterFor(type);
+        AttributeValue stored = converter.transformFrom(input);
+        Map<Year, String> read = converter.transformTo(stored);
+
+        assertThat(converter).isInstanceOf(MapAttributeConverter.class);
+        assertThat(converter.attributeValueType()).isEqualTo(AttributeValueType.M);
+        assertThat(stored.m()).containsOnlyKeys("2026");
+        assertThat(read).isInstanceOf(LinkedHashMap.class);
+        assertThat(read).containsEntry(year, "value");
+    }
+
+    @Test
+    @DisplayName("Direct Year lookup has no attribute converter")
+    void converterFor_whenYearType_throwsConverterNotFound() {
+        DefaultAttributeConverterProvider mapProvider = new DefaultAttributeConverterProvider();
+        EnhancedType<Year> type = EnhancedType.of(Year.class);
+
+        assertThatThrownBy(() -> mapProvider.converterFor(type))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + EnhancedType.of(Year.class));
+    }
+
+    @Test
+    @DisplayName("SdkBytes is not a registered map-key string type")
+    void converterFor_whenSdkBytesKeyMap_throwsNoStringConverter() {
+        DefaultAttributeConverterProvider mapProvider = new DefaultAttributeConverterProvider();
+        EnhancedType<Map<SdkBytes, String>> type = EnhancedType.mapOf(SdkBytes.class, String.class);
+
+        assertThatThrownBy(() -> mapProvider.converterFor(type))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("No string converter exists for class software.amazon.awssdk.core.SdkBytes");
+    }
+
+    @Test
+    @DisplayName("Enum generation does not apply to map keys")
+    void converterFor_whenEnumKeyMap_throwsNoStringConverter() {
+        DefaultAttributeConverterProvider mapProvider = new DefaultAttributeConverterProvider();
+        EnhancedType<Map<MapTestEnum, String>> type = EnhancedType.mapOf(MapTestEnum.class, String.class);
+
+        assertThatThrownBy(() -> mapProvider.converterFor(type))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("No string converter exists for " + MapTestEnum.class);
+    }
+
+    @Test
+    @DisplayName("An attribute-only custom converter cannot enable a map key")
+    void converterFor_whenAttributeOnlyKeyMap_throwsNoStringConverter() {
+        DefaultAttributeConverterProvider mapProvider = DefaultAttributeConverterProvider.builder()
+                                                                                         .addConverter(new AttributeOnlyKeyConverter())
+                                                                                         .addConverter(StringAttributeConverter.create())
+                                                                                         .build();
+        EnhancedType<Map<AttributeOnlyKey, String>> type =
+            EnhancedType.mapOf(AttributeOnlyKey.class, String.class);
+
+        assertThatThrownBy(() -> mapProvider.converterFor(type))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("No string converter exists for " + AttributeOnlyKey.class);
+    }
+
+    @Test
+    @DisplayName("Object map keys have no string converter")
+    void converterFor_whenObjectKeyMap_throwsNoStringConverter() {
+        DefaultAttributeConverterProvider mapProvider = new DefaultAttributeConverterProvider();
+        EnhancedType<Map<Object, String>> type = EnhancedType.mapOf(Object.class, String.class);
+
+        assertThatThrownBy(() -> mapProvider.converterFor(type))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("No string converter exists for class java.lang.Object");
+    }
+
+    @Test
+    @DisplayName("A nested map token cannot be used as a map key")
+    void converterFor_whenMapTokenKey_throwsNoStringConverter() {
+        DefaultAttributeConverterProvider mapProvider = new DefaultAttributeConverterProvider();
+        EnhancedType<Map<Map<String, String>, String>> type =
+            EnhancedType.mapOf(EnhancedType.mapOf(String.class, String.class), EnhancedType.of(String.class));
+
+        assertThatThrownBy(() -> mapProvider.converterFor(type))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("No string converter exists for interface java.util.Map");
+    }
+
+    @Test
+    @DisplayName("A list token cannot be used as a map key")
+    void converterFor_whenListTokenKey_throwsNoStringConverter() {
+        DefaultAttributeConverterProvider mapProvider = new DefaultAttributeConverterProvider();
+        EnhancedType<Map<List<String>, String>> type =
+            EnhancedType.mapOf(EnhancedType.listOf(String.class), EnhancedType.of(String.class));
+
+        assertThatThrownBy(() -> mapProvider.converterFor(type))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("No string converter exists for interface java.util.List");
+    }
+
+    @Test
+    @DisplayName("A set token cannot be used as a map key")
+    void converterFor_whenSetTokenKey_throwsNoStringConverter() {
+        DefaultAttributeConverterProvider mapProvider = new DefaultAttributeConverterProvider();
+        EnhancedType<Map<Set<String>, String>> type =
+            EnhancedType.mapOf(EnhancedType.setOf(String.class), EnhancedType.of(String.class));
+
+        assertThatThrownBy(() -> mapProvider.converterFor(type))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("No string converter exists for interface java.util.Set");
+    }
+
+    @Test
+    @DisplayName("A document token cannot be used as a map key")
+    void converterFor_whenDocumentTokenKey_throwsNoStringConverter() {
+        DefaultAttributeConverterProvider mapProvider = new DefaultAttributeConverterProvider();
+        TableSchema<MapDocumentType> mapDocumentSchema = mock(TableSchema.class);
+        EnhancedType<Map<MapDocumentType, String>> type =
+            EnhancedType.mapOf(EnhancedType.documentOf(MapDocumentType.class, mapDocumentSchema),
+                               EnhancedType.of(String.class));
+
+        assertThatThrownBy(() -> mapProvider.converterFor(type))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("No string converter exists for " + MapDocumentType.class);
+        verifyNoInteractions(mapDocumentSchema);
+    }
+
+    @Test
+    @DisplayName("A wildcard map key fails during raw-class validation")
+    void converterFor_whenWildcardKeyMap_throwsWildcardNotExpected() {
+        DefaultAttributeConverterProvider mapProvider = new DefaultAttributeConverterProvider();
+        EnhancedType<Map<?, String>> type = new EnhancedType<Map<?, String>>() {
+        };
+
+        assertThatThrownBy(() -> mapProvider.converterFor(type))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("A wildcard type is not expected here.");
+    }
+
+    @Test
+    @DisplayName("An Object map value fails converter lookup")
+    void converterFor_whenObjectValueMap_throwsConverterNotFound() {
+        DefaultAttributeConverterProvider mapProvider = new DefaultAttributeConverterProvider();
+        EnhancedType<Map<String, Object>> type = EnhancedType.mapOf(String.class, Object.class);
+
+        assertThatThrownBy(() -> mapProvider.converterFor(type))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + EnhancedType.of(Object.class));
+    }
+
+    @Test
+    @DisplayName("A document class without a schema is an unsupported map value")
+    void converterFor_whenDocumentValueWithoutSchema_throwsConverterNotFound() {
+        DefaultAttributeConverterProvider mapProvider = new DefaultAttributeConverterProvider();
+        EnhancedType<Map<String, MapDocumentType>> type = EnhancedType.mapOf(String.class, MapDocumentType.class);
+
+        assertThatThrownBy(() -> mapProvider.converterFor(type))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + EnhancedType.of(MapDocumentType.class));
+    }
+
+    @Test
+    @DisplayName("A list-valued map preserves list order and duplicates")
+    void converterFor_whenListValuedMap_roundTripsLinkedHashMapWithArrayList() {
+        DefaultAttributeConverterProvider mapProvider = new DefaultAttributeConverterProvider();
+        EnhancedType<Map<String, List<String>>> type =
+            EnhancedType.mapOf(EnhancedType.of(String.class), EnhancedType.listOf(String.class));
+        List<String> list = new ArrayList<>();
+        list.add("a");
+        list.add("a");
+        Map<String, List<String>> input = new LinkedHashMap<>();
+        input.put("one", list);
+
+        AttributeConverter<Map<String, List<String>>> converter = mapProvider.converterFor(type);
+        AttributeValue stored = converter.transformFrom(input);
+        Map<String, List<String>> read = converter.transformTo(stored);
+
+        assertThat(converter).isInstanceOf(MapAttributeConverter.class);
+        assertThat(converter.attributeValueType()).isEqualTo(AttributeValueType.M);
+        assertThat(stored.m().get("one").l()).extracting(AttributeValue::s).containsExactly("a", "a");
+        assertThat(read).isInstanceOf(LinkedHashMap.class);
+        assertThat(read.get("one")).isInstanceOf(ArrayList.class).containsExactly("a", "a");
+    }
+
+    @Test
+    @DisplayName("A set-valued map stores a string set and reads a LinkedHashSet")
+    void converterFor_whenSetValuedMap_roundTripsLinkedHashMapWithLinkedHashSet() {
+        DefaultAttributeConverterProvider mapProvider = new DefaultAttributeConverterProvider();
+        EnhancedType<Map<String, Set<String>>> type =
+            EnhancedType.mapOf(EnhancedType.of(String.class), EnhancedType.setOf(String.class));
+        Set<String> set = new LinkedHashSet<>();
+        set.add("a");
+        set.add("b");
+        Map<String, Set<String>> input = new LinkedHashMap<>();
+        input.put("one", set);
+
+        AttributeConverter<Map<String, Set<String>>> converter = mapProvider.converterFor(type);
+        AttributeValue stored = converter.transformFrom(input);
+        Map<String, Set<String>> read = converter.transformTo(stored);
+
+        assertThat(converter).isInstanceOf(MapAttributeConverter.class);
+        assertThat(converter.attributeValueType()).isEqualTo(AttributeValueType.M);
+        assertThat(stored.m().get("one").ss()).containsExactly("a", "b");
+        assertThat(read).isInstanceOf(LinkedHashMap.class);
+        assertThat(read.get("one")).isInstanceOf(LinkedHashSet.class).containsExactly("a", "b");
+    }
+
+    @Test
+    @DisplayName("A map-valued map uses M at both levels and reads LinkedHashMap at both levels")
+    void converterFor_whenMapValuedMap_roundTripsNestedLinkedHashMaps() {
+        DefaultAttributeConverterProvider mapProvider = new DefaultAttributeConverterProvider();
+        EnhancedType<Map<String, Map<String, Integer>>> type =
+            EnhancedType.mapOf(EnhancedType.of(String.class),
+                               EnhancedType.mapOf(String.class, Integer.class));
+        Map<String, Integer> inner = new LinkedHashMap<>();
+        inner.put("one", 1);
+        Map<String, Map<String, Integer>> input = new LinkedHashMap<>();
+        input.put("nested", inner);
+
+        AttributeConverter<Map<String, Map<String, Integer>>> converter = mapProvider.converterFor(type);
+        AttributeValue stored = converter.transformFrom(input);
+        Map<String, Map<String, Integer>> read = converter.transformTo(stored);
+
+        assertThat(converter).isInstanceOf(MapAttributeConverter.class);
+        assertThat(converter.attributeValueType()).isEqualTo(AttributeValueType.M);
+        assertThat(stored.m().get("nested").m().get("one").n()).isEqualTo("1");
+        assertThat(read).isInstanceOf(LinkedHashMap.class);
+        assertThat(read.get("nested")).isInstanceOf(LinkedHashMap.class).isEqualTo(inner);
+    }
+
+    @Test
+    @DisplayName("An enum-valued map stores the constant toString as S")
+    void converterFor_whenEnumValuedMap_roundTripsLinkedHashMap() {
+        DefaultAttributeConverterProvider mapProvider = new DefaultAttributeConverterProvider();
+        EnhancedType<Map<String, MapTestEnum>> type = EnhancedType.mapOf(String.class, MapTestEnum.class);
+        Map<String, MapTestEnum> input = new LinkedHashMap<>();
+        input.put("state", MapTestEnum.OPEN);
+
+        AttributeConverter<Map<String, MapTestEnum>> converter = mapProvider.converterFor(type);
+        AttributeValue stored = converter.transformFrom(input);
+        Map<String, MapTestEnum> read = converter.transformTo(stored);
+
+        assertThat(converter).isInstanceOf(MapAttributeConverter.class);
+        assertThat(converter.attributeValueType()).isEqualTo(AttributeValueType.M);
+        assertThat(stored.m().get("state").s()).isEqualTo(MapTestEnum.OPEN.toString());
+        assertThat(read).isInstanceOf(LinkedHashMap.class).containsEntry("state", MapTestEnum.OPEN);
+    }
+
+    @Test
+    @DisplayName("A document-valued map delegates both conversions to the table schema")
+    void converterFor_whenDocumentValuedMap_invokesSchemaAndRoundTripsLinkedHashMap() {
+        DefaultAttributeConverterProvider mapProvider = new DefaultAttributeConverterProvider();
+        TableSchema<MapDocumentType> schema = mapDocumentSchema();
+        MapDocumentType inputDocument = new MapDocumentType();
+        inputDocument.setName("doc");
+        EnhancedType<Map<String, MapDocumentType>> type =
+            EnhancedType.mapOf(EnhancedType.of(String.class),
+                               EnhancedType.documentOf(MapDocumentType.class, schema));
+        Map<String, MapDocumentType> input = new LinkedHashMap<>();
+        input.put("doc", inputDocument);
+
+        AttributeConverter<Map<String, MapDocumentType>> converter = mapProvider.converterFor(type);
+        AttributeValue stored = converter.transformFrom(input);
+        Map<String, MapDocumentType> read = converter.transformTo(stored);
+
+        assertThat(converter).isInstanceOf(MapAttributeConverter.class);
+        assertThat(converter.attributeValueType()).isEqualTo(AttributeValueType.M);
+        assertThat(stored.m().get("doc").m()).containsEntry("name", AttributeValue.fromS("doc"));
+        assertThat(read).isInstanceOf(LinkedHashMap.class);
+        assertThat(read.get("doc").getName()).isEqualTo("doc");
+    }
+
+    @Test
+    @DisplayName("A map whose value is a list of sets nests M, L, then SS")
+    void converterFor_whenListOfSetsValuedMap_roundTripsNestedCollectionClasses() {
+        DefaultAttributeConverterProvider mapProvider = new DefaultAttributeConverterProvider();
+        EnhancedType<Map<String, List<Set<String>>>> type =
+            EnhancedType.mapOf(EnhancedType.of(String.class),
+                               EnhancedType.listOf(EnhancedType.setOf(String.class)));
+        Set<String> set = new LinkedHashSet<>();
+        set.add("a");
+        set.add("b");
+        List<Set<String>> list = new ArrayList<>();
+        list.add(set);
+        Map<String, List<Set<String>>> input = new LinkedHashMap<>();
+        input.put("one", list);
+
+        AttributeConverter<Map<String, List<Set<String>>>> converter = mapProvider.converterFor(type);
+        AttributeValue stored = converter.transformFrom(input);
+        Map<String, List<Set<String>>> read = converter.transformTo(stored);
+
+        assertThat(converter).isInstanceOf(MapAttributeConverter.class);
+        assertThat(converter.attributeValueType()).isEqualTo(AttributeValueType.M);
+        assertThat(stored.m().get("one").l()).hasSize(1);
+        assertThat(stored.m().get("one").l().get(0).ss()).containsExactly("a", "b");
+        assertThat(read).isInstanceOf(LinkedHashMap.class);
+        assertThat(read.get("one")).isInstanceOf(ArrayList.class);
+        assertThat(read.get("one").get(0)).isInstanceOf(LinkedHashSet.class).containsExactly("a", "b");
+    }
+
+    @Test
+    @DisplayName("A null Java map key is rejected while wrapping the stored map")
+    void converterFor_whenNullMapKey_throwsMapMustNotHaveNullKeys() {
+        DefaultAttributeConverterProvider mapProvider = new DefaultAttributeConverterProvider();
+        EnhancedType<Map<String, String>> type = EnhancedType.mapOf(String.class, String.class);
+        Map<String, String> input = new HashMap<>();
+        input.put(null, "value");
+        AttributeConverter<Map<String, String>> converter = mapProvider.converterFor(type);
+
+        assertThatThrownBy(() -> converter.transformFrom(input))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Map must not have null keys.");
+    }
+
+    @Test
+    @DisplayName("A null string map value is stored as DynamoDB NULL")
+    void converterFor_whenNullStringMapValue_roundTripsNullValue() {
+        DefaultAttributeConverterProvider mapProvider = new DefaultAttributeConverterProvider();
+        EnhancedType<Map<String, String>> type = EnhancedType.mapOf(String.class, String.class);
+        Map<String, String> input = new LinkedHashMap<>();
+        input.put("key", null);
+
+        AttributeConverter<Map<String, String>> converter = mapProvider.converterFor(type);
+        AttributeValue stored = converter.transformFrom(input);
+        Map<String, String> read = converter.transformTo(stored);
+
+        assertThat(converter).isInstanceOf(MapAttributeConverter.class);
+        assertThat(converter.attributeValueType()).isEqualTo(AttributeValueType.M);
+        assertThat(stored.m().get("key").nul()).isTrue();
+        assertThat(read).isInstanceOf(LinkedHashMap.class);
+        assertThat(read).containsEntry("key", null);
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("unsupportedMapImplementationTypes")
+    @DisplayName("Unsupported Map implementations fail converter lookup")
+    void converterFor_whenUnsupportedMapImplementation_throwsConverterNotFound(EnhancedType<?> type) {
+        DefaultAttributeConverterProvider mapProvider = new DefaultAttributeConverterProvider();
+
+        assertThatThrownBy(() -> mapProvider.converterFor(type))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + type);
+    }
+
+    @Test
+    @DisplayName("A nested list of Object fails converter lookup for the inner Object")
+    void converterFor_whenNestedListOfObject_throwsConverterNotFoundForInnerObject() {
+        DefaultAttributeConverterProvider mapProvider = new DefaultAttributeConverterProvider();
+        EnhancedType<List<Object>> listType = EnhancedType.listOf(Object.class);
+        EnhancedType<Map<String, List<Object>>> type =
+            EnhancedType.mapOf(EnhancedType.of(String.class), listType);
+
+        assertThatThrownBy(() -> mapProvider.converterFor(type))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + EnhancedType.of(Object.class));
+    }
+
+    @Test
+    @DisplayName("A nested list of an unsupported member reports that member in the error")
+    void converterFor_whenNestedListOfUnsupportedType_throwsConverterNotFoundForMember() {
+        DefaultAttributeConverterProvider mapProvider = new DefaultAttributeConverterProvider();
+        EnhancedType<Map<String, List<MapUnsupportedType>>> type =
+            EnhancedType.mapOf(EnhancedType.of(String.class), EnhancedType.listOf(MapUnsupportedType.class));
+
+        assertThatThrownBy(() -> mapProvider.converterFor(type))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + EnhancedType.of(MapUnsupportedType.class));
+    }
+
+    @Test
+    @DisplayName("A raw nested Map value fails converter lookup")
+    void converterFor_whenRawNestedMapValue_throwsConverterNotFound() {
+        DefaultAttributeConverterProvider mapProvider = new DefaultAttributeConverterProvider();
+        EnhancedType<Map<String, Map>> type =
+            EnhancedType.mapOf(EnhancedType.of(String.class), EnhancedType.of(Map.class));
+
+        assertThatThrownBy(() -> mapProvider.converterFor(type))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + EnhancedType.of(Map.class)
+                        + ". Type parameters are required for this type.");
+    }
+
+    @Test
+    @DisplayName("A wildcard map value fails during nested raw-class validation")
+    void converterFor_whenWildcardValueMap_throwsWildcardNotExpected() {
+        DefaultAttributeConverterProvider mapProvider = new DefaultAttributeConverterProvider();
+        EnhancedType<Map<String, ?>> type = new EnhancedType<Map<String, ?>>() {
+        };
+
+        assertThatThrownBy(() -> mapProvider.converterFor(type))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("A wildcard type is not expected here.");
+    }
+
+    @Test
+    @DisplayName("An integer map key is stored as the decimal string name")
+    void converterFor_whenIntegerKeyMap_roundTripsLinkedHashMap() {
+        DefaultAttributeConverterProvider mapProvider = new DefaultAttributeConverterProvider();
+        EnhancedType<Map<Integer, String>> type = EnhancedType.mapOf(Integer.class, String.class);
+        Map<Integer, String> input = new LinkedHashMap<>();
+        input.put(7, "value");
+
+        AttributeConverter<Map<Integer, String>> converter = mapProvider.converterFor(type);
+        AttributeValue stored = converter.transformFrom(input);
+        Map<Integer, String> read = converter.transformTo(stored);
+
+        assertThat(converter).isInstanceOf(MapAttributeConverter.class);
+        assertThat(converter.attributeValueType()).isEqualTo(AttributeValueType.M);
+        assertThat(stored.m()).containsOnlyKeys("7");
+        assertThat(read).isInstanceOf(LinkedHashMap.class).containsEntry(7, "value");
+    }
+
+    @Test
+    @DisplayName("A byte-array map key is stored as Base64 text")
+    void converterFor_whenByteArrayKeyMap_roundTripsBase64Key() {
+        DefaultAttributeConverterProvider mapProvider = new DefaultAttributeConverterProvider();
+        EnhancedType<Map<byte[], String>> type = EnhancedType.mapOf(byte[].class, String.class);
+        Map<byte[], String> input = new LinkedHashMap<>();
+        input.put(new byte[] {1, 2}, "value");
+
+        AttributeConverter<Map<byte[], String>> converter = mapProvider.converterFor(type);
+        AttributeValue stored = converter.transformFrom(input);
+        Map<byte[], String> read = converter.transformTo(stored);
+
+        assertThat(converter).isInstanceOf(MapAttributeConverter.class);
+        assertThat(converter.attributeValueType()).isEqualTo(AttributeValueType.M);
+        assertThat(stored.m()).containsOnlyKeys("AQI=");
+        assertThat(read).isInstanceOf(LinkedHashMap.class).hasSize(1);
+        assertThat(read.keySet().iterator().next()).containsExactly((byte) 1, (byte) 2);
+        assertThat(read.values()).containsExactly("value");
+    }
+
+    private static Stream<EnhancedType<?>> unsupportedMapImplementationTypes() {
+        return Stream.of(EnhancedType.sortedMapOf(String.class, Integer.class),
+                         EnhancedType.navigableMapOf(String.class, Integer.class),
+                         EnhancedType.concurrentMapOf(String.class, Integer.class),
+                         new EnhancedType<MapCustomMap<String, Integer>>() {
+                         }, new EnhancedType<LinkedHashMap<String, Integer>>() {
+            }, new EnhancedType<TreeMap<String, Integer>>() {
+            }, new EnhancedType<ConcurrentHashMap<String, Integer>>() {
+            }, new EnhancedType<EnumMap<MapTestEnum, String>>() {
+            });
+    }
+
+    static class MapUnsupportedType {
+    }
+
+    private static TableSchema<MapDocumentType> mapDocumentSchema() {
+        return StaticTableSchema.builder(MapDocumentType.class)
+                                .newItemSupplier(MapDocumentType::new)
+                                .addAttribute(String.class, a -> a.name("name")
+                                                                  .getter(MapDocumentType::getName)
+                                                                  .setter(MapDocumentType::setName))
+                                .build();
+    }
+
+    static class MapDocumentType {
+        private String name;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+
+    enum MapTestEnum {
+        OPEN,
+        CLOSED
+    }
+
+    static class AttributeOnlyKey {
+    }
+
+    static class MapCustomMap<K, V> extends HashMap<K, V> {
+    }
+
+    static final class AttributeOnlyKeyConverter implements AttributeConverter<AttributeOnlyKey> {
+        @Override
+        public AttributeValue transformFrom(AttributeOnlyKey input) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public AttributeOnlyKey transformTo(AttributeValue input) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public EnhancedType<AttributeOnlyKey> type() {
+            return EnhancedType.of(AttributeOnlyKey.class);
+        }
+
+        @Override
+        public AttributeValueType attributeValueType() {
+            return AttributeValueType.S;
+        }
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/DefaultAttributeConverterProviderConversionTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/DefaultAttributeConverterProviderConversionTest.java
@@ -1,0 +1,955 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.OptionalInt;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.SetAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.StaticTableSchema;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+
+/**
+ * Tests converter behavior after lookup and the type tokens used to request converters.
+ * <p>
+ * The tests cover unsupported type shapes, incorrect DynamoDB attribute forms, Java null values, DynamoDB null values,
+ * and enumeration conversion. They also verify propagation of failures from collection members and table schemas,
+ * including document conversion options passed to a schema.
+ */
+public class DefaultAttributeConverterProviderConversionTest {
+
+    @Test
+    @DisplayName("Null class fails during token construction before provider lookup")
+    void of_whenNullClass_throwsIllegalArgumentExceptionBeforeProviderLookup() {
+        assertThatThrownBy(() -> EnhancedType.of((Class<Object>) null))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("class java.lang.Object isn't parameterized");
+    }
+
+    @Test
+    @DisplayName("Unbounded wildcard construction succeeds and later rawClass fails")
+    void of_whenUnboundedWildcardType_isWildcardAndRawClassThrowsIllegalArgumentException() {
+        EnhancedType<?> type = EnhancedType.of(wildcardTypeArgument("unbounded"));
+
+        assertThat(type.isWildcard()).isTrue();
+        assertThat(type.toString()).isEqualTo("EnhancedType(?)");
+        assertThatThrownBy(type::rawClass)
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("A wildcard type is not expected here.");
+    }
+
+    @Test
+    @DisplayName("Upper-bounded wildcard construction succeeds and later rawClass fails")
+    void of_whenUpperBoundedWildcardType_isWildcardAndRawClassThrowsIllegalArgumentException() {
+        EnhancedType<?> type = EnhancedType.of(wildcardTypeArgument("upperBounded"));
+
+        assertThat(type.isWildcard()).isTrue();
+        assertThatThrownBy(type::rawClass)
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("A wildcard type is not expected here.");
+    }
+
+    @Test
+    @DisplayName("Lower-bounded wildcard construction succeeds and later rawClass fails")
+    void of_whenLowerBoundedWildcardType_isWildcardAndRawClassThrowsIllegalArgumentException() {
+        EnhancedType<?> type = EnhancedType.of(wildcardTypeArgument("lowerBounded"));
+
+        assertThat(type.isWildcard()).isTrue();
+        assertThatThrownBy(type::rawClass)
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("A wildcard type is not expected here.");
+    }
+
+    @Test
+    @DisplayName("Type variable fails during construction")
+    void of_whenTypeVariable_throwsIllegalStateException() {
+        assertThatThrownBy(() -> EnhancedType.of(genericHolderFieldType("typeVariable")))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Type variable type T is not supported.");
+    }
+
+    @Test
+    @DisplayName("Generic array fails during construction")
+    void of_whenGenericArrayType_throwsIllegalStateException() {
+        assertThatThrownBy(() -> EnhancedType.of(genericHolderFieldType("genericArray")))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Array type T[] is not supported. Use java.util.List instead of arrays.");
+    }
+
+    @Test
+    @DisplayName("Parameterized Optional has no default converter")
+    void converterFor_whenOptionalOfString_throwsIllegalStateException() {
+        DefaultAttributeConverterProvider provider = new DefaultAttributeConverterProvider();
+        EnhancedType<?> type = EnhancedType.optionalOf(String.class);
+
+        assertThatThrownBy(() -> provider.converterFor(type))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + type);
+    }
+
+    @Test
+    @DisplayName("Primitive int array has no default converter")
+    void converterFor_whenIntArray_throwsIllegalStateException() {
+        DefaultAttributeConverterProvider provider = new DefaultAttributeConverterProvider();
+        EnhancedType<int[]> type = EnhancedType.of(int[].class);
+
+        assertThatThrownBy(() -> provider.converterFor(type))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + EnhancedType.of(int[].class));
+    }
+
+    @Test
+    @DisplayName("String array has no default converter")
+    void converterFor_whenStringArray_throwsIllegalStateException() {
+        DefaultAttributeConverterProvider provider = new DefaultAttributeConverterProvider();
+        EnhancedType<String[]> type = EnhancedType.of(String[].class);
+
+        assertThatThrownBy(() -> provider.converterFor(type))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + EnhancedType.of(String[].class));
+    }
+
+    @Test
+    @DisplayName("Abstract Number has no exact registration")
+    void converterFor_whenNumberClass_throwsIllegalStateException() {
+        DefaultAttributeConverterProvider provider = new DefaultAttributeConverterProvider();
+        EnhancedType<Number> type = EnhancedType.of(Number.class);
+
+        assertThatThrownBy(() -> provider.converterFor(type))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + EnhancedType.of(Number.class));
+    }
+
+    @Test
+    @DisplayName("Unsupported interface reaches normal lookup failure")
+    void converterFor_whenUnsupportedInterface_throwsIllegalStateException() {
+        DefaultAttributeConverterProvider provider = new DefaultAttributeConverterProvider();
+        EnhancedType<UnsupportedInterface> type = EnhancedType.of(UnsupportedInterface.class);
+
+        assertThatThrownBy(() -> provider.converterFor(type))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + type);
+    }
+
+    @Test
+    @DisplayName("Unsupported parameterized application type reaches normal failure")
+    void converterFor_whenCapturedEnvelopeString_throwsIllegalStateException() {
+        DefaultAttributeConverterProvider provider = new DefaultAttributeConverterProvider();
+        EnhancedType<Envelope<String>> type = new EnhancedType<Envelope<String>>() {
+        };
+
+        assertThatThrownBy(() -> provider.converterFor(type))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + type);
+    }
+
+    @Test
+    @DisplayName("A mappable class alone is not a document token")
+    void converterFor_whenDocumentTypeWithoutAttachedSchema_throwsIllegalStateException() {
+        DefaultAttributeConverterProvider provider = new DefaultAttributeConverterProvider();
+        EnhancedType<DocumentType> type = EnhancedType.of(DocumentType.class);
+
+        assertThat(type.tableSchema()).isEmpty();
+        assertThatThrownBy(() -> provider.converterFor(type))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + type);
+    }
+
+    @Test
+    @DisplayName("Unsupported abstract class reaches normal lookup failure")
+    void converterFor_whenAbstractUnsupportedType_throwsIllegalStateException() {
+        DefaultAttributeConverterProvider provider = new DefaultAttributeConverterProvider();
+        EnhancedType<AbstractUnsupportedType> type = EnhancedType.of(AbstractUnsupportedType.class);
+
+        assertThatThrownBy(() -> provider.converterFor(type))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + type);
+    }
+
+    @Test
+    @DisplayName("Map converter rejects an N input")
+    void transformTo_whenMapConverterWithNumberAttribute_throwsIllegalStateException() {
+        DefaultAttributeConverterProvider provider = new DefaultAttributeConverterProvider();
+        AttributeConverter<Map<String, Integer>> converter =
+            provider.converterFor(EnhancedType.mapOf(String.class, Integer.class));
+
+        assertThatThrownBy(() -> converter.transformTo(AttributeValue.fromN("1")))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute."
+                        + "MapAttributeConverter cannot convert an attribute of type N into the requested type "
+                        + "interface java.util.Map");
+    }
+
+    @Test
+    @DisplayName("List converter rejects an M input")
+    void transformTo_whenListConverterWithEmptyMapAttribute_throwsIllegalStateException() {
+        DefaultAttributeConverterProvider provider = new DefaultAttributeConverterProvider();
+        AttributeConverter<List<String>> converter = provider.converterFor(EnhancedType.listOf(String.class));
+
+        assertThatThrownBy(() -> converter.transformTo(AttributeValue.fromM(Collections.emptyMap())))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute."
+                        + "ListAttributeConverter cannot convert an attribute of type M into the requested type "
+                        + "interface java.util.List");
+    }
+
+    @Test
+    @DisplayName("Set converter rejects a BOOL input")
+    void transformTo_whenSetConverterWithBooleanAttribute_throwsIllegalStateException() {
+        DefaultAttributeConverterProvider provider = new DefaultAttributeConverterProvider();
+        AttributeConverter<Set<String>> converter = provider.converterFor(EnhancedType.setOf(String.class));
+
+        assertThatThrownBy(() -> converter.transformTo(AttributeValue.fromBool(true)))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute."
+                        + "SetAttributeConverter cannot convert an attribute of type BOOL into the requested type "
+                        + "interface java.util.Set");
+    }
+
+    @Test
+    @DisplayName("List converter also reads SS input")
+    void transformTo_whenListConverterWithStringSetAttribute_returnsArrayListContainingValuesInOrder() {
+        DefaultAttributeConverterProvider provider = new DefaultAttributeConverterProvider();
+        AttributeConverter<List<String>> converter = provider.converterFor(EnhancedType.listOf(String.class));
+
+        List<String> converted = converter.transformTo(AttributeValue.fromSs(Arrays.asList("a", "b")));
+
+        assertThat(converted).isInstanceOf(ArrayList.class).containsExactly("a", "b");
+    }
+
+    @Test
+    @DisplayName("Set converter also reads L input")
+    void transformTo_whenSetConverterWithListAttribute_returnsLinkedHashSetContainingValuesInOrder() {
+        DefaultAttributeConverterProvider provider = new DefaultAttributeConverterProvider();
+        AttributeConverter<Set<String>> converter = provider.converterFor(EnhancedType.setOf(String.class));
+        AttributeValue input = AttributeValue.fromL(Arrays.asList(AttributeValue.fromS("a"),
+                                                                  AttributeValue.fromS("b")));
+
+        Set<String> converted = converter.transformTo(input);
+
+        assertThat(converted).isInstanceOf(LinkedHashSet.class).containsExactly("a", "b");
+    }
+
+    @Test
+    @DisplayName("Document converter passes a wrong input type as an empty map")
+    void transformTo_whenDocumentConverterWithNumberAttribute_readsEmptyAutoConstructedMap() {
+        DefaultAttributeConverterProvider provider = new DefaultAttributeConverterProvider();
+        RecordingDocumentSchema schema = new RecordingDocumentSchema();
+        EnhancedType<DocumentType> type = EnhancedType.documentOf(DocumentType.class, schema);
+        AttributeValue input = AttributeValue.fromN("1");
+
+        DocumentType converted = provider.converterFor(type).transformTo(input);
+
+        assertThat(input.m()).isEmpty();
+        assertThat(schema.lastMapToItemMap()).isSameAs(input.m());
+        assertThat(schema.lastMapToItemPreserveEmptyObject()).isFalse();
+        assertThat(converted).isNull();
+    }
+
+    @Test
+    @DisplayName("Integer converter exposes its current wrong-type visitor target")
+    void transformTo_whenIntegerConverterWithBooleanAttribute_throwsIllegalStateExceptionForInstant() {
+        DefaultAttributeConverterProvider provider = new DefaultAttributeConverterProvider();
+        AttributeConverter<Integer> converter = provider.converterFor(EnhancedType.of(Integer.class));
+
+        assertThatThrownBy(() -> converter.transformTo(AttributeValue.fromBool(true)))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute."
+                        + "IntegerAttributeConverter cannot convert an attribute of type BOOL into the requested type "
+                        + "class java.time.Instant");
+    }
+
+    @Test
+    @DisplayName("Enum converter rejects a non-string input")
+    void transformTo_whenEnumConverterWithNumberAttribute_throwsIllegalArgumentException() {
+        DefaultAttributeConverterProvider provider = new DefaultAttributeConverterProvider();
+        AttributeConverter<TestEnum> converter = provider.converterFor(EnhancedType.of(TestEnum.class));
+
+        assertThatThrownBy(() -> converter.transformTo(AttributeValue.fromN("1")))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Cannot convert non-string value to enum.");
+    }
+
+    @Test
+    @DisplayName("Enum converter rejects unknown text")
+    void transformTo_whenEnumConverterWithUnknownText_throwsIllegalArgumentException() {
+        DefaultAttributeConverterProvider provider = new DefaultAttributeConverterProvider();
+        AttributeConverter<TestEnum> converter = provider.converterFor(EnhancedType.of(TestEnum.class));
+
+        assertThatThrownBy(() -> converter.transformTo(AttributeValue.fromS("missing")))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Unable to convert string value 'missing' to enum type '" + TestEnum.class + "'");
+    }
+
+    @Test
+    @DisplayName("Generated enum converter persists toString()")
+    void transformFrom_whenLowercaseEnumOpen_roundTripsOpenString() {
+        DefaultAttributeConverterProvider provider = new DefaultAttributeConverterProvider();
+        AttributeConverter<LowercaseEnum> converter =
+            provider.converterFor(EnhancedType.of(LowercaseEnum.class));
+
+        assertThat(LowercaseEnum.OPEN.toString()).isEqualTo("open");
+        assertThat(converter).isInstanceOf(EnumAttributeConverter.class);
+        assertThat(converter.attributeValueType()).isEqualTo(AttributeValueType.S);
+        assertThat(converter.transformFrom(LowercaseEnum.OPEN).s()).isEqualTo("open");
+        assertThat(converter.transformTo(AttributeValue.fromS("open"))).isEqualTo(LowercaseEnum.OPEN);
+    }
+
+    @Test
+    @DisplayName("Enum name text is not accepted when toString() differs")
+    void transformTo_whenLowercaseEnumWithNameText_throwsIllegalArgumentException() {
+        DefaultAttributeConverterProvider provider = new DefaultAttributeConverterProvider();
+        AttributeConverter<LowercaseEnum> converter =
+            provider.converterFor(EnhancedType.of(LowercaseEnum.class));
+
+        assertThatThrownBy(() -> converter.transformTo(AttributeValue.fromS("OPEN")))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Unable to convert string value 'OPEN' to enum type '" + LowercaseEnum.class + "'");
+    }
+
+    @Test
+    @DisplayName("String converter maps null Java input to NULL")
+    void transformFrom_whenStringConverterWithNullInput_returnsNullAttribute() {
+        DefaultAttributeConverterProvider provider = new DefaultAttributeConverterProvider();
+        AttributeConverter<String> converter = provider.converterFor(EnhancedType.of(String.class));
+
+        assertThat(converter.transformFrom(null)).isEqualTo(AttributeValue.fromNul(true));
+    }
+
+    @Test
+    @DisplayName("Map converter rejects null Java input")
+    void transformFrom_whenMapConverterWithNullInput_throwsNullPointerException() {
+        DefaultAttributeConverterProvider provider = new DefaultAttributeConverterProvider();
+        AttributeConverter<Map<String, Integer>> converter =
+            provider.converterFor(EnhancedType.mapOf(String.class, Integer.class));
+
+        assertThatThrownBy(() -> converter.transformFrom(null))
+            .isInstanceOf(NullPointerException.class)
+            .satisfies(ex -> assertThat(ex.getMessage() == null || ex.getMessage().contains("null")).isTrue());
+    }
+
+    @Test
+    @DisplayName("Set converter rejects null Java input")
+    void transformFrom_whenSetConverterWithNullInput_throwsNullPointerException() {
+        DefaultAttributeConverterProvider provider = new DefaultAttributeConverterProvider();
+        AttributeConverter<Set<String>> converter = provider.converterFor(EnhancedType.setOf(String.class));
+
+        assertThatThrownBy(() -> converter.transformFrom(null))
+            .isInstanceOf(NullPointerException.class)
+            .satisfies(ex -> assertThat(ex.getMessage() == null || ex.getMessage().contains("null")).isTrue());
+    }
+
+    @Test
+    @DisplayName("List converter rejects null Java input")
+    void transformFrom_whenListConverterWithNullInput_throwsNullPointerException() {
+        DefaultAttributeConverterProvider provider = new DefaultAttributeConverterProvider();
+        AttributeConverter<List<String>> converter = provider.converterFor(EnhancedType.listOf(String.class));
+
+        assertThatThrownBy(() -> converter.transformFrom(null))
+            .isInstanceOf(NullPointerException.class)
+            .satisfies(ex -> assertThat(ex.getMessage() == null || ex.getMessage().contains("null")).isTrue());
+    }
+
+    @Test
+    @DisplayName("Enum converter rejects null Java input")
+    void transformFrom_whenEnumConverterWithNullInput_throwsNullPointerException() {
+        DefaultAttributeConverterProvider provider = new DefaultAttributeConverterProvider();
+        AttributeConverter<TestEnum> converter = provider.converterFor(EnhancedType.of(TestEnum.class));
+
+        assertThatThrownBy(() -> converter.transformFrom(null))
+            .isInstanceOf(NullPointerException.class)
+            .satisfies(ex -> assertThat(ex.getMessage() == null || ex.getMessage().contains("null")).isTrue());
+    }
+
+    @Test
+    @DisplayName("Map converter rejects null AttributeValue input")
+    void transformTo_whenMapConverterWithNullAttribute_throwsNullPointerException() {
+        DefaultAttributeConverterProvider provider = new DefaultAttributeConverterProvider();
+        AttributeConverter<Map<String, Integer>> converter =
+            provider.converterFor(EnhancedType.mapOf(String.class, Integer.class));
+
+        assertThatThrownBy(() -> converter.transformTo(null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessage("Generated attribute value must not contain null values. Use AttributeValue#nul() instead.");
+    }
+
+    @Test
+    @DisplayName("List converter rejects null AttributeValue input")
+    void transformTo_whenListConverterWithNullAttribute_throwsNullPointerException() {
+        DefaultAttributeConverterProvider provider = new DefaultAttributeConverterProvider();
+        AttributeConverter<List<String>> converter = provider.converterFor(EnhancedType.listOf(String.class));
+
+        assertThatThrownBy(() -> converter.transformTo(null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessage("Generated attribute value must not contain null values. Use AttributeValue#nul() instead.");
+    }
+
+    @Test
+    @DisplayName("Set converter rejects null AttributeValue input")
+    void transformTo_whenSetConverterWithNullAttribute_throwsNullPointerException() {
+        DefaultAttributeConverterProvider provider = new DefaultAttributeConverterProvider();
+        AttributeConverter<Set<String>> converter = provider.converterFor(EnhancedType.setOf(String.class));
+
+        assertThatThrownBy(() -> converter.transformTo(null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessage("Generated attribute value must not contain null values. Use AttributeValue#nul() instead.");
+    }
+
+    @Test
+    @DisplayName("Map converter reads DynamoDB NULL as Java null")
+    void transformTo_whenMapConverterWithNullAttributeValue_returnsNull() {
+        DefaultAttributeConverterProvider provider = new DefaultAttributeConverterProvider();
+        AttributeConverter<Map<String, Integer>> converter =
+            provider.converterFor(EnhancedType.mapOf(String.class, Integer.class));
+
+        assertThat(converter.transformTo(AttributeValue.fromNul(true))).isNull();
+    }
+
+    @Test
+    @DisplayName("List converter reads DynamoDB NULL as Java null")
+    void transformTo_whenListConverterWithNullAttributeValue_returnsNull() {
+        DefaultAttributeConverterProvider provider = new DefaultAttributeConverterProvider();
+        AttributeConverter<List<String>> converter = provider.converterFor(EnhancedType.listOf(String.class));
+
+        assertThat(converter.transformTo(AttributeValue.fromNul(true))).isNull();
+    }
+
+    @Test
+    @DisplayName("Set converter reads DynamoDB NULL as Java null")
+    void transformTo_whenSetConverterWithNullAttributeValue_returnsNull() {
+        DefaultAttributeConverterProvider provider = new DefaultAttributeConverterProvider();
+        AttributeConverter<Set<String>> converter = provider.converterFor(EnhancedType.setOf(String.class));
+
+        assertThat(converter.transformTo(AttributeValue.fromNul(true))).isNull();
+    }
+
+    @Test
+    @DisplayName("Primitive optional reads DynamoDB NULL as empty")
+    void transformTo_whenOptionalIntConverterWithNullAttributeValue_returnsEmpty() {
+        DefaultAttributeConverterProvider provider = new DefaultAttributeConverterProvider();
+        AttributeConverter<OptionalInt> converter = provider.converterFor(EnhancedType.of(OptionalInt.class));
+
+        assertThat(converter.transformTo(AttributeValue.fromNul(true))).isEqualTo(OptionalInt.empty());
+    }
+
+    @Test
+    @DisplayName("Map value converter write failure propagates")
+    void transformFrom_whenMapOfThrowingType_throwsSameValueWriteException() {
+        ThrowingTypeConverter throwingConverter =
+            new ThrowingTypeConverter("Map value converter failed while writing ThrowingType", "unused read message");
+        DefaultAttributeConverterProvider provider = providerWith(throwingConverter);
+        Map<String, ThrowingType> input = Collections.singletonMap("key", new ThrowingType());
+
+        assertThatThrownBy(() -> provider.converterFor(EnhancedType.mapOf(String.class, ThrowingType.class))
+                                         .transformFrom(input))
+            .isSameAs(throwingConverter.fromFailure());
+    }
+
+    @Test
+    @DisplayName("Map value converter read failure propagates")
+    void transformTo_whenMapOfThrowingType_throwsSameValueReadException() {
+        ThrowingTypeConverter throwingConverter =
+            new ThrowingTypeConverter("unused write message", "Map value converter failed while reading ThrowingType");
+        DefaultAttributeConverterProvider provider = providerWith(throwingConverter);
+        AttributeValue mapAttribute =
+            AttributeValue.fromM(Collections.singletonMap("key", AttributeValue.fromS("x")));
+
+        assertThatThrownBy(() -> provider.converterFor(EnhancedType.mapOf(String.class, ThrowingType.class))
+                                         .transformTo(mapAttribute))
+            .isSameAs(throwingConverter.toFailure());
+    }
+
+    @Test
+    @DisplayName("List member converter write failure propagates")
+    void transformFrom_whenListOfThrowingType_throwsSameMemberWriteException() {
+        ThrowingTypeConverter throwingConverter =
+            new ThrowingTypeConverter("List member converter failed while writing ThrowingType", "unused read message");
+        DefaultAttributeConverterProvider provider = providerWith(throwingConverter);
+        List<ThrowingType> input = Collections.singletonList(new ThrowingType());
+
+        assertThatThrownBy(() -> provider.converterFor(EnhancedType.listOf(ThrowingType.class))
+                                         .transformFrom(input))
+            .isSameAs(throwingConverter.fromFailure());
+    }
+
+    @Test
+    @DisplayName("List member converter read failure propagates")
+    void transformTo_whenListOfThrowingType_throwsSameMemberReadException() {
+        ThrowingTypeConverter throwingConverter =
+            new ThrowingTypeConverter("unused write message", "List member converter failed while reading ThrowingType");
+        DefaultAttributeConverterProvider provider = providerWith(throwingConverter);
+        AttributeValue listAttribute =
+            AttributeValue.fromL(Collections.singletonList(AttributeValue.fromS("x")));
+
+        assertThatThrownBy(() -> provider.converterFor(EnhancedType.listOf(ThrowingType.class))
+                                         .transformTo(listAttribute))
+            .isSameAs(throwingConverter.toFailure());
+    }
+
+    @Test
+    @DisplayName("Set member converter write failure propagates")
+    void transformFrom_whenSetOfThrowingType_throwsSameSetWriteException() {
+        ThrowingTypeConverter throwingConverter =
+            new ThrowingTypeConverter("Set member converter failed while writing ThrowingType", "unused read message");
+        DefaultAttributeConverterProvider provider = providerWith(throwingConverter);
+        Set<ThrowingType> input = Collections.singleton(new ThrowingType());
+
+        assertThatThrownBy(() -> provider.converterFor(EnhancedType.setOf(ThrowingType.class))
+                                         .transformFrom(input))
+            .isSameAs(throwingConverter.fromFailure());
+    }
+
+    @Test
+    @DisplayName("Set member converter read failure propagates")
+    void transformTo_whenSetOfThrowingType_throwsSameSetReadException() {
+        ThrowingTypeConverter throwingConverter =
+            new ThrowingTypeConverter("unused write message", "Set member converter failed while reading ThrowingType");
+        DefaultAttributeConverterProvider provider = providerWith(throwingConverter);
+        AttributeValue stringSetAttribute = AttributeValue.fromSs(Collections.singletonList("x"));
+
+        assertThatThrownBy(() -> provider.converterFor(EnhancedType.setOf(ThrowingType.class))
+                                         .transformTo(stringSetAttribute))
+            .isSameAs(throwingConverter.toFailure());
+    }
+
+    @Test
+    @DisplayName("Set member declaring S but returning NULL fails while flattening")
+    void transformFrom_whenSetOfMisreportingStringMember_throwsAttributeValueMustBeS() {
+        DefaultAttributeConverterProvider provider = providerWith(new MisreportingStringMemberConverter());
+        EnhancedType<Set<MisreportingStringMember>> type = EnhancedType.setOf(MisreportingStringMember.class);
+        Set<MisreportingStringMember> input = Collections.singleton(new MisreportingStringMember());
+
+        AttributeConverter<Set<MisreportingStringMember>> converter = provider.converterFor(type);
+
+        assertThat(converter).isInstanceOf(SetAttributeConverter.class);
+        assertThatThrownBy(() -> converter.transformFrom(input))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Attribute value must be S.");
+    }
+
+    @Test
+    @DisplayName("Document schema write failure propagates")
+    void transformFrom_whenDocumentConverterItemToMapThrows_throwsSameSchemaWriteException() {
+        DefaultAttributeConverterProvider provider = new DefaultAttributeConverterProvider();
+        TableSchema<ThrowingWriteDocument> throwingWriteSchema = throwingWriteSchema();
+        EnhancedType<ThrowingWriteDocument> type =
+            EnhancedType.documentOf(ThrowingWriteDocument.class, throwingWriteSchema);
+
+        assertThatThrownBy(() -> provider.converterFor(type).transformFrom(new ThrowingWriteDocument()))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Document schema failed while converting ThrowingWriteDocument to a map");
+    }
+
+    @Test
+    @DisplayName("Document schema read failure propagates")
+    void transformTo_whenDocumentConverterMapToItemThrows_throwsSameSchemaReadException() {
+        DefaultAttributeConverterProvider provider = new DefaultAttributeConverterProvider();
+        TableSchema<ThrowingReadDocument> throwingReadSchema = throwingReadSchema();
+        EnhancedType<ThrowingReadDocument> type =
+            EnhancedType.documentOf(ThrowingReadDocument.class, throwingReadSchema);
+        AttributeValue mapAttribute =
+            AttributeValue.fromM(Collections.singletonMap("name", AttributeValue.fromS("x")));
+
+        assertThatThrownBy(() -> provider.converterFor(type).transformTo(mapAttribute))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Document schema failed while converting a map to ThrowingReadDocument");
+    }
+
+    @Test
+    @DisplayName("Document converter delegates null Java input to its schema")
+    void transformFrom_whenDocumentConverterWithNullInput_recordsNullAndFalseAndStoresEmptyMap() {
+        DefaultAttributeConverterProvider provider = new DefaultAttributeConverterProvider();
+        RecordingDocumentSchema schema = new RecordingDocumentSchema();
+        EnhancedType<DocumentType> type = EnhancedType.documentOf(DocumentType.class, schema);
+
+        AttributeValue stored = provider.converterFor(type).transformFrom(null);
+
+        assertThat(schema.lastItemToMapItem()).isNull();
+        assertThat(schema.lastItemToMapIgnoreNulls()).isFalse();
+        assertThat(stored.hasM()).isTrue();
+        assertThat(stored.m()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Integer converter rejects null Java input")
+    void transformFrom_whenIntegerConverterWithNullInput_throwsNullPointerException() {
+        DefaultAttributeConverterProvider provider = new DefaultAttributeConverterProvider();
+        AttributeConverter<Integer> converter = provider.converterFor(EnhancedType.of(Integer.class));
+
+        assertThatThrownBy(() -> converter.transformFrom(null))
+            .isInstanceOf(NullPointerException.class)
+            .satisfies(ex -> assertThat(ex.getMessage() == null || ex.getMessage().contains("null")).isTrue());
+    }
+
+    @Test
+    @DisplayName("Null integer map value propagates member-converter failure")
+    void transformFrom_whenStringToIntegerMapWithNullValue_throwsNullPointerException() {
+        DefaultAttributeConverterProvider provider = new DefaultAttributeConverterProvider();
+        AttributeConverter<Map<String, Integer>> converter =
+            provider.converterFor(EnhancedType.mapOf(String.class, Integer.class));
+        Map<String, Integer> input = new HashMap<>();
+        input.put("key", null);
+
+        assertThatThrownBy(() -> converter.transformFrom(input))
+            .isInstanceOf(NullPointerException.class)
+            .satisfies(ex -> assertThat(ex.getMessage() == null || ex.getMessage().contains("null")).isTrue());
+    }
+
+    @Test
+    @DisplayName("Document converter forwards ignoreNulls")
+    void transformFrom_whenDocumentConverterWithIgnoreNulls_invokesItemToMapWithTrueAndWrapsMap() {
+        DefaultAttributeConverterProvider provider = new DefaultAttributeConverterProvider();
+        RecordingDocumentSchema schema = new RecordingDocumentSchema();
+        Map<String, AttributeValue> schemaMap =
+            Collections.singletonMap("name", AttributeValue.fromS("doc"));
+        schema.setItemToMapResult(schemaMap);
+        DocumentType input = new DocumentType();
+        EnhancedType<DocumentType> type =
+            EnhancedType.documentOf(DocumentType.class, schema, b -> b.ignoreNulls(true));
+
+        AttributeValue stored = provider.converterFor(type).transformFrom(input);
+
+        assertThat(schema.lastItemToMapItem()).isSameAs(input);
+        assertThat(schema.lastItemToMapIgnoreNulls()).isTrue();
+        assertThat(stored.hasM()).isTrue();
+        assertThat(stored.m()).isEqualTo(schemaMap);
+    }
+
+    @Test
+    @DisplayName("Document converter forwards preserveEmptyObject")
+    void transformTo_whenDocumentConverterWithPreserveEmptyObject_invokesMapToItemWithTrue() {
+        DefaultAttributeConverterProvider provider = new DefaultAttributeConverterProvider();
+        RecordingDocumentSchema schema = new RecordingDocumentSchema();
+        DocumentType reconstructed = new DocumentType();
+        schema.setMapToItemResult(reconstructed);
+        AttributeValue input = AttributeValue.fromM(Collections.emptyMap());
+        EnhancedType<DocumentType> type =
+            EnhancedType.documentOf(DocumentType.class, schema, b -> b.preserveEmptyObject(true));
+
+        DocumentType converted = provider.converterFor(type).transformTo(input);
+
+        assertThat(schema.lastMapToItemMap()).isSameAs(input.m());
+        assertThat(schema.lastMapToItemPreserveEmptyObject()).isTrue();
+        assertThat(converted).isSameAs(reconstructed);
+    }
+
+    @Test
+    @DisplayName("Null AttributeValue from a list member converter is rejected")
+    void transformFrom_whenListWithNullReturningMember_throwsListMustNotHaveNullValues() {
+        DefaultAttributeConverterProvider provider = providerWith(new NullReturningMemberConverter());
+        List<NullReturningMember> input = Collections.singletonList(new NullReturningMember());
+
+        assertThatThrownBy(() -> provider.converterFor(EnhancedType.listOf(NullReturningMember.class))
+                                         .transformFrom(input))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("List must not have null values.");
+    }
+
+    private static DefaultAttributeConverterProvider providerWith(AttributeConverter<?> converter) {
+        return DefaultAttributeConverterProvider.builder().addConverter(converter).build();
+    }
+
+    private static TableSchema<ThrowingWriteDocument> throwingWriteSchema() {
+        return StaticTableSchema.builder(ThrowingWriteDocument.class)
+                                .newItemSupplier(ThrowingWriteDocument::new)
+                                .addAttribute(String.class, a -> a.name("name")
+                                                                  .getter(ThrowingWriteDocument::getName)
+                                                                  .setter(ThrowingWriteDocument::setName))
+                                .build();
+    }
+
+    private static TableSchema<ThrowingReadDocument> throwingReadSchema() {
+        return StaticTableSchema.builder(ThrowingReadDocument.class)
+                                .newItemSupplier(ThrowingReadDocument::new)
+                                .addAttribute(String.class, a -> a.name("name")
+                                                                  .getter(ThrowingReadDocument::getName)
+                                                                  .setter(ThrowingReadDocument::setName))
+                                .build();
+    }
+
+    private static Type wildcardTypeArgument(String fieldName) {
+        try {
+            Type genericType = WildcardHolder.class.getDeclaredField(fieldName).getGenericType();
+            return ((ParameterizedType) genericType).getActualTypeArguments()[0];
+        } catch (NoSuchFieldException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private static Type genericHolderFieldType(String fieldName) {
+        try {
+            return GenericHolder.class.getDeclaredField(fieldName).getGenericType();
+        } catch (NoSuchFieldException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private static class WildcardHolder {
+        List<?> unbounded;
+        List<? extends Number> upperBounded;
+        List<? super String> lowerBounded;
+    }
+
+    private static class GenericHolder<T> {
+        T typeVariable;
+        T[] genericArray;
+    }
+
+    static class Envelope<T> {
+    }
+
+    interface UnsupportedInterface {
+    }
+
+    abstract static class AbstractUnsupportedType {
+    }
+
+    static class DocumentType {
+        private String name;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+
+    static class ThrowingWriteDocument {
+        public String getName() {
+            throw new IllegalArgumentException("Document schema failed while converting ThrowingWriteDocument to a map");
+        }
+
+        public void setName(String name) {
+        }
+    }
+
+    static class ThrowingReadDocument {
+        public String getName() {
+            return null;
+        }
+
+        public void setName(String name) {
+            throw new IllegalArgumentException("Document schema failed while converting a map to ThrowingReadDocument");
+        }
+    }
+
+    static class ThrowingType {
+    }
+
+    static class MisreportingStringMember {
+    }
+
+    static class NullReturningMember {
+    }
+
+    enum TestEnum {
+        OPEN,
+        CLOSED
+    }
+
+    enum LowercaseEnum {
+        OPEN,
+        CLOSED;
+
+        @Override
+        public String toString() {
+            return name().toLowerCase(Locale.ROOT);
+        }
+    }
+
+    private static final class ThrowingTypeConverter implements AttributeConverter<ThrowingType> {
+        private final IllegalArgumentException fromFailure;
+        private final IllegalArgumentException toFailure;
+
+        ThrowingTypeConverter(String fromMessage, String toMessage) {
+            this.fromFailure = new IllegalArgumentException(fromMessage);
+            this.toFailure = new IllegalArgumentException(toMessage);
+        }
+
+        IllegalArgumentException fromFailure() {
+            return fromFailure;
+        }
+
+        IllegalArgumentException toFailure() {
+            return toFailure;
+        }
+
+        @Override
+        public AttributeValue transformFrom(ThrowingType input) {
+            throw fromFailure;
+        }
+
+        @Override
+        public ThrowingType transformTo(AttributeValue input) {
+            throw toFailure;
+        }
+
+        @Override
+        public EnhancedType<ThrowingType> type() {
+            return EnhancedType.of(ThrowingType.class);
+        }
+
+        @Override
+        public AttributeValueType attributeValueType() {
+            return AttributeValueType.S;
+        }
+    }
+
+    private static final class MisreportingStringMemberConverter
+        implements AttributeConverter<MisreportingStringMember> {
+
+        @Override
+        public AttributeValue transformFrom(MisreportingStringMember input) {
+            return AttributeValue.fromNul(true);
+        }
+
+        @Override
+        public MisreportingStringMember transformTo(AttributeValue input) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public EnhancedType<MisreportingStringMember> type() {
+            return EnhancedType.of(MisreportingStringMember.class);
+        }
+
+        @Override
+        public AttributeValueType attributeValueType() {
+            return AttributeValueType.S;
+        }
+    }
+
+    private static final class RecordingDocumentSchema implements TableSchema<DocumentType> {
+        private DocumentType lastItemToMapItem;
+        private Boolean lastItemToMapIgnoreNulls;
+        private Map<String, AttributeValue> itemToMapResult = Collections.emptyMap();
+        private Map<String, AttributeValue> lastMapToItemMap;
+        private Boolean lastMapToItemPreserveEmptyObject;
+        private DocumentType mapToItemResult;
+
+        void setItemToMapResult(Map<String, AttributeValue> itemToMapResult) {
+            this.itemToMapResult = itemToMapResult;
+        }
+
+        void setMapToItemResult(DocumentType mapToItemResult) {
+            this.mapToItemResult = mapToItemResult;
+        }
+
+        DocumentType lastItemToMapItem() {
+            return lastItemToMapItem;
+        }
+
+        Boolean lastItemToMapIgnoreNulls() {
+            return lastItemToMapIgnoreNulls;
+        }
+
+        Map<String, AttributeValue> lastMapToItemMap() {
+            return lastMapToItemMap;
+        }
+
+        Boolean lastMapToItemPreserveEmptyObject() {
+            return lastMapToItemPreserveEmptyObject;
+        }
+
+        @Override
+        public DocumentType mapToItem(Map<String, AttributeValue> attributeMap) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public DocumentType mapToItem(Map<String, AttributeValue> attributeMap, boolean preserveEmptyObject) {
+            lastMapToItemMap = attributeMap;
+            lastMapToItemPreserveEmptyObject = preserveEmptyObject;
+            return mapToItemResult;
+        }
+
+        @Override
+        public Map<String, AttributeValue> itemToMap(DocumentType item, boolean ignoreNulls) {
+            lastItemToMapItem = item;
+            lastItemToMapIgnoreNulls = ignoreNulls;
+            return itemToMapResult;
+        }
+
+        @Override
+        public Map<String, AttributeValue> itemToMap(DocumentType item, Collection<String> attributes) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public AttributeValue attributeValue(DocumentType item, String attributeName) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public TableMetadata tableMetadata() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public EnhancedType<DocumentType> itemType() {
+            return EnhancedType.of(DocumentType.class);
+        }
+
+        @Override
+        public List<String> attributeNames() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public boolean isAbstract() {
+            return false;
+        }
+    }
+
+    private static final class NullReturningMemberConverter implements AttributeConverter<NullReturningMember> {
+        @Override
+        public AttributeValue transformFrom(NullReturningMember input) {
+            return null;
+        }
+
+        @Override
+        public NullReturningMember transformTo(AttributeValue input) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public EnhancedType<NullReturningMember> type() {
+            return EnhancedType.of(NullReturningMember.class);
+        }
+
+        @Override
+        public AttributeValueType attributeValueType() {
+            return AttributeValueType.S;
+        }
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/DefaultAttributeConverterProviderLookupTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/DefaultAttributeConverterProviderLookupTest.java
@@ -1,0 +1,1702 @@
+package software.amazon.awssdk.enhanced.dynamodb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import java.lang.reflect.Type;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URL;
+import java.nio.ByteBuffer;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.MonthDay;
+import java.time.OffsetDateTime;
+import java.time.Period;
+import java.time.Year;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.OptionalDouble;
+import java.util.OptionalInt;
+import java.util.OptionalLong;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.BiConsumer;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+import org.apache.logging.log4j.core.LogEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.slf4j.event.Level;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.core.SdkNumber;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.PrimitiveConverter;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.AtomicBooleanAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.AtomicIntegerAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.AtomicLongAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.BigDecimalAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.BigIntegerAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.BooleanAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.ByteArrayAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.ByteAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.ByteBufferAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.CharSequenceAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.CharacterArrayAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.CharacterAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.DocumentAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.DoubleAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.DurationAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.FloatAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.InstantAsStringAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.IntegerAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.ListAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.LocalDateAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.LocalDateTimeAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.LocalTimeAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.LocaleAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.LongAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.MapAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.MonthDayAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.OffsetDateTimeAsStringAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.OptionalDoubleAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.OptionalIntAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.OptionalLongAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.PeriodAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.SdkBytesAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.SdkNumberAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.SetAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.ShortAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.StringAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.StringBufferAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.StringBuilderAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.UriAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.UrlAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.UuidAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.ZoneIdAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.ZoneOffsetAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.ZonedDateTimeAsStringAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.StaticTableSchema;
+import software.amazon.awssdk.protocols.jsoncore.JsonNode;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+
+/**
+ * Consolidated lookup, built-in, registry, and cache coverage.
+ */
+public class DefaultAttributeConverterProviderLookupTest {
+
+    // Built-in converter coverage.
+    private static final BiConsumer<Object, Object> EQUAL_TO_INPUT =
+        (input, read) -> assertThat(read).isEqualTo(input);
+
+    private final DefaultAttributeConverterProvider builtInProvider = DefaultAttributeConverterProvider.create();
+
+    @ParameterizedTest(name = "{0} registration converts using {1}")
+    @MethodSource("builtInTypes")
+    @DisplayName("Registered built-in types convert to AttributeValue and back")
+    void converterFor_whenRegisteredBuiltInType_convertsToAttributeValueAndBack(String typeName,
+                                                                                String converterName,
+                                                                                BuiltInCase testCase) {
+        AttributeConverter<Object> converter = converterFor(testCase.type);
+
+        AttributeValue stored = converter.transformFrom(testCase.input);
+        Object read = converter.transformTo(stored);
+
+        assertThat(converter).as(typeName).isInstanceOf(testCase.converterClass);
+        assertThat(converter.getClass().getSimpleName()).isEqualTo(converterName);
+        assertThat(converter.type()).isEqualTo(testCase.type);
+        assertThat(converter.attributeValueType()).isEqualTo(testCase.attributeValueType);
+        assertThat(stored).isEqualTo(testCase.expectedStored);
+        if (testCase.input instanceof ByteBuffer) {
+            assertThat(stored.b().asByteArray()).containsExactly((byte) 1, (byte) 2);
+        }
+        testCase.reconstructed.accept(testCase.input, read);
+    }
+
+    @ParameterizedTest(name = "{0} registration converts using {1}")
+    @MethodSource("primitiveAliases")
+    @DisplayName("Primitive aliases share the wrapper converter and convert using the wrapper declared type")
+    void converterFor_whenPrimitiveType_sharesWrapperConverterAndConvertsRoundTrip(String typeName,
+                                                                                   String converterName,
+                                                                                   PrimitiveCase testCase) {
+        AttributeConverter<Object> primitive = converterFor(EnhancedType.of(testCase.primitiveClass));
+        AttributeConverter<Object> wrapper = converterFor(EnhancedType.of(testCase.wrapperClass));
+
+        AttributeValue stored = primitive.transformFrom(testCase.input);
+        Object read = primitive.transformTo(stored);
+
+        assertThat(primitive).as(typeName).isInstanceOf(testCase.converterClass);
+        assertThat(primitive.getClass().getSimpleName()).isEqualTo(converterName);
+        assertThat(primitive).isSameAs(wrapper);
+        assertThat(primitive.type()).isEqualTo(EnhancedType.of(testCase.wrapperClass));
+        assertThat(primitive.attributeValueType()).isEqualTo(testCase.attributeValueType);
+        assertThat(stored).isEqualTo(testCase.expectedStored);
+        assertThat(read).isEqualTo(testCase.input);
+    }
+
+    @ParameterizedTest(name = "{0} has no default cache key")
+    @MethodSource("unregisteredTypes")
+    @DisplayName("Types with a converter class or string converter still fail when they are not default cache keys")
+    void converterFor_whenUnregisteredType_throwsIllegalStateException(String typeName, EnhancedType<?> type) {
+        assertThatThrownBy(() -> builtInProvider.converterFor(type))
+            .as(typeName)
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + type);
+    }
+
+    static Stream<Arguments> builtInTypes() {
+        Instant instant = Instant.parse("2020-01-02T03:04:05Z");
+        OffsetDateTime offsetDateTime = OffsetDateTime.parse("2020-01-02T03:04:05+02:00");
+        ZonedDateTime zonedDateTime = ZonedDateTime.parse("2020-01-02T03:04:05+01:00[Europe/Paris]");
+        byte[] bytes = new byte[] {1, 2};
+        ByteBuffer byteBuffer = ByteBuffer.wrap(new byte[] {1, 2});
+        SdkBytes sdkBytes = SdkBytes.fromUtf8String("ab");
+        URL url = url("https://example.com/a");
+        List<String> stringList = new ArrayList<>();
+        stringList.add("a");
+        stringList.add("b");
+        Set<String> stringSet = new LinkedHashSet<>();
+        stringSet.add("a");
+        stringSet.add("b");
+        Map<String, Integer> stringIntegerMap = new LinkedHashMap<>();
+        stringIntegerMap.put("one", 1);
+        TableSchema<BuiltInDocumentType> documentSchema =
+            StaticTableSchema.builder(BuiltInDocumentType.class)
+                             .newItemSupplier(BuiltInDocumentType::new)
+                             .addAttribute(String.class, a -> a.name("name")
+                                                               .getter(BuiltInDocumentType::getName)
+                                                               .setter(BuiltInDocumentType::setName))
+                             .build();
+        EnhancedType<BuiltInDocumentType> documentType = EnhancedType.documentOf(BuiltInDocumentType.class, documentSchema);
+        BuiltInDocumentType document = new BuiltInDocumentType();
+        document.setName("child");
+
+        return Stream.of(
+            builtIn("AtomicBoolean", AtomicBooleanAttributeConverter.class, EnhancedType.of(AtomicBoolean.class),
+                    new AtomicBoolean(true), bool(true), AttributeValueType.BOOL,
+                    (input, read) -> assertThat(((AtomicBoolean) read).get()).isTrue()),
+            builtIn("AtomicInteger", AtomicIntegerAttributeConverter.class, EnhancedType.of(AtomicInteger.class),
+                    new AtomicInteger(7), n("7"), AttributeValueType.S,
+                    (input, read) -> assertThat(((AtomicInteger) read).get()).isEqualTo(7)),
+            builtIn("AtomicLong", AtomicLongAttributeConverter.class, EnhancedType.of(AtomicLong.class),
+                    new AtomicLong(7L), n("7"), AttributeValueType.N,
+                    (input, read) -> assertThat(((AtomicLong) read).get()).isEqualTo(7L)),
+            builtIn("BigDecimal", BigDecimalAttributeConverter.class, EnhancedType.of(BigDecimal.class),
+                    new BigDecimal("1.25"), n("1.25"), AttributeValueType.N, EQUAL_TO_INPUT),
+            builtIn("BigInteger", BigIntegerAttributeConverter.class, EnhancedType.of(BigInteger.class),
+                    new BigInteger("12345678901234567890"), n("12345678901234567890"), AttributeValueType.N,
+                    EQUAL_TO_INPUT),
+            builtIn("Boolean", BooleanAttributeConverter.class, EnhancedType.of(Boolean.class),
+                    Boolean.TRUE, bool(true), AttributeValueType.BOOL, EQUAL_TO_INPUT),
+            builtIn("byte[]", ByteArrayAttributeConverter.class, EnhancedType.of(byte[].class),
+                    bytes, binary(SdkBytes.fromByteArray(bytes)), AttributeValueType.B,
+                    (input, read) -> assertThat((byte[]) read).containsExactly((byte) 1, (byte) 2)),
+            builtIn("ByteBuffer", ByteBufferAttributeConverter.class, EnhancedType.of(ByteBuffer.class),
+                    byteBuffer, binary(SdkBytes.fromByteArray(new byte[] {1, 2})), AttributeValueType.B,
+                    DefaultAttributeConverterProviderLookupTest::assertByteBufferRoundTrip),
+            builtIn("Byte", ByteAttributeConverter.class, EnhancedType.of(Byte.class),
+                    Byte.valueOf((byte) 7), n("7"), AttributeValueType.N, EQUAL_TO_INPUT),
+            builtIn("char[]", CharacterArrayAttributeConverter.class, EnhancedType.of(char[].class),
+                    new char[] {'a', 'b'}, s("ab"), AttributeValueType.S,
+                    (input, read) -> assertThat((char[]) read).containsExactly('a', 'b')),
+            builtIn("Character", CharacterAttributeConverter.class, EnhancedType.of(Character.class),
+                    Character.valueOf('x'), s("x"), AttributeValueType.S, EQUAL_TO_INPUT),
+            builtIn("CharSequence", CharSequenceAttributeConverter.class, EnhancedType.of(CharSequence.class),
+                    "text", s("text"), AttributeValueType.S,
+                    (input, read) -> assertThat(read).isInstanceOf(String.class).isEqualTo("text")),
+            builtIn("Double", DoubleAttributeConverter.class, EnhancedType.of(Double.class),
+                    Double.valueOf(1.5d), n("1.5"), AttributeValueType.N, EQUAL_TO_INPUT),
+            builtIn("Duration", DurationAttributeConverter.class, EnhancedType.of(Duration.class),
+                    Duration.ofSeconds(90), n("90"), AttributeValueType.N, EQUAL_TO_INPUT),
+            builtIn("Float", FloatAttributeConverter.class, EnhancedType.of(Float.class),
+                    Float.valueOf(1.5f), n("1.5"), AttributeValueType.N, EQUAL_TO_INPUT),
+            builtIn("Instant", InstantAsStringAttributeConverter.class, EnhancedType.of(Instant.class),
+                    instant, s("2020-01-02T03:04:05Z"), AttributeValueType.S, EQUAL_TO_INPUT),
+            builtIn("Integer", IntegerAttributeConverter.class, EnhancedType.of(Integer.class),
+                    Integer.valueOf(7), n("7"), AttributeValueType.N, EQUAL_TO_INPUT),
+            builtIn("LocalDate", LocalDateAttributeConverter.class, EnhancedType.of(LocalDate.class),
+                    LocalDate.parse("2020-01-02"), s("2020-01-02"), AttributeValueType.S, EQUAL_TO_INPUT),
+            builtIn("LocalDateTime", LocalDateTimeAttributeConverter.class, EnhancedType.of(LocalDateTime.class),
+                    LocalDateTime.parse("2020-01-02T03:04:05"), s("2020-01-02T03:04:05"), AttributeValueType.S,
+                    EQUAL_TO_INPUT),
+            builtIn("Locale", LocaleAttributeConverter.class, EnhancedType.of(Locale.class),
+                    Locale.forLanguageTag("en-US"), s("en-US"), AttributeValueType.S, EQUAL_TO_INPUT),
+            builtIn("LocalTime", LocalTimeAttributeConverter.class, EnhancedType.of(LocalTime.class),
+                    LocalTime.parse("03:04:05"), s("03:04:05"), AttributeValueType.S, EQUAL_TO_INPUT),
+            builtIn("Long", LongAttributeConverter.class, EnhancedType.of(Long.class),
+                    Long.valueOf(7L), n("7"), AttributeValueType.N, EQUAL_TO_INPUT),
+            builtIn("MonthDay", MonthDayAttributeConverter.class, EnhancedType.of(MonthDay.class),
+                    MonthDay.of(1, 2), s("--01-02"), AttributeValueType.S, EQUAL_TO_INPUT),
+            builtIn("OffsetDateTime", OffsetDateTimeAsStringAttributeConverter.class,
+                    EnhancedType.of(OffsetDateTime.class), offsetDateTime, s(offsetDateTime.toString()),
+                    AttributeValueType.S, EQUAL_TO_INPUT),
+            builtIn("OptionalDouble", OptionalDoubleAttributeConverter.class, EnhancedType.of(OptionalDouble.class),
+                    OptionalDouble.of(1.5d), n("1.5"), AttributeValueType.N,
+                    (input, read) -> assertThat(((OptionalDouble) read).getAsDouble()).isEqualTo(1.5d)),
+            builtIn("OptionalInt", OptionalIntAttributeConverter.class, EnhancedType.of(OptionalInt.class),
+                    OptionalInt.of(7), n("7"), AttributeValueType.N,
+                    (input, read) -> assertThat(((OptionalInt) read).getAsInt()).isEqualTo(7)),
+            builtIn("OptionalLong", OptionalLongAttributeConverter.class, EnhancedType.of(OptionalLong.class),
+                    OptionalLong.of(7L), n("7"), AttributeValueType.N,
+                    (input, read) -> assertThat(((OptionalLong) read).getAsLong()).isEqualTo(7L)),
+            builtIn("Period", PeriodAttributeConverter.class, EnhancedType.of(Period.class),
+                    Period.of(1, 2, 3), s("P1Y2M3D"), AttributeValueType.S, EQUAL_TO_INPUT),
+            builtIn("SdkBytes", SdkBytesAttributeConverter.class, EnhancedType.of(SdkBytes.class),
+                    sdkBytes, binary(sdkBytes), AttributeValueType.B, EQUAL_TO_INPUT),
+            builtIn("Short", ShortAttributeConverter.class, EnhancedType.of(Short.class),
+                    Short.valueOf((short) 7), n("7"), AttributeValueType.N, EQUAL_TO_INPUT),
+            builtIn("String", StringAttributeConverter.class, EnhancedType.of(String.class),
+                    "text", s("text"), AttributeValueType.S, EQUAL_TO_INPUT),
+            builtIn("StringBuffer", StringBufferAttributeConverter.class, EnhancedType.of(StringBuffer.class),
+                    new StringBuffer("text"), s("text"), AttributeValueType.S,
+                    (input, read) -> assertThat(read.toString()).isEqualTo("text")),
+            builtIn("StringBuilder", StringBuilderAttributeConverter.class, EnhancedType.of(StringBuilder.class),
+                    new StringBuilder("text"), s("text"), AttributeValueType.S,
+                    (input, read) -> assertThat(read.toString()).isEqualTo("text")),
+            builtIn("URI", UriAttributeConverter.class, EnhancedType.of(URI.class),
+                    URI.create("https://example.com/a"), s("https://example.com/a"), AttributeValueType.S,
+                    EQUAL_TO_INPUT),
+            builtIn("URL", UrlAttributeConverter.class, EnhancedType.of(URL.class),
+                    url, s("https://example.com/a"), AttributeValueType.S,
+                    (input, read) -> assertThat(((URL) read).toExternalForm())
+                        .isEqualTo(((URL) input).toExternalForm())),
+            builtIn("UUID", UuidAttributeConverter.class, EnhancedType.of(UUID.class),
+                    UUID.fromString("123e4567-e89b-12d3-a456-426614174000"),
+                    s("123e4567-e89b-12d3-a456-426614174000"), AttributeValueType.S, EQUAL_TO_INPUT),
+            builtIn("ZonedDateTime", ZonedDateTimeAsStringAttributeConverter.class, EnhancedType.of(ZonedDateTime.class),
+                    zonedDateTime, s(zonedDateTime.toString()), AttributeValueType.S, EQUAL_TO_INPUT),
+            builtIn("ZoneId", ZoneIdAttributeConverter.class, EnhancedType.of(ZoneId.class),
+                    ZoneId.of("Europe/Paris"), s("Europe/Paris"), AttributeValueType.S, EQUAL_TO_INPUT),
+            builtIn("ZoneOffset", ZoneOffsetAttributeConverter.class, EnhancedType.of(ZoneOffset.class),
+                    ZoneOffset.ofHours(2), s("+02:00"), AttributeValueType.S, EQUAL_TO_INPUT),
+            builtIn("SdkNumber", SdkNumberAttributeConverter.class, EnhancedType.of(SdkNumber.class),
+                    SdkNumber.fromString("1.25"), n("1.25"), AttributeValueType.N, EQUAL_TO_INPUT),
+            builtIn("List", ListAttributeConverter.class, EnhancedType.listOf(String.class),
+                    stringList, l(s("a"), s("b")), AttributeValueType.L,
+                    (input, read) -> assertThat(read).isInstanceOf(ArrayList.class).isEqualTo(stringList)),
+            builtIn("Set", SetAttributeConverter.class, EnhancedType.setOf(String.class),
+                    stringSet, ss("a", "b"), AttributeValueType.SS,
+                    (input, read) -> assertThat(read).isInstanceOf(LinkedHashSet.class).isEqualTo(stringSet)),
+            builtIn("Map", MapAttributeConverter.class, EnhancedType.mapOf(String.class, Integer.class),
+                    stringIntegerMap, m(Collections.singletonMap("one", n("1"))), AttributeValueType.M,
+                    (input, read) -> assertThat(read).isInstanceOf(LinkedHashMap.class).isEqualTo(stringIntegerMap)),
+            builtIn("Enum", EnumAttributeConverter.class, EnhancedType.of(BuiltInTestEnum.class),
+                    BuiltInTestEnum.OPEN, s("OPEN"), AttributeValueType.S, EQUAL_TO_INPUT),
+            builtIn("Document", DocumentAttributeConverter.class, documentType,
+                    document, m(Collections.singletonMap("name", s("child"))), AttributeValueType.M, EQUAL_TO_INPUT)
+        );
+    }
+
+    static Stream<Arguments> unregisteredTypes() {
+        return Stream.of(
+            Arguments.of("Optional", EnhancedType.optionalOf(String.class)),
+            Arguments.of("JsonNode", EnhancedType.of(JsonNode.class)),
+            Arguments.of("Year", EnhancedType.of(Year.class))
+        );
+    }
+
+    static Stream<Arguments> primitiveAliases() {
+        return Stream.of(
+            primitive("boolean", boolean.class, Boolean.class, BooleanAttributeConverter.class,
+                      true, bool(true), AttributeValueType.BOOL),
+            primitive("byte", byte.class, Byte.class, ByteAttributeConverter.class,
+                      (byte) 7, n("7"), AttributeValueType.N),
+            primitive("short", short.class, Short.class, ShortAttributeConverter.class,
+                      (short) 7, n("7"), AttributeValueType.N),
+            primitive("int", int.class, Integer.class, IntegerAttributeConverter.class,
+                      7, n("7"), AttributeValueType.N),
+            primitive("long", long.class, Long.class, LongAttributeConverter.class,
+                      7L, n("7"), AttributeValueType.N),
+            primitive("float", float.class, Float.class, FloatAttributeConverter.class,
+                      1.5f, n("1.5"), AttributeValueType.N),
+            primitive("double", double.class, Double.class, DoubleAttributeConverter.class,
+                      1.5d, n("1.5"), AttributeValueType.N),
+            primitive("char", char.class, Character.class, CharacterAttributeConverter.class,
+                      'x', s("x"), AttributeValueType.S)
+        );
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> AttributeConverter<T> converterFor(EnhancedType<?> type) {
+        return (AttributeConverter<T>) builtInProvider.converterFor(type);
+    }
+
+    private static void assertByteBufferRoundTrip(Object input, Object read) {
+        ByteBuffer inputBuffer = ((ByteBuffer) input).duplicate();
+        ByteBuffer readBuffer = ((ByteBuffer) read).duplicate();
+        assertThat(readBuffer).isEqualTo(inputBuffer);
+        assertThat(((ByteBuffer) read).equals(input)).isTrue();
+    }
+
+    private static Arguments builtIn(String typeName,
+                                     Class<?> converterClass,
+                                     EnhancedType<?> type,
+                                     Object input,
+                                     AttributeValue expectedStored,
+                                     AttributeValueType attributeValueType,
+                                     BiConsumer<Object, Object> reconstructed) {
+        return Arguments.of(typeName, converterClass.getSimpleName(),
+                            new BuiltInCase(type, converterClass, input, expectedStored, attributeValueType,
+                                            reconstructed));
+    }
+
+    private static Arguments primitive(String typeName,
+                                       Class<?> primitiveClass,
+                                       Class<?> wrapperClass,
+                                       Class<?> converterClass,
+                                       Object input,
+                                       AttributeValue expectedStored,
+                                       AttributeValueType attributeValueType) {
+        return Arguments.of(typeName, converterClass.getSimpleName(),
+                            new PrimitiveCase(primitiveClass, wrapperClass, converterClass, input, expectedStored,
+                                              attributeValueType));
+    }
+
+    private static AttributeValue bool(boolean value) {
+        return AttributeValue.builder().bool(value).build();
+    }
+
+    private static AttributeValue n(String value) {
+        return AttributeValue.builder().n(value).build();
+    }
+
+    private static AttributeValue s(String value) {
+        return AttributeValue.builder().s(value).build();
+    }
+
+    private static AttributeValue binary(SdkBytes value) {
+        return AttributeValue.builder().b(value).build();
+    }
+
+    private static AttributeValue l(AttributeValue... values) {
+        return AttributeValue.builder().l(Arrays.asList(values)).build();
+    }
+
+    private static AttributeValue ss(String... values) {
+        return AttributeValue.builder().ss(Arrays.asList(values)).build();
+    }
+
+    private static AttributeValue m(Map<String, AttributeValue> members) {
+        return AttributeValue.builder().m(members).build();
+    }
+
+    private static URL url(String value) {
+        try {
+            return new URL(value);
+        } catch (MalformedURLException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private static final class BuiltInCase {
+        private final EnhancedType<?> type;
+        private final Class<?> converterClass;
+        private final Object input;
+        private final AttributeValue expectedStored;
+        private final AttributeValueType attributeValueType;
+        private final BiConsumer<Object, Object> reconstructed;
+
+        private BuiltInCase(EnhancedType<?> type,
+                            Class<?> converterClass,
+                            Object input,
+                            AttributeValue expectedStored,
+                            AttributeValueType attributeValueType,
+                            BiConsumer<Object, Object> reconstructed) {
+            this.type = type;
+            this.converterClass = converterClass;
+            this.input = input;
+            this.expectedStored = expectedStored;
+            this.attributeValueType = attributeValueType;
+            this.reconstructed = reconstructed;
+        }
+    }
+
+    private static final class PrimitiveCase {
+        private final Class<?> primitiveClass;
+        private final Class<?> wrapperClass;
+        private final Class<?> converterClass;
+        private final Object input;
+        private final AttributeValue expectedStored;
+        private final AttributeValueType attributeValueType;
+
+        private PrimitiveCase(Class<?> primitiveClass,
+                              Class<?> wrapperClass,
+                              Class<?> converterClass,
+                              Object input,
+                              AttributeValue expectedStored,
+                              AttributeValueType attributeValueType) {
+            this.primitiveClass = primitiveClass;
+            this.wrapperClass = wrapperClass;
+            this.converterClass = converterClass;
+            this.input = input;
+            this.expectedStored = expectedStored;
+            this.attributeValueType = attributeValueType;
+        }
+    }
+
+    enum BuiltInTestEnum {
+        OPEN,
+        CLOSED
+    }
+
+    static final class BuiltInDocumentType {
+        private String name;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof BuiltInDocumentType)) {
+                return false;
+            }
+            return Objects.equals(name, ((BuiltInDocumentType) o).name);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(name);
+        }
+    }
+
+    // Generated-converter cache and logging coverage.
+    @Test
+    @DisplayName("Equal map tokens return the same cached map converter")
+    void converterFor_whenEqualMapTokens_returnsSameCachedMapAttributeConverter() {
+        DefaultAttributeConverterProvider provider = new DefaultAttributeConverterProvider();
+        EnhancedType<Map<String, Integer>> firstType = EnhancedType.mapOf(String.class, Integer.class);
+        EnhancedType<Map<String, Integer>> secondType = EnhancedType.mapOf(String.class, Integer.class);
+
+        AttributeConverter<Map<String, Integer>> first = provider.converterFor(firstType);
+        AttributeConverter<Map<String, Integer>> second = provider.converterFor(secondType);
+
+        assertThat(first).isInstanceOf(MapAttributeConverter.class);
+        assertThat(first.attributeValueType()).isEqualTo(AttributeValueType.M);
+        assertThat(second).isSameAs(first);
+    }
+
+    @Test
+    @DisplayName("Equal set tokens return the same cached set converter")
+    void converterFor_whenEqualSetTokens_returnsSameCachedSetAttributeConverter() {
+        DefaultAttributeConverterProvider provider = new DefaultAttributeConverterProvider();
+        EnhancedType<Set<String>> firstType = EnhancedType.setOf(String.class);
+        EnhancedType<Set<String>> secondType = EnhancedType.setOf(String.class);
+
+        AttributeConverter<Set<String>> first = provider.converterFor(firstType);
+        AttributeConverter<Set<String>> second = provider.converterFor(secondType);
+
+        assertThat(first).isInstanceOf(SetAttributeConverter.class);
+        assertThat(first.attributeValueType()).isEqualTo(AttributeValueType.SS);
+        assertThat(second).isSameAs(first);
+    }
+
+    @Test
+    @DisplayName("Equal list tokens return different list converters")
+    void converterFor_whenEqualListTokens_returnsDifferentListAttributeConverters() {
+        DefaultAttributeConverterProvider provider = new DefaultAttributeConverterProvider();
+        EnhancedType<List<String>> firstType = EnhancedType.listOf(String.class);
+        EnhancedType<List<String>> secondType = EnhancedType.listOf(String.class);
+
+        AttributeConverter<List<String>> first = provider.converterFor(firstType);
+        AttributeConverter<List<String>> second = provider.converterFor(secondType);
+
+        assertThat(first).isInstanceOf(ListAttributeConverter.class);
+        assertThat(first.attributeValueType()).isEqualTo(AttributeValueType.L);
+        assertThat(second).isInstanceOf(ListAttributeConverter.class);
+        assertThat(second.attributeValueType()).isEqualTo(AttributeValueType.L);
+        assertThat(second).isNotSameAs(first);
+    }
+
+    @Test
+    @DisplayName("An enum type looked up twice returns different enum converters")
+    void converterFor_whenEnumTypeCalledTwice_returnsDifferentEnumAttributeConverters() {
+        DefaultAttributeConverterProvider provider = new DefaultAttributeConverterProvider();
+        EnhancedType<CacheTestEnum> type = EnhancedType.of(CacheTestEnum.class);
+
+        AttributeConverter<CacheTestEnum> first = provider.converterFor(type);
+        AttributeConverter<CacheTestEnum> second = provider.converterFor(type);
+
+        assertThat(first).isInstanceOf(EnumAttributeConverter.class);
+        assertThat(first.attributeValueType()).isEqualTo(AttributeValueType.S);
+        assertThat(second).isInstanceOf(EnumAttributeConverter.class);
+        assertThat(second.attributeValueType()).isEqualTo(AttributeValueType.S);
+        assertThat(second).isNotSameAs(first);
+    }
+
+    @Test
+    @DisplayName("Equal named document tokens return the same cached document converter")
+    void converterFor_whenEqualNamedDocumentTokens_returnsSameCachedDocumentAttributeConverter() {
+        DefaultAttributeConverterProvider provider = new DefaultAttributeConverterProvider();
+        TableSchema<CacheDocumentType> schema = cacheUnusedSchema(CacheDocumentType.class, CacheDocumentType::new);
+        EnhancedType<CacheDocumentType> firstType = EnhancedType.documentOf(CacheDocumentType.class, schema);
+        EnhancedType<CacheDocumentType> secondType = EnhancedType.documentOf(CacheDocumentType.class, schema);
+
+        AttributeConverter<CacheDocumentType> first = provider.converterFor(firstType);
+        AttributeConverter<CacheDocumentType> second = provider.converterFor(secondType);
+
+        assertThat(first).isInstanceOf(DocumentAttributeConverter.class);
+        assertThat(first.attributeValueType()).isEqualTo(AttributeValueType.M);
+        assertThat(second).isSameAs(first);
+    }
+
+    @Test
+    @DisplayName("An anonymous Map raw class document is not cached")
+    void converterFor_whenAnonymousMapRawClassDocument_returnsUncachedDocumentAttributeConverter() {
+        DefaultAttributeConverterProvider provider = new DefaultAttributeConverterProvider();
+        LinkedHashMap<String, Integer> anonymousMap = new LinkedHashMap<String, Integer>() {
+        };
+        TableSchema<LinkedHashMap<String, Integer>> recordingSchema =
+            unusedLinkedHashMapSchema(anonymousMap);
+        @SuppressWarnings("unchecked")
+        EnhancedType<LinkedHashMap<String, Integer>> type =
+            EnhancedType.documentOf((Class) anonymousMap.getClass(), recordingSchema);
+
+        AttributeConverter<LinkedHashMap<String, Integer>> first = provider.converterFor(type);
+        AttributeConverter<LinkedHashMap<String, Integer>> second = provider.converterFor(type);
+
+        assertThat(first).isInstanceOf(DocumentAttributeConverter.class);
+        assertThat(first.attributeValueType()).isEqualTo(AttributeValueType.M);
+        assertThat(second).isInstanceOf(DocumentAttributeConverter.class);
+        assertThat(second.attributeValueType()).isEqualTo(AttributeValueType.M);
+        assertThat(second).isNotSameAs(first);
+    }
+
+    @Test
+    @DisplayName("An anonymous Set raw class document is not cached")
+    void converterFor_whenAnonymousSetRawClassDocument_returnsUncachedDocumentAttributeConverter() {
+        DefaultAttributeConverterProvider provider = new DefaultAttributeConverterProvider();
+        LinkedHashSet<String> anonymousSet = new LinkedHashSet<String>() {
+        };
+        TableSchema<LinkedHashSet<String>> recordingSchema = unusedLinkedHashSetSchema(anonymousSet);
+        @SuppressWarnings("unchecked")
+        EnhancedType<LinkedHashSet<String>> type =
+            EnhancedType.documentOf((Class) anonymousSet.getClass(), recordingSchema);
+
+        AttributeConverter<LinkedHashSet<String>> first = provider.converterFor(type);
+        AttributeConverter<LinkedHashSet<String>> second = provider.converterFor(type);
+
+        assertThat(first).isInstanceOf(DocumentAttributeConverter.class);
+        assertThat(first.attributeValueType()).isEqualTo(AttributeValueType.M);
+        assertThat(second).isInstanceOf(DocumentAttributeConverter.class);
+        assertThat(second.attributeValueType()).isEqualTo(AttributeValueType.M);
+        assertThat(second).isNotSameAs(first);
+    }
+
+    @Test
+    @DisplayName("A named custom Map document returns the same cached document converter")
+    void converterFor_whenNamedCustomMapDocument_returnsSameCachedDocumentAttributeConverter() {
+        DefaultAttributeConverterProvider provider = new DefaultAttributeConverterProvider();
+        TableSchema<CacheCustomMap> schema = cacheUnusedSchema(CacheCustomMap.class, CacheCustomMap::new);
+        EnhancedType<CacheCustomMap> type = EnhancedType.documentOf(CacheCustomMap.class, schema);
+
+        AttributeConverter<CacheCustomMap> first = provider.converterFor(type);
+        AttributeConverter<CacheCustomMap> second = provider.converterFor(type);
+
+        assertThat(first).isInstanceOf(DocumentAttributeConverter.class);
+        assertThat(first).isNotInstanceOf(MapAttributeConverter.class);
+        assertThat(first.attributeValueType()).isEqualTo(AttributeValueType.M);
+        assertThat(second).isSameAs(first);
+    }
+
+    @Test
+    @DisplayName("Separately constructed equal map tokens share one cache key")
+    void converterFor_whenSeparatelyConstructedEqualMapTokens_useOneCacheKey() {
+        DefaultAttributeConverterProvider provider = new DefaultAttributeConverterProvider();
+        EnhancedType<Map<String, Integer>> firstType = EnhancedType.mapOf(String.class, Integer.class);
+        EnhancedType<Map<String, Integer>> secondType = EnhancedType.mapOf(String.class, Integer.class);
+
+        AttributeConverter<Map<String, Integer>> first = provider.converterFor(firstType);
+        AttributeConverter<Map<String, Integer>> second = provider.converterFor(secondType);
+
+        assertThat(firstType).isNotSameAs(secondType);
+        assertThat(firstType).isEqualTo(secondType);
+        assertThat(first).isInstanceOf(MapAttributeConverter.class);
+        assertThat(second).isSameAs(first);
+    }
+
+    @Test
+    @DisplayName("A UUID key map is not the string key map converter")
+    void converterFor_whenUuidKeyMap_isNotStringKeyMapConverter() {
+        DefaultAttributeConverterProvider provider = new DefaultAttributeConverterProvider();
+        EnhancedType<Map<String, Integer>> stringKeyType = EnhancedType.mapOf(String.class, Integer.class);
+        EnhancedType<Map<UUID, Integer>> uuidKeyType = EnhancedType.mapOf(UUID.class, Integer.class);
+
+        AttributeConverter<Map<String, Integer>> stringKeyConverter = provider.converterFor(stringKeyType);
+        AttributeConverter<Map<UUID, Integer>> uuidKeyConverter = provider.converterFor(uuidKeyType);
+
+        assertThat(uuidKeyConverter).isInstanceOf(MapAttributeConverter.class);
+        assertThat(uuidKeyConverter.attributeValueType()).isEqualTo(AttributeValueType.M);
+        assertThat(uuidKeyConverter).isNotSameAs(stringKeyConverter);
+    }
+
+    @Test
+    @DisplayName("A Long value map is not the Integer value map converter")
+    void converterFor_whenLongValueMap_isNotIntegerValueMapConverter() {
+        DefaultAttributeConverterProvider provider = new DefaultAttributeConverterProvider();
+        EnhancedType<Map<String, Integer>> integerValueType = EnhancedType.mapOf(String.class, Integer.class);
+        EnhancedType<Map<String, Long>> longValueType = EnhancedType.mapOf(String.class, Long.class);
+
+        AttributeConverter<Map<String, Integer>> integerValueConverter = provider.converterFor(integerValueType);
+        AttributeConverter<Map<String, Long>> longValueConverter = provider.converterFor(longValueType);
+
+        assertThat(longValueConverter).isInstanceOf(MapAttributeConverter.class);
+        assertThat(longValueConverter.attributeValueType()).isEqualTo(AttributeValueType.M);
+        assertThat(longValueConverter).isNotSameAs(integerValueConverter);
+    }
+
+    @Test
+    @DisplayName("A failed unsupported map value lookup does not cache the failure")
+    void converterFor_whenFailedUnsupportedMapValue_doesNotCacheFailure() {
+        DefaultAttributeConverterProvider provider = new DefaultAttributeConverterProvider();
+        EnhancedType<Map<String, CacheUnsupportedType>> type = EnhancedType.mapOf(String.class, CacheUnsupportedType.class);
+
+        assertThatThrownBy(() -> provider.converterFor(type))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + EnhancedType.of(CacheUnsupportedType.class));
+        assertThatThrownBy(() -> provider.converterFor(type))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + EnhancedType.of(CacheUnsupportedType.class));
+    }
+
+    @Test
+    @DisplayName("Concurrent map misses leave a later lookup matching one concurrent result")
+    void converterFor_whenConcurrentMapMisses_laterLookupMatchesOneConcurrentResult() throws Exception {
+        DefaultAttributeConverterProvider provider = new DefaultAttributeConverterProvider();
+        EnhancedType<Map<String, Integer>> type = EnhancedType.mapOf(String.class, Integer.class);
+        int threadCount = 8;
+        CyclicBarrier startBarrier = new CyclicBarrier(threadCount + 1);
+        List<AttributeConverter<Map<String, Integer>>> concurrentResults =
+            Collections.synchronizedList(new ArrayList<>());
+        List<Throwable> failures = Collections.synchronizedList(new ArrayList<>());
+        Thread[] threads = new Thread[threadCount];
+
+        for (int i = 0; i < threadCount; i++) {
+            threads[i] = new Thread(() -> {
+                try {
+                    startBarrier.await(5, TimeUnit.SECONDS);
+                    concurrentResults.add(provider.converterFor(type));
+                } catch (Throwable t) {
+                    failures.add(t);
+                }
+            });
+            threads[i].start();
+        }
+
+        startBarrier.await(5, TimeUnit.SECONDS);
+
+        for (int i = 0; i < threadCount; i++) {
+            threads[i].join(TimeUnit.SECONDS.toMillis(5));
+            assertThat(threads[i].isAlive()).isFalse();
+        }
+
+        assertThat(failures).isEmpty();
+        assertThat(concurrentResults).hasSize(threadCount);
+        for (AttributeConverter<Map<String, Integer>> converter : concurrentResults) {
+            assertThat(converter).isInstanceOf(MapAttributeConverter.class);
+            assertThat(converter.attributeValueType()).isEqualTo(AttributeValueType.M);
+        }
+
+        AttributeConverter<Map<String, Integer>> later = provider.converterFor(type);
+
+        assertThat(later).isInstanceOf(MapAttributeConverter.class);
+        assertThat(later.attributeValueType()).isEqualTo(AttributeValueType.M);
+        assertThat(concurrentResults).anySatisfy(result -> assertThat(result).isSameAs(later));
+    }
+
+    @Test
+    @DisplayName("A successful String lookup emits the exact debug record")
+    void converterFor_whenSuccessfulStringLookup_emitsExactDebugRecord() {
+        DefaultAttributeConverterProvider provider = new DefaultAttributeConverterProvider();
+
+        try (LogCaptor logCaptor = new LogCaptor(DefaultAttributeConverterProvider.class, Level.DEBUG)) {
+            provider.converterFor(EnhancedType.of(String.class));
+
+            List<LogEvent> logEvents = logCaptor.loggedEvents();
+            assertThat(logEvents).hasSize(1);
+            assertThat(logEvents.get(0).getLevel().name()).isEqualTo(Level.DEBUG.name());
+            assertThat(logEvents.get(0).getMessage().getFormattedMessage())
+                .isEqualTo("Converter for EnhancedType(java.lang.String): software.amazon.awssdk.enhanced.dynamodb.internal"
+                           + ".converter.attribute.StringAttributeConverter");
+        }
+    }
+
+    @Test
+    @DisplayName("A missing converter emits the exact debug record and throws")
+    void converterFor_whenMissingConverter_emitsExactDebugRecordAndThrows() {
+        DefaultAttributeConverterProvider provider = new DefaultAttributeConverterProvider();
+        EnhancedType<CacheUnsupportedType> type = EnhancedType.of(CacheUnsupportedType.class);
+
+        try (LogCaptor logCaptor = new LogCaptor(DefaultAttributeConverterProvider.class, Level.DEBUG)) {
+            Throwable thrown = catchThrowable(() -> provider.converterFor(type));
+
+            assertThat(thrown).isInstanceOf(IllegalStateException.class)
+                              .hasMessage("Converter not found for " + type);
+            List<LogEvent> logEvents = logCaptor.loggedEvents();
+            assertThat(logEvents).hasSize(1);
+            assertThat(logEvents.get(0).getLevel().name()).isEqualTo(Level.DEBUG.name());
+            assertThat(logEvents.get(0).getMessage().getFormattedMessage())
+                .isEqualTo("No converter available for " + type);
+        }
+    }
+
+    @Test
+    @DisplayName("A failed Boolean set lookup does not cache the failure")
+    void converterFor_whenFailedBooleanSet_doesNotCacheFailure() {
+        DefaultAttributeConverterProvider provider = new DefaultAttributeConverterProvider();
+        EnhancedType<Set<Boolean>> type = EnhancedType.setOf(Boolean.class);
+        String expectedMessage =
+            "SetAttributeConverter cannot be created with a parameterized type of 'class java.lang.Boolean'. "
+            + "Supported parameterized types must convert to B, S or N DynamoDB AttributeValues.";
+
+        assertThatThrownBy(() -> provider.converterFor(type))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage(expectedMessage);
+        assertThatThrownBy(() -> provider.converterFor(type))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage(expectedMessage);
+    }
+
+    @Test
+    @DisplayName("A document conversion failure does not evict the cached converter")
+    void converterFor_whenDocumentConversionFailure_doesNotEvictCachedConverter() {
+        DefaultAttributeConverterProvider provider = new DefaultAttributeConverterProvider();
+        TableSchema<ThrowingWriteDocument> schema = throwingWriteSchema();
+        EnhancedType<ThrowingWriteDocument> type = EnhancedType.documentOf(ThrowingWriteDocument.class, schema);
+        ThrowingWriteDocument input = new ThrowingWriteDocument();
+
+        AttributeConverter<ThrowingWriteDocument> first = provider.converterFor(type);
+        assertThatThrownBy(() -> first.transformFrom(input))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Document schema failed while converting ThrowingWriteDocument to a map");
+        AttributeConverter<ThrowingWriteDocument> second = provider.converterFor(type);
+
+        assertThat(first).isInstanceOf(DocumentAttributeConverter.class);
+        assertThat(second).isSameAs(first);
+    }
+
+    private static <T> TableSchema<T> cacheUnusedSchema(Class<T> type, java.util.function.Supplier<T> supplier) {
+        return StaticTableSchema.builder(type).newItemSupplier(supplier).build();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static TableSchema<LinkedHashMap<String, Integer>> unusedLinkedHashMapSchema(
+        LinkedHashMap<String, Integer> instance) {
+        return cacheUnusedSchema((Class<LinkedHashMap<String, Integer>>) instance.getClass(), () -> instance);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static TableSchema<LinkedHashSet<String>> unusedLinkedHashSetSchema(LinkedHashSet<String> instance) {
+        return cacheUnusedSchema((Class<LinkedHashSet<String>>) instance.getClass(), () -> instance);
+    }
+
+    private static TableSchema<ThrowingWriteDocument> throwingWriteSchema() {
+        return StaticTableSchema.builder(ThrowingWriteDocument.class)
+                                .newItemSupplier(ThrowingWriteDocument::new)
+                                .addAttribute(String.class, a -> a.name("name")
+                                                                  .getter(ThrowingWriteDocument::getName)
+                                                                  .setter(ThrowingWriteDocument::setName))
+                                .build();
+    }
+
+    static class CacheUnsupportedType {
+    }
+
+    static class CacheDocumentType {
+    }
+
+    static class ThrowingWriteDocument {
+        public String getName() {
+            throw new IllegalArgumentException("Document schema failed while converting ThrowingWriteDocument to a map");
+        }
+
+        public void setName(String name) {
+        }
+    }
+
+    enum CacheTestEnum {
+        OPEN,
+        CLOSED
+    }
+
+    static class CacheCustomMap extends HashMap<String, Integer> {
+    }
+
+    // General lookup, raw-type, document, and custom-provider coverage.
+    private DefaultAttributeConverterProvider provider;
+
+    @BeforeEach
+    void setUp() {
+        provider = new DefaultAttributeConverterProvider();
+    }
+
+    @Test
+    @DisplayName("Null EnhancedType fails during cache lookup")
+    void converterFor_whenNullType_throwsNullPointerException() {
+        assertThatThrownBy(() -> provider.converterFor(null))
+            .isInstanceOf(NullPointerException.class)
+            .satisfies(ex -> assertThat(ex.getMessage() == null || ex.getMessage().contains("null")).isTrue());
+    }
+
+    @Test
+    @DisplayName("Registered String type returns the cached string converter")
+    void converterFor_whenRegisteredStringType_returnsCachedStringAttributeConverter() {
+        EnhancedType<String> type = EnhancedType.of(String.class);
+
+        AttributeConverter<String> converter = provider.converterFor(type);
+
+        assertThat(converter).isInstanceOf(StringAttributeConverter.class);
+        assertThat(converter.attributeValueType()).isEqualTo(AttributeValueType.S);
+        assertThat(provider.converterFor(type)).isSameAs(converter);
+    }
+
+    @Test
+    @DisplayName("Unbounded wildcard type fails while reading the raw class")
+    void converterFor_whenUnboundedWildcardType_throwsIllegalArgumentException() {
+        EnhancedType<?> type = EnhancedType.of(unboundedWildcardType());
+
+        assertThatThrownBy(() -> provider.converterFor(type))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("A wildcard type is not expected here.");
+    }
+
+    @Test
+    @DisplayName("Document token with a null raw class fails during assignability")
+    void converterFor_whenDocumentTokenWithNullRawClass_throwsNullPointerException() {
+        TableSchema<DocumentType> schema = mock(TableSchema.class);
+        EnhancedType<DocumentType> type = EnhancedType.documentOf((Class<DocumentType>) null, schema);
+
+        assertThatThrownBy(() -> provider.converterFor(type))
+            .isInstanceOf(NullPointerException.class)
+            .satisfies(ex -> assertThat(ex.getMessage() == null || ex.getMessage().contains("null")).isTrue());
+        verifyNoInteractions(schema);
+    }
+
+    @Test
+    @DisplayName("Map of String to Integer selects and caches a map converter")
+    void converterFor_whenStringToIntegerMap_returnsCachedMapAttributeConverter() {
+        EnhancedType<Map<String, Integer>> type = EnhancedType.mapOf(String.class, Integer.class);
+
+        AttributeConverter<Map<String, Integer>> converter = provider.converterFor(type);
+
+        assertThat(converter).isInstanceOf(MapAttributeConverter.class);
+        assertThat(converter.attributeValueType()).isEqualTo(AttributeValueType.M);
+        assertThat(provider.converterFor(type)).isSameAs(converter);
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("rawCollectionTypes")
+    @DisplayName("A raw collection declaration requires type parameters")
+    void converterFor_whenRawCollectionType_throwsConverterNotFound(EnhancedType<?> type) {
+        assertThatThrownBy(() -> provider.converterFor(type))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + type + ". Type parameters are required for this type.");
+    }
+
+    private static Stream<EnhancedType<?>> rawCollectionTypes() {
+        return Stream.of(EnhancedType.of(Map.class), EnhancedType.of(Set.class), EnhancedType.of(List.class));
+    }
+
+    @Test
+    @DisplayName("A Map document token fails while reading map parameters before the schema is read")
+    void converterFor_whenMapDocumentToken_throwsNullPointerExceptionBeforeReadingSchema() {
+        TableSchema<Map> mapSchema = mock(TableSchema.class);
+        EnhancedType<Map> type = EnhancedType.documentOf(Map.class, mapSchema);
+
+        assertThatThrownBy(() -> provider.converterFor(type))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + EnhancedType.of(Map.class)
+                        + ". Type parameters are required for this type.");
+        verifyNoInteractions(mapSchema);
+    }
+
+    @Test
+    @DisplayName("Map with an unsupported key type fails during string-key lookup")
+    void converterFor_whenMapWithUnsupportedKey_throwsIllegalArgumentException() {
+        EnhancedType<Map<UnsupportedKey, String>> type = EnhancedType.mapOf(UnsupportedKey.class, String.class);
+
+        assertThatThrownBy(() -> provider.converterFor(type))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("No string converter exists for " + UnsupportedKey.class);
+    }
+
+    @Test
+    @DisplayName("Map with an unsupported value type fails during recursive lookup")
+    void converterFor_whenMapWithUnsupportedValue_throwsIllegalStateException() {
+        EnhancedType<Map<String, UnsupportedType>> type = EnhancedType.mapOf(String.class, UnsupportedType.class);
+
+        assertThatThrownBy(() -> provider.converterFor(type))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + EnhancedType.of(UnsupportedType.class));
+    }
+
+    @Test
+    @DisplayName("Schema-bearing Map token replaces the generated map converter")
+    void converterFor_whenSchemaBearingMapType_returnsCachedDocumentAttributeConverter() {
+        TableSchema<Map<String, Integer>> mapSchema = unusedMapSchema();
+        EnhancedType<Map<String, Integer>> type = new EnhancedType<Map<String, Integer>>() {
+            @Override
+            public Optional<TableSchema<Map<String, Integer>>> tableSchema() {
+                return Optional.of(mapSchema);
+            }
+        };
+
+        AttributeConverter<Map<String, Integer>> converter = provider.converterFor(type);
+
+        assertThat(converter).isInstanceOf(DocumentAttributeConverter.class);
+        assertThat(converter.attributeValueType()).isEqualTo(AttributeValueType.M);
+        assertThat(provider.converterFor(type)).isSameAs(converter);
+    }
+
+    @Test
+    @DisplayName("Plain Object type fails converter lookup")
+    void converterFor_whenObjectType_throwsConverterNotFound() {
+        EnhancedType<Object> type = EnhancedType.of(Object.class);
+
+        assertThatThrownBy(() -> provider.converterFor(type))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + type);
+    }
+
+    @Test
+    @DisplayName("A schema-bearing Object document token creates and caches a document converter")
+    void converterFor_whenObjectDocumentToken_returnsCachedDocumentConverter() {
+        TableSchema<Object> objectSchema = mock(TableSchema.class);
+        EnhancedType<Object> type = EnhancedType.documentOf(Object.class, objectSchema);
+
+        AttributeConverter<Object> converter = provider.converterFor(type);
+
+        assertThat(converter).isInstanceOf(DocumentAttributeConverter.class);
+        assertThat(provider.converterFor(type)).isSameAs(converter);
+        verifyNoInteractions(objectSchema);
+    }
+
+    @Test
+    @DisplayName("Set of String selects and caches a string-set converter")
+    void converterFor_whenStringSet_returnsCachedSetAttributeConverter() {
+        EnhancedType<Set<String>> type = EnhancedType.setOf(String.class);
+
+        AttributeConverter<Set<String>> converter = provider.converterFor(type);
+
+        assertThat(converter).isInstanceOf(SetAttributeConverter.class);
+        assertThat(converter.attributeValueType()).isEqualTo(AttributeValueType.SS);
+        assertThat(provider.converterFor(type)).isSameAs(converter);
+    }
+
+    @Test
+    @DisplayName("A Set document token fails while reading set parameters before the schema is read")
+    void converterFor_whenSetDocumentToken_throwsNullPointerExceptionBeforeReadingSchema() {
+        TableSchema<Set> setSchema = mock(TableSchema.class);
+        EnhancedType<Set> type = EnhancedType.documentOf(Set.class, setSchema);
+
+        assertThatThrownBy(() -> provider.converterFor(type))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + EnhancedType.of(Set.class)
+                        + ". Type parameters are required for this type.");
+        verifyNoInteractions(setSchema);
+    }
+
+    @Test
+    @DisplayName("Set with an unsupported member type fails during recursive lookup")
+    void converterFor_whenSetWithUnsupportedMember_throwsIllegalStateException() {
+        EnhancedType<Set<UnsupportedType>> type = EnhancedType.setOf(UnsupportedType.class);
+
+        assertThatThrownBy(() -> provider.converterFor(type))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + EnhancedType.of(UnsupportedType.class));
+    }
+
+    @Test
+    @DisplayName("Set of Boolean is rejected because BOOL is not a set member type")
+    void converterFor_whenBooleanSet_throwsIllegalArgumentException() {
+        EnhancedType<Set<Boolean>> type = EnhancedType.setOf(Boolean.class);
+
+        assertThatThrownBy(() -> provider.converterFor(type))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("SetAttributeConverter cannot be created with a parameterized type of 'class java.lang.Boolean'. "
+                        + "Supported parameterized types must convert to B, S or N DynamoDB AttributeValues.");
+    }
+
+    @Test
+    @DisplayName("Schema-bearing Set token replaces the generated set converter")
+    void converterFor_whenSchemaBearingSetType_returnsCachedDocumentAttributeConverter() {
+        TableSchema<Set<String>> setSchema = unusedSetSchema();
+        EnhancedType<Set<String>> type = new EnhancedType<Set<String>>() {
+            @Override
+            public Optional<TableSchema<Set<String>>> tableSchema() {
+                return Optional.of(setSchema);
+            }
+        };
+
+        AttributeConverter<Set<String>> converter = provider.converterFor(type);
+
+        assertThat(converter).isInstanceOf(DocumentAttributeConverter.class);
+        assertThat(converter.attributeValueType()).isEqualTo(AttributeValueType.M);
+        assertThat(provider.converterFor(type)).isSameAs(converter);
+    }
+
+    @Test
+    @DisplayName("Collection of String enters the set branch and caches a string-set converter")
+    void converterFor_whenStringCollection_returnsCachedSetAttributeConverter() {
+        EnhancedType<Collection<String>> type = EnhancedType.collectionOf(String.class);
+
+        AttributeConverter<Collection<String>> converter = provider.converterFor(type);
+
+        assertThat(converter).isInstanceOf(SetAttributeConverter.class);
+        assertThat(converter.type()).isEqualTo(EnhancedType.setOf(String.class));
+        assertThat(converter.attributeValueType()).isEqualTo(AttributeValueType.SS);
+        assertThat(provider.converterFor(type)).isSameAs(converter);
+    }
+
+    @Test
+    @DisplayName("Iterable of String enters the set branch and caches a string-set converter")
+    void converterFor_whenStringIterable_returnsCachedSetAttributeConverter() {
+        EnhancedType<Iterable<String>> type = new EnhancedType<Iterable<String>>() {
+        };
+
+        AttributeConverter<Iterable<String>> converter = provider.converterFor(type);
+
+        assertThat(converter).isInstanceOf(SetAttributeConverter.class);
+        assertThat(converter.type()).isEqualTo(EnhancedType.setOf(String.class));
+        assertThat(converter.attributeValueType()).isEqualTo(AttributeValueType.SS);
+        assertThat(provider.converterFor(type)).isSameAs(converter);
+    }
+
+    @Test
+    @DisplayName("List of String selects a list converter without caching it")
+    void converterFor_whenStringList_returnsUncachedListAttributeConverter() {
+        EnhancedType<List<String>> type = EnhancedType.listOf(String.class);
+
+        AttributeConverter<List<String>> first = provider.converterFor(type);
+        AttributeConverter<List<String>> second = provider.converterFor(type);
+
+        assertThat(first).isInstanceOf(ListAttributeConverter.class);
+        assertThat(first.attributeValueType()).isEqualTo(AttributeValueType.L);
+        assertThat(second).isInstanceOf(ListAttributeConverter.class);
+        assertThat(second).isNotSameAs(first);
+    }
+
+    @Test
+    @DisplayName("A List document token fails while reading list parameters before the schema is read")
+    void converterFor_whenListDocumentToken_throwsIllegalStateExceptionBeforeReadingSchema() {
+        TableSchema<List> listSchema = mock(TableSchema.class);
+        EnhancedType<List> type = EnhancedType.documentOf(List.class, listSchema);
+
+        assertThatThrownBy(() -> provider.converterFor(type))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + EnhancedType.of(List.class)
+                        + ". Type parameters are required for this type.");
+        verifyNoInteractions(listSchema);
+    }
+
+    @Test
+    @DisplayName("List with an unsupported member type fails during recursive lookup")
+    void converterFor_whenListWithUnsupportedMember_throwsIllegalStateException() {
+        EnhancedType<List<UnsupportedType>> type = EnhancedType.listOf(UnsupportedType.class);
+
+        assertThatThrownBy(() -> provider.converterFor(type))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + EnhancedType.of(UnsupportedType.class));
+    }
+
+    @Test
+    @DisplayName("Enum type selects an enum converter without caching it")
+    void converterFor_whenEnumType_returnsUncachedEnumAttributeConverter() {
+        EnhancedType<TestEnum> type = EnhancedType.of(TestEnum.class);
+
+        AttributeConverter<TestEnum> first = provider.converterFor(type);
+        AttributeConverter<TestEnum> second = provider.converterFor(type);
+
+        assertThat(first).isInstanceOf(EnumAttributeConverter.class);
+        assertThat(first.attributeValueType()).isEqualTo(AttributeValueType.S);
+        assertThat(second).isInstanceOf(EnumAttributeConverter.class);
+        assertThat(second).isNotSameAs(first);
+    }
+
+    @Test
+    @DisplayName("Enum type with a table schema still selects the enum converter")
+    void converterFor_whenEnumDocumentToken_returnsUncachedEnumAttributeConverter() {
+        TableSchema<TestEnum> enumSchema = mock(TableSchema.class);
+        EnhancedType<TestEnum> type = EnhancedType.documentOf(TestEnum.class, enumSchema);
+
+        AttributeConverter<TestEnum> converter = provider.converterFor(type);
+
+        assertThat(converter).isInstanceOf(EnumAttributeConverter.class);
+        verifyNoInteractions(enumSchema);
+        assertThat(provider.converterFor(type)).isNotSameAs(converter);
+    }
+
+    @Test
+    @DisplayName("Named document type selects and caches a document converter")
+    void converterFor_whenNamedDocumentType_returnsCachedDocumentAttributeConverter() {
+        TableSchema<DocumentType> documentSchema = unusedSchema(DocumentType.class, DocumentType::new);
+        EnhancedType<DocumentType> type = EnhancedType.documentOf(DocumentType.class, documentSchema);
+
+        AttributeConverter<DocumentType> converter = provider.converterFor(type);
+
+        assertThat(converter).isInstanceOf(DocumentAttributeConverter.class);
+        assertThat(converter.attributeValueType()).isEqualTo(AttributeValueType.M);
+        assertThat(provider.converterFor(type)).isSameAs(converter);
+    }
+
+    @Test
+    @DisplayName("Anonymous document class is not cached")
+    void converterFor_whenAnonymousDocumentType_returnsUncachedDocumentAttributeConverter() {
+        DocumentType anonymousDocument = new DocumentType() {
+        };
+        TableSchema<DocumentType> schema = unusedSchema(DocumentType.class, DocumentType::new);
+        @SuppressWarnings("unchecked")
+        EnhancedType<DocumentType> type = EnhancedType.documentOf((Class) anonymousDocument.getClass(), schema);
+
+        AttributeConverter<DocumentType> first = provider.converterFor(type);
+        AttributeConverter<DocumentType> second = provider.converterFor(type);
+
+        assertThat(first).isInstanceOf(DocumentAttributeConverter.class);
+        assertThat(first.attributeValueType()).isEqualTo(AttributeValueType.M);
+        assertThat(second).isInstanceOf(DocumentAttributeConverter.class);
+        assertThat(second.attributeValueType()).isEqualTo(AttributeValueType.M);
+        assertThat(second).isNotSameAs(first);
+    }
+
+    @Test
+    @DisplayName("Named concrete Map class with a schema reaches the document branch")
+    void converterFor_whenNamedCustomMapDocument_returnsCachedDocumentAttributeConverter() {
+        TableSchema<CustomMap> customMapSchema = unusedSchema(CustomMap.class, CustomMap::new);
+        EnhancedType<CustomMap> type = EnhancedType.documentOf(CustomMap.class, customMapSchema);
+
+        AttributeConverter<CustomMap> converter = provider.converterFor(type);
+
+        assertThat(converter).isInstanceOf(DocumentAttributeConverter.class);
+        assertThat(converter.attributeValueType()).isEqualTo(AttributeValueType.M);
+        assertThat(provider.converterFor(type)).isSameAs(converter);
+    }
+
+    @Test
+    @DisplayName("Named concrete Set class with a schema reaches the document branch")
+    void converterFor_whenNamedCustomSetDocument_returnsCachedDocumentAttributeConverter() {
+        TableSchema<CustomSet> customSetSchema = unusedSchema(CustomSet.class, CustomSet::new);
+        EnhancedType<CustomSet> type = EnhancedType.documentOf(CustomSet.class, customSetSchema);
+
+        AttributeConverter<CustomSet> converter = provider.converterFor(type);
+
+        assertThat(converter).isInstanceOf(DocumentAttributeConverter.class);
+        assertThat(converter.attributeValueType()).isEqualTo(AttributeValueType.M);
+        assertThat(provider.converterFor(type)).isSameAs(converter);
+    }
+
+    @Test
+    @DisplayName("Named concrete List class with a schema reaches the document branch")
+    void converterFor_whenNamedCustomListDocument_returnsCachedDocumentAttributeConverter() {
+        TableSchema<CustomList> customListSchema = unusedSchema(CustomList.class, CustomList::new);
+        EnhancedType<CustomList> type = EnhancedType.documentOf(CustomList.class, customListSchema);
+
+        AttributeConverter<CustomList> converter = provider.converterFor(type);
+
+        assertThat(converter).isInstanceOf(DocumentAttributeConverter.class);
+        assertThat(converter.attributeValueType()).isEqualTo(AttributeValueType.M);
+        assertThat(provider.converterFor(type)).isSameAs(converter);
+    }
+
+    @Test
+    @DisplayName("Named class without a converter or schema fails lookup")
+    void converterFor_whenUnsupportedType_throwsIllegalStateException() {
+        EnhancedType<UnsupportedType> type = EnhancedType.of(UnsupportedType.class);
+
+        assertThatThrownBy(() -> provider.converterFor(type))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + type);
+    }
+
+    @Test
+    @DisplayName("Document token created with a null schema is treated as absent")
+    void converterFor_whenDocumentTokenWithNullSchema_throwsIllegalStateException() {
+        EnhancedType<DocumentType> type = EnhancedType.documentOf(DocumentType.class, null);
+
+        assertThat(type.tableSchema()).isEmpty();
+        assertThatThrownBy(() -> provider.converterFor(type))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + type);
+    }
+
+    @Test
+    @DisplayName("Deque of String has no default converter")
+    void converterFor_whenStringDeque_throwsIllegalStateException() {
+        EnhancedType<?> type = EnhancedType.dequeOf(String.class);
+
+        assertThatThrownBy(() -> provider.converterFor(type))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + type);
+    }
+
+    @Test
+    @DisplayName("Concrete HashMap declaration has no default converter")
+    void converterFor_whenHashMapType_throwsIllegalStateException() {
+        EnhancedType<HashMap<String, Integer>> type = new EnhancedType<HashMap<String, Integer>>() {
+        };
+
+        assertThatThrownBy(() -> provider.converterFor(type))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + type);
+    }
+
+    @Test
+    @DisplayName("Concrete HashSet declaration has no default converter")
+    void converterFor_whenHashSetType_throwsIllegalStateException() {
+        EnhancedType<HashSet<String>> type = new EnhancedType<HashSet<String>>() {
+        };
+
+        assertThatThrownBy(() -> provider.converterFor(type))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + type);
+    }
+
+    @Test
+    @DisplayName("Concrete ArrayList declaration has no default converter")
+    void converterFor_whenArrayListType_throwsIllegalStateException() {
+        EnhancedType<ArrayList<String>> type = new EnhancedType<ArrayList<String>>() {
+        };
+
+        assertThatThrownBy(() -> provider.converterFor(type))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + type);
+    }
+
+    private static <T> TableSchema<T> unusedSchema(Class<T> type, Supplier<T> supplier) {
+        return StaticTableSchema.builder(type).newItemSupplier(supplier).build();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static TableSchema<Map<String, Integer>> unusedMapSchema() {
+        return unusedSchema((Class<Map<String, Integer>>) (Class<?>) Map.class, HashMap::new);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static TableSchema<Set<String>> unusedSetSchema() {
+        return unusedSchema((Class<Set<String>>) (Class<?>) Set.class, HashSet::new);
+    }
+
+    private static Type unboundedWildcardType() {
+        try {
+            return WildcardHolder.class.getDeclaredField("unbounded").getGenericType();
+        } catch (NoSuchFieldException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private static class WildcardHolder {
+        List<?> unbounded;
+    }
+
+    static class UnsupportedType {
+    }
+
+    static class UnsupportedKey {
+    }
+
+    static class DocumentType {
+    }
+
+    enum TestEnum {
+        OPEN,
+        CLOSED
+    }
+
+    static class CustomMap extends HashMap<String, Integer> {
+    }
+
+    static class CustomSet extends HashSet<String> {
+    }
+
+    static class CustomList extends ArrayList<String> {
+    }
+
+    // Provider construction, registration, and precedence coverage.
+    @Test
+    @DisplayName("defaultProvider and create return the same singleton and cached string converter")
+    void create_whenDefaultProviderAlsoCalled_returnsSameSingletonAndCachedStringConverter() {
+        AttributeConverterProvider defaultProvider = AttributeConverterProvider.defaultProvider();
+        DefaultAttributeConverterProvider created = DefaultAttributeConverterProvider.create();
+        EnhancedType<String> type = EnhancedType.of(String.class);
+
+        AttributeConverter<String> defaultConverter = defaultProvider.converterFor(type);
+        AttributeConverter<String> createdConverter = created.converterFor(type);
+
+        assertThat(defaultProvider).isSameAs(created);
+        assertThat(defaultConverter).isInstanceOf(StringAttributeConverter.class);
+        assertThat(createdConverter).isSameAs(defaultConverter);
+    }
+
+    @Test
+    @DisplayName("Repeated create calls share the generated map converter cache")
+    void create_whenCalledTwice_sharesGeneratedMapConverterCache() {
+        DefaultAttributeConverterProvider firstProvider = DefaultAttributeConverterProvider.create();
+        DefaultAttributeConverterProvider secondProvider = DefaultAttributeConverterProvider.create();
+        EnhancedType<Map<String, Integer>> type = EnhancedType.mapOf(String.class, Integer.class);
+
+        AttributeConverter<Map<String, Integer>> firstConverter = firstProvider.converterFor(type);
+        AttributeConverter<Map<String, Integer>> secondConverter = secondProvider.converterFor(type);
+
+        assertThat(firstProvider).isSameAs(secondProvider);
+        assertThat(firstConverter).isInstanceOf(MapAttributeConverter.class);
+        assertThat(secondConverter).isSameAs(firstConverter);
+    }
+
+    @Test
+    @DisplayName("The public constructor creates an isolated default registry")
+    void converterFor_whenPubliclyConstructedProvider_isIsolatedFromSingletonRegistry() {
+        DefaultAttributeConverterProvider singleton = DefaultAttributeConverterProvider.create();
+        DefaultAttributeConverterProvider constructed = new DefaultAttributeConverterProvider();
+        EnhancedType<String> type = EnhancedType.of(String.class);
+
+        AttributeConverter<String> singletonConverter = singleton.converterFor(type);
+        AttributeConverter<String> constructedConverter = constructed.converterFor(type);
+
+        assertThat(singleton).isNotSameAs(constructed);
+        assertThat(singletonConverter).isInstanceOf(StringAttributeConverter.class);
+        assertThat(singletonConverter.attributeValueType()).isEqualTo(AttributeValueType.S);
+        assertThat(constructedConverter).isInstanceOf(StringAttributeConverter.class);
+        assertThat(constructedConverter.attributeValueType()).isEqualTo(AttributeValueType.S);
+        assertThat(constructedConverter).isNotSameAs(singletonConverter);
+    }
+
+    @Test
+    @DisplayName("Publicly constructed providers own separate generated map caches")
+    void converterFor_whenTwoPubliclyConstructedProviders_ownSeparateGeneratedMapCaches() {
+        DefaultAttributeConverterProvider firstProvider = new DefaultAttributeConverterProvider();
+        DefaultAttributeConverterProvider secondProvider = new DefaultAttributeConverterProvider();
+        EnhancedType<Map<String, Integer>> type = EnhancedType.mapOf(String.class, Integer.class);
+
+        AttributeConverter<Map<String, Integer>> firstConverter = firstProvider.converterFor(type);
+        AttributeConverter<Map<String, Integer>> secondConverter = secondProvider.converterFor(type);
+
+        assertThat(firstProvider).isNotSameAs(secondProvider);
+        assertThat(firstConverter).isInstanceOf(MapAttributeConverter.class);
+        assertThat(firstConverter.attributeValueType()).isEqualTo(AttributeValueType.M);
+        assertThat(secondConverter).isInstanceOf(MapAttributeConverter.class);
+        assertThat(secondConverter.attributeValueType()).isEqualTo(AttributeValueType.M);
+        assertThat(secondConverter).isNotSameAs(firstConverter);
+    }
+
+    @Test
+    @DisplayName("An empty builder has no converter for String")
+    void converterFor_whenEmptyBuilder_throwsConverterNotFoundForString() {
+        DefaultAttributeConverterProvider provider = DefaultAttributeConverterProvider.builder().build();
+        EnhancedType<String> type = EnhancedType.of(String.class);
+
+        assertThatThrownBy(() -> provider.converterFor(type))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + EnhancedType.of(String.class));
+    }
+
+    @Test
+    @DisplayName("A builder with a custom converter returns the supplied reference")
+    void converterFor_whenBuilderWithCustomConverter_returnsSuppliedReference() {
+        EnhancedType<CustomType> type = EnhancedType.of(CustomType.class);
+        TestAttributeConverter<CustomType> customConverter = new TestAttributeConverter<>(type);
+        DefaultAttributeConverterProvider provider = DefaultAttributeConverterProvider.builder()
+                                                                                      .addConverter(customConverter)
+                                                                                      .build();
+
+        AttributeConverter<CustomType> converter = provider.converterFor(type);
+
+        assertThat(converter).isSameAs(customConverter);
+        assertThat(converter.attributeValueType()).isEqualTo(AttributeValueType.S);
+    }
+
+    @Test
+    @DisplayName("A primitive converter alias serves both int and Integer")
+    void converterFor_whenBuilderWithPrimitiveAlias_returnsSameConverterForIntAndInteger() {
+        TestPrimitiveConverter<Integer> primitiveConverter =
+            new TestPrimitiveConverter<>(EnhancedType.of(Integer.class), EnhancedType.of(int.class));
+        DefaultAttributeConverterProvider provider = DefaultAttributeConverterProvider.builder()
+                                                                                      .addConverter(primitiveConverter)
+                                                                                      .build();
+
+        AttributeConverter<Integer> integerConverter = provider.converterFor(EnhancedType.of(Integer.class));
+        AttributeConverter<Integer> intConverter = provider.converterFor(EnhancedType.of(int.class));
+
+        assertThat(intConverter).isSameAs(primitiveConverter);
+        assertThat(integerConverter).isSameAs(intConverter);
+    }
+
+    @Test
+    @DisplayName("The first added converter wins for a duplicate type")
+    void converterFor_whenFirstAddedDuplicateRegistration_wins() {
+        EnhancedType<CustomType> type = EnhancedType.of(CustomType.class);
+        TestAttributeConverter<CustomType> firstConverter = new TestAttributeConverter<>(type);
+        TestAttributeConverter<CustomType> secondConverter = new TestAttributeConverter<>(type);
+        DefaultAttributeConverterProvider provider = DefaultAttributeConverterProvider.builder()
+                                                                                      .addConverter(firstConverter)
+                                                                                      .addConverter(secondConverter)
+                                                                                      .build();
+
+        AttributeConverter<CustomType> converter = provider.converterFor(type);
+
+        assertThat(converter).isSameAs(firstConverter);
+        assertThat(converter).isNotSameAs(secondConverter);
+    }
+
+    @Test
+    @DisplayName("Adding a null converter is rejected")
+    void addConverter_whenNullConverter_throwsNullPointerException() {
+        DefaultAttributeConverterProvider.Builder builder = DefaultAttributeConverterProvider.builder();
+
+        assertThatThrownBy(() -> builder.addConverter(null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessage("converter must not be null.");
+    }
+
+    @Test
+    @DisplayName("A reused builder creates separate providers that share the supplied converter")
+    void build_whenReusedBuilder_createsSeparateProvidersSharingSuppliedConverter() {
+        EnhancedType<CustomType> type = EnhancedType.of(CustomType.class);
+        TestAttributeConverter<CustomType> customConverter = new TestAttributeConverter<>(type);
+        DefaultAttributeConverterProvider.Builder builder = DefaultAttributeConverterProvider.builder()
+                                                                                             .addConverter(customConverter);
+
+        DefaultAttributeConverterProvider firstProvider = builder.build();
+        DefaultAttributeConverterProvider secondProvider = builder.build();
+        AttributeConverter<CustomType> firstConverter = firstProvider.converterFor(type);
+        AttributeConverter<CustomType> secondConverter = secondProvider.converterFor(type);
+
+        assertThat(firstProvider).isNotSameAs(secondProvider);
+        assertThat(firstConverter).isSameAs(customConverter);
+        assertThat(secondConverter).isSameAs(customConverter);
+    }
+
+    @Test
+    @DisplayName("An exact custom map registration precedes generated map selection")
+    void converterFor_whenExactCustomMapRegistration_precedesGeneratedMapSelection() {
+        EnhancedType<Map<String, Integer>> type = EnhancedType.mapOf(String.class, Integer.class);
+        TestAttributeConverter<Map<String, Integer>> customConverter = new TestAttributeConverter<>(type);
+        DefaultAttributeConverterProvider provider = DefaultAttributeConverterProvider.builder()
+                                                                                      .addConverter(customConverter)
+                                                                                      .build();
+
+        AttributeConverter<Map<String, Integer>> converter = provider.converterFor(type);
+
+        assertThat(converter).isSameAs(customConverter);
+        assertThat(converter).isNotInstanceOf(MapAttributeConverter.class);
+    }
+
+    @Test
+    @DisplayName("An exact custom set registration precedes generated set selection")
+    void converterFor_whenExactCustomSetRegistration_precedesGeneratedSetSelection() {
+        EnhancedType<Set<String>> type = EnhancedType.setOf(String.class);
+        TestAttributeConverter<Set<String>> customConverter = new TestAttributeConverter<>(type);
+        DefaultAttributeConverterProvider provider = DefaultAttributeConverterProvider.builder()
+                                                                                      .addConverter(customConverter)
+                                                                                      .build();
+
+        AttributeConverter<Set<String>> converter = provider.converterFor(type);
+
+        assertThat(converter).isSameAs(customConverter);
+        assertThat(converter).isNotInstanceOf(SetAttributeConverter.class);
+    }
+
+    @Test
+    @DisplayName("An exact custom list registration precedes generated list selection")
+    void converterFor_whenExactCustomListRegistration_precedesGeneratedListSelection() {
+        EnhancedType<List<String>> type = EnhancedType.listOf(String.class);
+        TestAttributeConverter<List<String>> customConverter = new TestAttributeConverter<>(type);
+        DefaultAttributeConverterProvider provider = DefaultAttributeConverterProvider.builder()
+                                                                                      .addConverter(customConverter)
+                                                                                      .build();
+
+        AttributeConverter<List<String>> converter = provider.converterFor(type);
+
+        assertThat(converter).isSameAs(customConverter);
+        assertThat(converter).isNotInstanceOf(ListAttributeConverter.class);
+    }
+
+    @Test
+    @DisplayName("An exact custom enum registration precedes generated enum selection")
+    void converterFor_whenExactCustomEnumRegistration_precedesGeneratedEnumSelection() {
+        EnhancedType<RegistryTestEnum> type = EnhancedType.of(RegistryTestEnum.class);
+        TestAttributeConverter<RegistryTestEnum> customConverter = new TestAttributeConverter<>(type);
+        DefaultAttributeConverterProvider provider = DefaultAttributeConverterProvider.builder()
+                                                                                      .addConverter(customConverter)
+                                                                                      .build();
+
+        AttributeConverter<RegistryTestEnum> converter = provider.converterFor(type);
+
+        assertThat(converter).isSameAs(customConverter);
+        assertThat(converter).isNotInstanceOf(EnumAttributeConverter.class);
+    }
+
+    @Test
+    @DisplayName("An exact custom document registration precedes generated document selection")
+    void converterFor_whenExactCustomDocumentRegistration_precedesGeneratedDocumentSelection() {
+        TableSchema<RegistryDocumentType> schema =
+            StaticTableSchema.builder(RegistryDocumentType.class).newItemSupplier(RegistryDocumentType::new).build();
+        EnhancedType<RegistryDocumentType> type = EnhancedType.documentOf(RegistryDocumentType.class, schema);
+        TestAttributeConverter<RegistryDocumentType> customConverter = new TestAttributeConverter<>(type);
+        DefaultAttributeConverterProvider provider = DefaultAttributeConverterProvider.builder()
+                                                                                      .addConverter(customConverter)
+                                                                                      .build();
+
+        AttributeConverter<RegistryDocumentType> converter = provider.converterFor(type);
+
+        assertThat(converter).isSameAs(customConverter);
+        assertThat(converter).isNotInstanceOf(DocumentAttributeConverter.class);
+    }
+
+    @Test
+    @DisplayName("A built provider is isolated from later builder mutation")
+    void converterFor_whenBuilderMutatedAfterFirstBuild_throwsThenReturnsLaterConverter() {
+        TestAttributeConverter<CustomType> firstConverter =
+            new TestAttributeConverter<>(EnhancedType.of(CustomType.class));
+        DefaultAttributeConverterProvider.Builder builder = DefaultAttributeConverterProvider.builder()
+                                                                                             .addConverter(firstConverter);
+        DefaultAttributeConverterProvider firstProvider = builder.build();
+        EnhancedType<SecondCustomType> secondType = EnhancedType.of(SecondCustomType.class);
+        TestAttributeConverter<SecondCustomType> secondConverter = new TestAttributeConverter<>(secondType);
+        builder.addConverter(secondConverter);
+        DefaultAttributeConverterProvider secondProvider = builder.build();
+
+        assertThatThrownBy(() -> firstProvider.converterFor(secondType))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + secondType);
+        assertThat(secondProvider.converterFor(secondType)).isSameAs(secondConverter);
+    }
+
+    @Test
+    @DisplayName("An exact custom registration intercepts a schema-bearing Object type")
+    void converterFor_whenExactCustomRegistration_interceptsSchemaBearingObject() {
+        TableSchema<Object> objectSchema =
+            StaticTableSchema.builder(Object.class).newItemSupplier(Object::new).build();
+        EnhancedType<Object> type = EnhancedType.documentOf(Object.class, objectSchema);
+        TestAttributeConverter<Object> customConverter = new TestAttributeConverter<>(type);
+        DefaultAttributeConverterProvider provider = DefaultAttributeConverterProvider.builder()
+                                                                                      .addConverter(customConverter)
+                                                                                      .build();
+
+        AttributeConverter<Object> converter = provider.converterFor(type);
+
+        assertThat(converter).isSameAs(customConverter);
+        assertThat(converter).isNotInstanceOf(MapAttributeConverter.class);
+    }
+
+    private static final class TestAttributeConverter<T> implements AttributeConverter<T> {
+        private final EnhancedType<T> type;
+
+        TestAttributeConverter(EnhancedType<T> type) {
+            this.type = type;
+        }
+
+        @Override
+        public AttributeValue transformFrom(T input) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public T transformTo(AttributeValue input) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public EnhancedType<T> type() {
+            return type;
+        }
+
+        @Override
+        public AttributeValueType attributeValueType() {
+            return AttributeValueType.S;
+        }
+    }
+
+    private static final class TestPrimitiveConverter<T> implements AttributeConverter<T>, PrimitiveConverter<T> {
+        private final EnhancedType<T> type;
+        private final EnhancedType<T> primitiveType;
+
+        TestPrimitiveConverter(EnhancedType<T> type, EnhancedType<T> primitiveType) {
+            this.type = type;
+            this.primitiveType = primitiveType;
+        }
+
+        @Override
+        public AttributeValue transformFrom(T input) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public T transformTo(AttributeValue input) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public EnhancedType<T> type() {
+            return type;
+        }
+
+        @Override
+        public AttributeValueType attributeValueType() {
+            return AttributeValueType.S;
+        }
+
+        @Override
+        public EnhancedType<T> primitiveType() {
+            return primitiveType;
+        }
+    }
+
+    static class RegistryDocumentType {
+    }
+
+    enum RegistryTestEnum {
+        OPEN,
+        CLOSED
+    }
+
+    static class CustomType {
+        private String value;
+
+        public String getValue() {
+            return value;
+        }
+
+        public void setValue(String value) {
+            this.value = value;
+        }
+    }
+
+    static class SecondCustomType {
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/DefaultAttributeConverterProviderTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/DefaultAttributeConverterProviderTest.java
@@ -18,10 +18,15 @@ package software.amazon.awssdk.enhanced.dynamodb;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import org.apache.logging.log4j.core.LogEvent;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.slf4j.event.Level;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.StaticTableSchema;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 public class DefaultAttributeConverterProviderTest {
 
@@ -47,8 +52,7 @@ public class DefaultAttributeConverterProviderTest {
 
             assertThatThrownBy(() -> provider.converterFor(EnhancedType.of(CustomUnsupportedType.class)))
                 .isInstanceOf(IllegalStateException.class)
-                .hasMessageContaining("Converter not found for EnhancedType(software.amazon.awssdk.enhanced.dynamodb"
-                                      + ".DefaultAttributeConverterProviderTest$CustomUnsupportedType)");
+                .hasMessage("Converter not found for " + EnhancedType.of(CustomUnsupportedType.class));
             List<LogEvent> logEvents = logCaptor.loggedEvents();
             assertThat(logEvents).hasSize(1);
             assertThat(logEvents.get(0).getLevel().name()).isEqualTo(Level.DEBUG.name());
@@ -58,9 +62,128 @@ public class DefaultAttributeConverterProviderTest {
         }
     }
 
+    @Test
+    void findConverter_whenConverterIsCached_returnsTheCachedConverter() {
+        DefaultAttributeConverterProvider provider = DefaultAttributeConverterProvider.create();
+
+        assertThat(provider.converterFor(EnhancedType.of(String.class)))
+            .isSameAs(provider.converterFor(EnhancedType.of(String.class)));
+    }
+
+    @Test
+    void findConverter_whenMapSubtypeHasSupportedEntries_throwsConverterNotFound() {
+        DefaultAttributeConverterProvider provider = DefaultAttributeConverterProvider.create();
+        EnhancedType<HashMap<String, Integer>> type = new EnhancedType<HashMap<String, Integer>>() { };
+
+        assertThatThrownBy(() -> provider.converterFor(type))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + type);
+    }
+
+    @Test
+    @DisplayName("An Object map value fails converter lookup")
+    void findConverter_whenMapEntryValueIsObject_throwsConverterNotFound() {
+        DefaultAttributeConverterProvider provider = DefaultAttributeConverterProvider.create();
+
+        assertThatThrownBy(() -> provider.converterFor(EnhancedType.mapOf(String.class, Object.class)))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + EnhancedType.of(Object.class));
+    }
+
+    @Test
+    void findConverter_whenMapEntryValueHasNoConverter_throwsConverterNotFound() {
+        DefaultAttributeConverterProvider provider = DefaultAttributeConverterProvider.create();
+
+        assertThatThrownBy(() -> provider.converterFor(EnhancedType.mapOf(String.class, CustomUnsupportedType.class)))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + EnhancedType.of(CustomUnsupportedType.class));
+    }
+
+    @Test
+    void findConverter_whenSetHasSupportedEntries_createsSetConverter() {
+        DefaultAttributeConverterProvider provider = DefaultAttributeConverterProvider.create();
+
+        assertThat(provider.converterFor(EnhancedType.setOf(String.class))
+                           .transformFrom(Collections.singleton("value")).ss())
+            .containsExactly("value");
+    }
+
+    @Test
+    void findConverter_whenSetEntryHasNoConverter_throwsConverterNotFound() {
+        DefaultAttributeConverterProvider provider = DefaultAttributeConverterProvider.create();
+
+        assertThatThrownBy(() -> provider.converterFor(EnhancedType.setOf(CustomUnsupportedType.class)))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + EnhancedType.of(CustomUnsupportedType.class));
+    }
+
+    @Test
+    void findConverter_whenListHasSupportedEntries_createsListConverter() {
+        DefaultAttributeConverterProvider provider = DefaultAttributeConverterProvider.create();
+
+        assertThat(provider.converterFor(EnhancedType.listOf(String.class))
+                           .transformFrom(Collections.singletonList("value")).l())
+            .containsExactly(AttributeValue.builder().s("value").build());
+    }
+
+    @Test
+    void findConverter_whenListEntryHasNoConverter_throwsConverterNotFound() {
+        DefaultAttributeConverterProvider provider = DefaultAttributeConverterProvider.create();
+
+        assertThatThrownBy(() -> provider.converterFor(EnhancedType.listOf(CustomUnsupportedType.class)))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + EnhancedType.of(CustomUnsupportedType.class));
+    }
+
+    @Test
+    void findConverter_whenTypeIsEnum_createsEnumConverter() {
+        DefaultAttributeConverterProvider provider = DefaultAttributeConverterProvider.create();
+
+        assertThat(provider.converterFor(EnhancedType.of(TestEnum.class)).transformFrom(TestEnum.VALUE).s())
+            .isEqualTo("VALUE");
+    }
+
+    @Test
+    void findConverter_whenTypeHasTableSchema_createsDocumentConverter() {
+        DefaultAttributeConverterProvider provider = DefaultAttributeConverterProvider.create();
+        TableSchema<TestDocument> schema = StaticTableSchema.builder(TestDocument.class)
+                                                            .newItemSupplier(TestDocument::new)
+                                                            .addAttribute(String.class, a -> a.name("value")
+                                                                                       .getter(TestDocument::value)
+                                                                                       .setter(TestDocument::value))
+                                                            .build();
+
+        assertThat(provider.converterFor(EnhancedType.documentOf(TestDocument.class, schema))
+                           .transformFrom(new TestDocument("value")).m())
+            .containsEntry("value", AttributeValue.builder().s("value").build());
+    }
+
     /**
      * A custom type with no converter registered for it.
      */
     private static class CustomUnsupportedType {
+    }
+
+    private enum TestEnum {
+        VALUE
+    }
+
+    private static final class TestDocument {
+        private String value;
+
+        private TestDocument() {
+        }
+
+        private TestDocument(String value) {
+            this.value = value;
+        }
+
+        private String value() {
+            return value;
+        }
+
+        private void value(String value) {
+            this.value = value;
+        }
     }
 }

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/DocumentTableSchemaConverterTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/DocumentTableSchemaConverterTest.java
@@ -1,0 +1,460 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.enhanced.dynamodb.document.DocumentTableSchema;
+import software.amazon.awssdk.enhanced.dynamodb.document.EnhancedDocument;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.StaticTableSchema;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+
+/**
+ * Tests typed item conversion through document table schemas.
+ * <p>
+ * The tests verify default and configured converter providers, provider ordering, fallback, and propagated failures.
+ * They also cover typed scalar, list, and nested document values, explicit document nulls, null items, preconverted
+ * attribute values, schema metadata, and unsupported attribute converter lookup.
+ */
+public class DocumentTableSchemaConverterTest {
+
+    @Test
+    @DisplayName("The default schema provider supports typed reads")
+    void mapToItem_whenDefaultSchema_installsDefaultProviderAndReadsString() {
+        EnhancedType<String> type = EnhancedType.of(String.class);
+        DocumentTableSchema schema = DocumentTableSchema.builder().build();
+        Map<String, AttributeValue> map = Collections.singletonMap("value", AttributeValue.fromS("text"));
+
+        EnhancedDocument document = schema.mapToItem(map);
+        String read = document.get("value", type);
+
+        assertThat(document.attributeConverterProviders())
+            .contains(AttributeConverterProvider.defaultProvider());
+        assertThat(read).isEqualTo("text");
+    }
+
+    @Test
+    @DisplayName("The default schema provider supports typed writes")
+    void itemToMap_whenTypedIntegerDocument_storesN() {
+        DocumentTableSchema schema = DocumentTableSchema.builder().build();
+        EnhancedDocument document = EnhancedDocument.builder()
+                                                    .put("value", 7, EnhancedType.of(Integer.class))
+                                                    .build();
+
+        Map<String, AttributeValue> map = schema.itemToMap(document, false);
+
+        assertThat(map).containsEntry("value", AttributeValue.fromN("7"));
+    }
+
+    @Test
+    @DisplayName("A document provider precedes the schema provider and is invoked twice by the merged chain")
+    void itemToMap_whenDocumentProviderBeforeSchemaProvider_selectsDocumentConverterAndCallsItTwice() {
+        EnhancedType<CustomType> type = EnhancedType.of(CustomType.class);
+        RecordingPrefixProvider documentProvider = new RecordingPrefixProvider("document");
+        RecordingPrefixProvider schemaProvider = new RecordingPrefixProvider("schema");
+        EnhancedDocument document = EnhancedDocument.builder()
+                                                    .attributeConverterProviders(documentProvider)
+                                                    .put("value", new CustomType("x"), type)
+                                                    .build();
+        DocumentTableSchema schema = DocumentTableSchema.builder()
+                                                        .attributeConverterProviders(schemaProvider)
+                                                        .build();
+
+        Map<String, AttributeValue> map = schema.itemToMap(document, false);
+
+        assertThat(documentProvider.requestedTypes()).containsExactly(type, type);
+        assertThat(map.get("value").s()).isEqualTo("document:x");
+        assertThat(schemaProvider.requestedTypes()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("A null-returning document provider falls back to the schema default")
+    void itemToMap_whenNullReturningDocumentProvider_fallsBackToSchemaDefault() {
+        EnhancedType<String> type = EnhancedType.of(String.class);
+        ReturningNullProvider returningNull = new ReturningNullProvider();
+        EnhancedDocument document = EnhancedDocument.builder()
+                                                    .attributeConverterProviders(returningNull)
+                                                    .put("value", "text", type)
+                                                    .build();
+        DocumentTableSchema schema = DocumentTableSchema.builder().build();
+
+        Map<String, AttributeValue> map = schema.itemToMap(document, false);
+
+        assertThat(returningNull.requestedTypes()).containsExactly(type);
+        assertThat(map).containsEntry("value", AttributeValue.fromS("text"));
+    }
+
+    @Test
+    @DisplayName("A default document provider can block a later schema custom provider")
+    void itemToMap_whenDefaultDocumentProviderBeforeSchemaCustom_throwsConverterNotFoundAndSkipsSchemaCustom() {
+        EnhancedType<CustomType> type = EnhancedType.of(CustomType.class);
+        RecordingPrefixProvider schemaCustom = new RecordingPrefixProvider("schema");
+        EnhancedDocument document = EnhancedDocument.builder()
+                                                    .attributeConverterProviders(
+                                                        AttributeConverterProvider.defaultProvider())
+                                                    .put("value", new CustomType("x"), type)
+                                                    .build();
+        DocumentTableSchema schema = DocumentTableSchema.builder()
+                                                        .attributeConverterProviders(schemaCustom)
+                                                        .build();
+
+        assertThatThrownBy(() -> schema.itemToMap(document, false))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + type);
+        assertThat(schemaCustom.requestedTypes()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Empty schema providers fail lazily for typed data")
+    void itemToMap_whenEmptySchemaProvidersAndTypedString_throwsDocumentConverterNotFound() {
+        EnhancedType<String> type = EnhancedType.of(String.class);
+        DocumentTableSchema schema = DocumentTableSchema.builder()
+                                                        .attributeConverterProviders(Collections.emptyList())
+                                                        .build();
+        EnhancedDocument document = EnhancedDocument.builder()
+                                                    .put("value", "text", type)
+                                                    .build();
+
+        assertThatThrownBy(() -> schema.itemToMap(document, false))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage(documentConverterNotFoundMessage(type));
+    }
+
+    @Test
+    @DisplayName("Empty schema providers preserve preconverted AttributeValue data")
+    void itemToMap_whenEmptySchemaProvidersAndAttributeValue_preservesSWithoutConverterLookup() {
+        DocumentTableSchema schema = DocumentTableSchema.builder()
+                                                        .attributeConverterProviders(Collections.emptyList())
+                                                        .build();
+        EnhancedDocument document = EnhancedDocument.builder()
+                                                    .attributeValueMap(Collections.singletonMap(
+                                                        "value", AttributeValue.fromS("text")))
+                                                    .build();
+
+        Map<String, AttributeValue> map = schema.itemToMap(document, false);
+
+        assertThat(map).containsEntry("value", AttributeValue.fromS("text"));
+    }
+
+    @Test
+    @DisplayName("A null item write is explicitly supported")
+    void itemToMap_whenNullItem_returnsNull() {
+        DocumentTableSchema schema = DocumentTableSchema.builder().build();
+
+        assertThat(schema.itemToMap(null, false)).isNull();
+    }
+
+    @Test
+    @DisplayName("A null map read is explicitly supported")
+    void mapToItem_whenNullMap_returnsNull() {
+        DocumentTableSchema schema = DocumentTableSchema.builder().build();
+
+        assertThat(schema.mapToItem(null)).isNull();
+    }
+
+    @Test
+    @DisplayName("A false ignore-null flag retains explicit document null")
+    void itemToMap_whenExplicitNullWithIgnoreNullsFalse_retainsNul() {
+        DocumentTableSchema schema = DocumentTableSchema.builder().build();
+        EnhancedDocument document = EnhancedDocument.builder().putNull("value").build();
+
+        Map<String, AttributeValue> map = schema.itemToMap(document, false);
+
+        assertThat(map).containsEntry("value", AttributeValue.fromNul(true));
+    }
+
+    @Test
+    @DisplayName("A true ignore-null flag also retains explicit document null")
+    void itemToMap_whenExplicitNullWithIgnoreNullsTrue_retainsNul() {
+        DocumentTableSchema schema = DocumentTableSchema.builder().build();
+        EnhancedDocument document = EnhancedDocument.builder().putNull("value").build();
+
+        Map<String, AttributeValue> map = schema.itemToMap(document, true);
+
+        assertThat(map).containsEntry("value", AttributeValue.fromNul(true));
+    }
+
+    @Test
+    @DisplayName("Attribute converter lookup is unsupported")
+    void converterForAttribute_whenAnyName_throwsUnsupportedOperationExceptionWithNullMessage() {
+        DocumentTableSchema schema = DocumentTableSchema.builder().build();
+
+        assertThatThrownBy(() -> schema.converterForAttribute("value"))
+            .isInstanceOf(UnsupportedOperationException.class)
+            .hasMessage(null);
+    }
+
+    @Test
+    @DisplayName("The document schema item type is fixed as EnhancedDocument")
+    void itemType_whenBuiltSchema_returnsEnhancedDocumentType() {
+        DocumentTableSchema schema = DocumentTableSchema.builder().build();
+
+        assertThat(schema.itemType()).isEqualTo(EnhancedType.of(EnhancedDocument.class));
+    }
+
+    @Test
+    @DisplayName("A typed Object write fails converter lookup")
+    void itemToMap_whenTypedObject_throwsConverterNotFound() {
+        DocumentTableSchema schema = DocumentTableSchema.builder().build();
+        EnhancedDocument document = EnhancedDocument.builder()
+                                                    .put("value", new Object(), EnhancedType.of(Object.class))
+                                                    .build();
+
+        assertThatThrownBy(() -> schema.itemToMap(document, false))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + EnhancedType.of(Object.class));
+    }
+
+    @Test
+    @DisplayName("An unsupported typed write propagates the schema default provider failure")
+    void itemToMap_whenUnsupportedType_throwsConverterNotFound() {
+        EnhancedType<UnsupportedType> type = EnhancedType.of(UnsupportedType.class);
+        DocumentTableSchema schema = DocumentTableSchema.builder().build();
+        EnhancedDocument document = EnhancedDocument.builder()
+                                                    .put("value", new UnsupportedType("x"), type)
+                                                    .build();
+
+        assertThatThrownBy(() -> schema.itemToMap(document, false))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + type);
+    }
+
+    @Test
+    @DisplayName("The default schema provider converts a typed list")
+    void itemToMapThenMapToItem_whenTypedStringList_roundTripsAsLAndArrayList() {
+        EnhancedType<List<String>> type = EnhancedType.listOf(String.class);
+        List<String> input = new ArrayList<>();
+        input.add("a");
+        DocumentTableSchema schema = DocumentTableSchema.builder().build();
+        EnhancedDocument document = EnhancedDocument.builder()
+                                                    .put("value", input, type)
+                                                    .build();
+
+        Map<String, AttributeValue> map = schema.itemToMap(document, false);
+        EnhancedDocument readDocument = schema.mapToItem(map);
+        List<String> read = readDocument.get("value", type);
+
+        assertThat(map.get("value").hasL()).isTrue();
+        assertThat(map.get("value").l()).containsExactly(AttributeValue.fromS("a"));
+        assertThat(read).isInstanceOf(ArrayList.class).isEqualTo(input);
+    }
+
+    @Test
+    @DisplayName("The default schema provider converts a typed nested document")
+    void itemToMapThenMapToItem_whenSchemaBearingDocument_storesMAndReconstructsThroughSchema() {
+        TableSchema<DocumentType> documentSchema = documentSchema();
+        EnhancedType<DocumentType> type = EnhancedType.documentOf(DocumentType.class, documentSchema);
+        DocumentTableSchema schema = DocumentTableSchema.builder().build();
+        DocumentType input = new DocumentType();
+        input.setName("doc");
+        EnhancedDocument document = EnhancedDocument.builder()
+                                                    .put("value", input, type)
+                                                    .build();
+
+        Map<String, AttributeValue> map = schema.itemToMap(document, false);
+        EnhancedDocument readDocument = schema.mapToItem(map);
+        DocumentType read = readDocument.get("value", type);
+
+        assertThat(map.get("value").hasM()).isTrue();
+        assertThat(map.get("value").m()).containsEntry("name", AttributeValue.fromS("doc"));
+        assertThat(read.getName()).isEqualTo("doc");
+    }
+
+    @Test
+    @DisplayName("The default schema provider rejects a typed concrete list")
+    void itemToMap_whenConcreteArrayList_throwsConverterNotFound() {
+        EnhancedType<ArrayList<String>> type = new EnhancedType<ArrayList<String>>() { };
+        ArrayList<String> input = new ArrayList<>();
+        input.add("a");
+        DocumentTableSchema schema = DocumentTableSchema.builder().build();
+        EnhancedDocument document = EnhancedDocument.builder()
+                                                    .put("value", input, type)
+                                                    .build();
+
+        assertThatThrownBy(() -> schema.itemToMap(document, false))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + type);
+    }
+
+    @Test
+    @DisplayName("A schema provider exception propagates through document conversion")
+    void itemToMap_whenThrowingSchemaProvider_propagatesExceptionAndSkipsLaterProvider() {
+        EnhancedType<CustomType> type = EnhancedType.of(CustomType.class);
+        AttributeConverterProvider throwing = new ThrowingProvider();
+        AttributeConverterProvider later = mock(AttributeConverterProvider.class);
+        DocumentTableSchema schema = DocumentTableSchema.builder()
+                                                        .attributeConverterProviders(throwing, later)
+                                                        .build();
+        EnhancedDocument document = EnhancedDocument.builder()
+                                                    .put("value", new CustomType("x"), type)
+                                                    .build();
+
+        assertThatThrownBy(() -> schema.itemToMap(document, false))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Attribute converter provider failed while looking up " + type);
+        verifyNoInteractions(later);
+    }
+
+    @Test
+    @DisplayName("Object lookup consults the merged schema provider before reporting a missing converter")
+    void itemToMap_whenObjectTypeWithObjectProviderOnSchema_throwsConverterNotFoundAfterInvokingProvider() {
+        AttributeConverterProvider objectProvider = mock(AttributeConverterProvider.class);
+        DocumentTableSchema schema = DocumentTableSchema.builder()
+                                                        .attributeConverterProviders(
+                                                            objectProvider,
+                                                            AttributeConverterProvider.defaultProvider())
+                                                        .build();
+        EnhancedDocument document = EnhancedDocument.builder()
+                                                    .put("value", new Object(), EnhancedType.of(Object.class))
+                                                    .build();
+
+        assertThatThrownBy(() -> schema.itemToMap(document, false))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + EnhancedType.of(Object.class));
+        verify(objectProvider).converterFor(EnhancedType.of(Object.class));
+    }
+
+    private static TableSchema<DocumentType> documentSchema() {
+        return StaticTableSchema.builder(DocumentType.class)
+                                .newItemSupplier(DocumentType::new)
+                                .addAttribute(String.class, a -> a.name("name")
+                                                                  .getter(DocumentType::getName)
+                                                                  .setter(DocumentType::setName))
+                                .build();
+    }
+
+    private static String documentConverterNotFoundMessage(EnhancedType<?> type) {
+        return "AttributeConverter not found for class " + type
+               + ". Please add an AttributeConverterProvider for this type. If it is a default type, add the "
+               + "DefaultAttributeConverterProvider to the builder.";
+    }
+
+    static final class CustomType {
+        private final String value;
+
+        CustomType(String value) {
+            this.value = value;
+        }
+
+        String value() {
+            return value;
+        }
+    }
+
+    static final class UnsupportedType {
+        private final String value;
+
+        UnsupportedType(String value) {
+            this.value = value;
+        }
+    }
+
+    static final class DocumentType {
+        private String name;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+
+    static final class ReturningNullProvider implements AttributeConverterProvider {
+        private final List<EnhancedType<?>> requestedTypes = new ArrayList<>();
+
+        @Override
+        public <T> AttributeConverter<T> converterFor(EnhancedType<T> enhancedType) {
+            requestedTypes.add(enhancedType);
+            return null;
+        }
+
+        List<EnhancedType<?>> requestedTypes() {
+            return requestedTypes;
+        }
+    }
+
+    static final class CustomTypeConverter implements AttributeConverter<CustomType> {
+        private final String prefix;
+
+        CustomTypeConverter(String prefix) {
+            this.prefix = prefix;
+        }
+
+        @Override
+        public AttributeValue transformFrom(CustomType input) {
+            return AttributeValue.fromS(prefix + ":" + input.value());
+        }
+
+        @Override
+        public CustomType transformTo(AttributeValue input) {
+            String text = input.s();
+            return new CustomType(text.substring(prefix.length() + 1));
+        }
+
+        @Override
+        public EnhancedType<CustomType> type() {
+            return EnhancedType.of(CustomType.class);
+        }
+
+        @Override
+        public AttributeValueType attributeValueType() {
+            return AttributeValueType.S;
+        }
+    }
+
+    static final class RecordingPrefixProvider implements AttributeConverterProvider {
+        private final List<EnhancedType<?>> requestedTypes = new ArrayList<>();
+        private final CustomTypeConverter converter;
+
+        RecordingPrefixProvider(String prefix) {
+            this.converter = new CustomTypeConverter(prefix);
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> AttributeConverter<T> converterFor(EnhancedType<T> enhancedType) {
+            requestedTypes.add(enhancedType);
+            if (EnhancedType.of(CustomType.class).equals(enhancedType)) {
+                return (AttributeConverter<T>) converter;
+            }
+            return null;
+        }
+
+        List<EnhancedType<?>> requestedTypes() {
+            return requestedTypes;
+        }
+    }
+
+    static final class ThrowingProvider implements AttributeConverterProvider {
+        @Override
+        public <T> AttributeConverter<T> converterFor(EnhancedType<T> enhancedType) {
+            throw new IllegalArgumentException("Attribute converter provider failed while looking up " + enhancedType);
+        }
+    }
+
+}

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/EnhancedDocumentConverterTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/EnhancedDocumentConverterTest.java
@@ -1,0 +1,887 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.enhanced.dynamodb.document.EnhancedDocument;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.StaticTableSchema;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+
+/**
+ * Tests typed value conversion performed by enhanced documents.
+ * <p>
+ * The tests cover scalar, enumeration, collection, map, iterable, and schema backed document values. They verify
+ * provider ordering and fallback, recursive member lookup, JSON provider configuration, explicit null values,
+ * unsupported type errors, and propagation of converter failures.
+ */
+public class EnhancedDocumentConverterTest {
+
+    @Test
+    @DisplayName("Typed scalar conversion stores S text and reads the original string")
+    void putThenGet_whenStringType_storesSTextAndReadsOriginalString() {
+        EnhancedType<String> type = EnhancedType.of(String.class);
+
+        EnhancedDocument document = defaultBuilder().put("value", "text", type).build();
+        Map<String, AttributeValue> map = document.toMap();
+        String read = document.get("value", type);
+
+        assertThat(map.get("value")).isEqualTo(AttributeValue.fromS("text"));
+        assertThat(read).isEqualTo("text");
+    }
+
+    @Test
+    @DisplayName("Typed list conversion stores L and reads an ArrayList that retains order and duplicates")
+    void putThenGet_whenStringList_storesLAndReadsArrayListRetainingOrderAndDuplicates() {
+        EnhancedType<List<String>> type = EnhancedType.listOf(String.class);
+        List<String> input = new ArrayList<>();
+        input.add("a");
+        input.add("b");
+        input.add("a");
+
+        EnhancedDocument document = defaultBuilder().put("value", input, type).build();
+        Map<String, AttributeValue> map = document.toMap();
+        List<String> read = document.get("value", type);
+
+        assertThat(map.get("value").hasL()).isTrue();
+        assertThat(read).isInstanceOf(ArrayList.class)
+                        .containsExactly("a", "b", "a")
+                        .isEqualTo(input);
+    }
+
+    @Test
+    @DisplayName("Typed set conversion stores SS and reads an equal LinkedHashSet")
+    void putThenGet_whenStringSet_storesSsAndReadsEqualLinkedHashSet() {
+        EnhancedType<Set<String>> type = EnhancedType.setOf(String.class);
+        Set<String> input = new LinkedHashSet<>();
+        input.add("a");
+        input.add("b");
+
+        EnhancedDocument document = defaultBuilder().put("value", input, type).build();
+        Map<String, AttributeValue> map = document.toMap();
+        Set<String> read = document.get("value", type);
+
+        assertThat(map.get("value").hasSs()).isTrue();
+        assertThat(read).isInstanceOf(LinkedHashSet.class).isEqualTo(input);
+    }
+
+    @Test
+    @DisplayName("Typed map conversion stores M with an N member and reads an equal LinkedHashMap")
+    void putThenGet_whenStringToIntegerMap_storesMWithNMemberAndReadsEqualLinkedHashMap() {
+        EnhancedType<Map<String, Integer>> type = EnhancedType.mapOf(String.class, Integer.class);
+        Map<String, Integer> input = new LinkedHashMap<>();
+        input.put("count", 7);
+
+        EnhancedDocument document = defaultBuilder().put("value", input, type).build();
+        Map<String, AttributeValue> map = document.toMap();
+        Map<String, Integer> read = document.get("value", type);
+
+        assertThat(map.get("value").hasM()).isTrue();
+        assertThat(map.get("value").m().get("count")).isEqualTo(AttributeValue.fromN("7"));
+        assertThat(read).isInstanceOf(LinkedHashMap.class).isEqualTo(input);
+    }
+
+    @Test
+    @DisplayName("Typed enum conversion stores toString text and reads the same constant")
+    void putThenGet_whenEnumType_storesToStringTextAndReadsSameConstant() {
+        EnhancedType<TestEnum> type = EnhancedType.of(TestEnum.class);
+        TestEnum input = TestEnum.OPEN;
+
+        EnhancedDocument document = defaultBuilder().put("value", input, type).build();
+        Map<String, AttributeValue> map = document.toMap();
+        TestEnum read = document.get("value", type);
+
+        assertThat(map.get("value")).isEqualTo(AttributeValue.fromS(input.toString()));
+        assertThat(read).isSameAs(input);
+    }
+
+    @Test
+    @DisplayName("Typed document conversion stores M and reconstructs through the table schema")
+    void putThenGet_whenSchemaBearingDocument_storesMAndReconstructsThroughTableSchema() {
+        TableSchema<DocumentType> documentSchema = documentSchema();
+        EnhancedType<DocumentType> type = EnhancedType.documentOf(DocumentType.class, documentSchema);
+        DocumentType input = new DocumentType();
+        input.setName("doc");
+
+        EnhancedDocument document = defaultBuilder().put("value", input, type).build();
+        Map<String, AttributeValue> map = document.toMap();
+        DocumentType read = document.get("value", type);
+
+        assertThat(map.get("value").hasM()).isTrue();
+        assertThat(map.get("value").m()).containsEntry("name", AttributeValue.fromS("doc"));
+        assertThat(read.getName()).isEqualTo("doc");
+    }
+
+    @Test
+    @DisplayName("Deep typed document conversion nests L then M then M and reconstructs the document")
+    void putThenGet_whenListOfMapOfDocument_nestsLThenMThenMAndReconstructsDocument() {
+        TableSchema<DocumentType> documentSchema = documentSchema();
+        EnhancedType<List<Map<String, DocumentType>>> type =
+            EnhancedType.listOf(EnhancedType.mapOf(EnhancedType.of(String.class),
+                                                   EnhancedType.documentOf(DocumentType.class, documentSchema)));
+        DocumentType nested = new DocumentType();
+        nested.setName("doc");
+        Map<String, DocumentType> inner = new LinkedHashMap<>();
+        inner.put("doc", nested);
+        List<Map<String, DocumentType>> input = new ArrayList<>();
+        input.add(inner);
+
+        EnhancedDocument document = defaultBuilder().put("value", input, type).build();
+        Map<String, AttributeValue> map = document.toMap();
+        List<Map<String, DocumentType>> read = document.get("value", type);
+
+        assertThat(map.get("value").hasL()).isTrue();
+        assertThat(map.get("value").l().get(0).hasM()).isTrue();
+        assertThat(map.get("value").l().get(0).m().get("doc").hasM()).isTrue();
+        assertThat(read).isInstanceOf(ArrayList.class);
+        assertThat(read.get(0)).isInstanceOf(LinkedHashMap.class);
+        assertThat(read.get(0).get("doc").getName()).isEqualTo("doc");
+    }
+
+    @Test
+    @DisplayName("A builder with no provider succeeds on build then fails on toMap with the document error")
+    void toMap_whenBuilderWithNoProvider_throwsDocumentConverterNotFound() {
+        EnhancedType<String> type = EnhancedType.of(String.class);
+
+        EnhancedDocument document = EnhancedDocument.builder().put("value", "text", type).build();
+
+        assertThat(document).isNotNull();
+        assertThatThrownBy(document::toMap)
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage(documentConverterNotFoundMessage(type));
+    }
+
+    @Test
+    @DisplayName("An all-null custom chain reports the document error and calls each provider once")
+    void toMap_whenAllNullCustomChain_throwsDocumentConverterNotFoundAndCallsEachProviderOnce() {
+        EnhancedType<String> type = EnhancedType.of(String.class);
+        ReturningNullProvider first = new ReturningNullProvider();
+        ReturningNullProvider second = new ReturningNullProvider();
+
+        assertThatThrownBy(() -> EnhancedDocument.builder()
+                                                 .attributeConverterProviders(first, second)
+                                                 .put("value", "text", type)
+                                                 .build()
+                                                 .toMap())
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage(documentConverterNotFoundMessage(type));
+        assertThat(first.requestedTypes()).containsExactly(type);
+        assertThat(second.requestedTypes()).containsExactly(type);
+    }
+
+    @Test
+    @DisplayName("A null-returning custom provider falls back to the default provider")
+    void toMap_whenNullReturningCustomThenDefault_fallsBackToDefaultStringConverter() {
+        EnhancedType<String> type = EnhancedType.of(String.class);
+        ReturningNullProvider returningNull = new ReturningNullProvider();
+
+        Map<String, AttributeValue> map = EnhancedDocument.builder()
+                                                          .attributeConverterProviders(
+                                                              returningNull,
+                                                              AttributeConverterProvider.defaultProvider())
+                                                          .put("value", "text", type)
+                                                          .build()
+                                                          .toMap();
+
+        assertThat(returningNull.requestedTypes()).containsExactly(type);
+        assertThat(map.get("value")).isEqualTo(AttributeValue.fromS("text"));
+    }
+
+    @Test
+    @DisplayName("A custom provider before the default is selected twice by the chain")
+    void toMap_whenCustomProviderBeforeDefault_selectsCustomConverterAndCallsProviderTwice() {
+        EnhancedType<CustomType> type = EnhancedType.of(CustomType.class);
+        RecordingCustomProvider customProvider = new RecordingCustomProvider();
+
+        Map<String, AttributeValue> map = EnhancedDocument.builder()
+                                                          .attributeConverterProviders(
+                                                              customProvider,
+                                                              AttributeConverterProvider.defaultProvider())
+                                                          .put("value", new CustomType("x"), type)
+                                                          .build()
+                                                          .toMap();
+
+        assertThat(customProvider.requestedTypes()).containsExactly(type, type);
+        assertThat(customProvider.converter().attributeValueType()).isEqualTo(AttributeValueType.S);
+        assertThat(map.get("value").s()).isEqualTo("custom:x");
+    }
+
+    @Test
+    @DisplayName("A throwing custom provider exception propagates and skips the default provider")
+    void toMap_whenThrowingCustomProviderBeforeDefault_propagatesExceptionAndSkipsDefault() {
+        EnhancedType<CustomType> type = EnhancedType.of(CustomType.class);
+        AttributeConverterProvider throwing = new ThrowingProvider();
+        AttributeConverterProvider defaultProvider = mock(AttributeConverterProvider.class);
+
+        assertThatThrownBy(() -> EnhancedDocument.builder()
+                                                 .attributeConverterProviders(throwing, defaultProvider)
+                                                 .put("value", new CustomType("x"), type)
+                                                 .build()
+                                                 .toMap())
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Attribute converter provider failed while looking up " + type);
+        verifyNoInteractions(defaultProvider);
+    }
+
+    @Test
+    @DisplayName("Default-first order blocks a later custom provider")
+    void toMap_whenDefaultProviderBeforeCustom_throwsConverterNotFoundAndSkipsCustom() {
+        EnhancedType<CustomType> type = EnhancedType.of(CustomType.class);
+        RecordingCustomProvider customProvider = new RecordingCustomProvider();
+
+        assertThatThrownBy(() -> EnhancedDocument.builder()
+                                                 .attributeConverterProviders(
+                                                     AttributeConverterProvider.defaultProvider(),
+                                                     customProvider)
+                                                 .put("value", new CustomType("x"), type)
+                                                 .build()
+                                                 .toMap())
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + type);
+        assertThat(customProvider.requestedTypes()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("A configured default provider propagates its direct failure for an unsupported type")
+    void toMap_whenUnsupportedTypeWithDefaultProvider_throwsConverterNotFound() {
+        EnhancedType<UnsupportedType> type = EnhancedType.of(UnsupportedType.class);
+
+        assertThatThrownBy(() -> defaultBuilder().put("value", new UnsupportedType("x"), type).build().toMap())
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + type);
+    }
+
+    @Test
+    @DisplayName("EnhancedType Object fails converter lookup")
+    void toMap_whenObjectEnhancedType_throwsConverterNotFound() {
+        EnhancedType<Object> type = EnhancedType.of(Object.class);
+
+        assertThatThrownBy(() -> defaultBuilder().put("value", new Object(), type).build().toMap())
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + EnhancedType.of(Object.class));
+    }
+
+    @Test
+    @DisplayName("Class-based get rejects Object before provider lookup")
+    void get_whenObjectClass_throwsIllegalArgumentExceptionToUseGetList() {
+        EnhancedDocument document = defaultBuilder()
+            .put("value", "text", EnhancedType.of(String.class))
+            .build();
+
+        assertThatThrownBy(() -> document.get("value", Object.class))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Values of type List are not supported by this API, please use the getList API instead");
+    }
+
+    @Test
+    @DisplayName("Class-based put rejects Object before lazy conversion")
+    void put_whenObjectClass_throwsIllegalArgumentExceptionToUsePutList() {
+        assertThatThrownBy(() -> EnhancedDocument.builder().put("value", new Object(), Object.class))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Values of type List are not supported by this API, please use the putList API instead");
+    }
+
+    @Test
+    @DisplayName("EnhancedDocument sends Collection to its list branch and reads an ArrayList")
+    void putThenGet_whenStringCollection_storesLAndReadsArrayList() {
+        EnhancedType<Collection<String>> type = EnhancedType.collectionOf(String.class);
+        List<String> input = new ArrayList<>();
+        input.add("a");
+
+        EnhancedDocument document = defaultBuilder().put("value", input, type).build();
+        Map<String, AttributeValue> map = document.toMap();
+        Collection<String> read = document.get("value", type);
+
+        assertThat(map.get("value").hasL()).isTrue();
+        assertThat(read).isInstanceOf(ArrayList.class).containsExactly("a");
+    }
+
+    @Test
+    @DisplayName("EnhancedDocument sends Iterable to its list branch and reads an ArrayList")
+    void putThenGet_whenStringIterable_storesLAndReadsArrayList() {
+        EnhancedType<Iterable<String>> type = new EnhancedType<Iterable<String>>() { };
+        Iterable<String> input = new ArrayList<>(Collections.singletonList("a"));
+
+        EnhancedDocument document = defaultBuilder().put("value", input, type).build();
+        Map<String, AttributeValue> map = document.toMap();
+        Iterable<String> read = document.get("value", type);
+
+        assertThat(map.get("value").hasL()).isTrue();
+        assertThat(read).isInstanceOf(ArrayList.class);
+        assertThat((List<String>) read).containsExactly("a");
+    }
+
+    @Test
+    @DisplayName("A non-Collection Iterable fails in the document list converter")
+    void toMap_whenNonCollectionIterable_throwsClassCastException() {
+        EnhancedType<Iterable<String>> type = new EnhancedType<Iterable<String>>() { };
+        Iterable<String> input = new NonCollectionIterable();
+
+        assertThatThrownBy(() -> defaultBuilder().put("value", input, type).build().toMap())
+            .isInstanceOf(ClassCastException.class)
+            .hasMessageContaining(NonCollectionIterable.class.getName())
+            .hasMessageContaining("cannot be cast");
+    }
+
+    @Test
+    @DisplayName("Deque delegates to the default provider and remains unsupported")
+    void toMap_whenStringDeque_throwsConverterNotFound() {
+        EnhancedType<Deque<String>> type = EnhancedType.dequeOf(String.class);
+        Deque<String> input = new ArrayDeque<>();
+        input.add("a");
+
+        assertThatThrownBy(() -> defaultBuilder().put("value", input, type).build().toMap())
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + type);
+    }
+
+    @Test
+    @DisplayName("A concrete ArrayList token delegates to the default provider and remains unsupported")
+    void toMap_whenConcreteArrayList_throwsConverterNotFound() {
+        EnhancedType<ArrayList<String>> type = new EnhancedType<ArrayList<String>>() { };
+        ArrayList<String> input = new ArrayList<>();
+        input.add("a");
+
+        assertThatThrownBy(() -> defaultBuilder().put("value", input, type).build().toMap())
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + type);
+    }
+
+    @Test
+    @DisplayName("Document list recursion can use a custom member provider")
+    void putThenGet_whenListOfUnsupportedTypeWithMemberProvider_storesLWithSMembersAndReadsArrayList() {
+        EnhancedType<List<UnsupportedType>> type = EnhancedType.listOf(UnsupportedType.class);
+        List<UnsupportedType> input = new ArrayList<>();
+        input.add(new UnsupportedType("a"));
+        input.add(new UnsupportedType("b"));
+        AttributeConverterProvider memberProvider = new UnsupportedMemberProvider();
+
+        EnhancedDocument document = EnhancedDocument.builder()
+                                                    .attributeConverterProviders(memberProvider)
+                                                    .put("value", input, type)
+                                                    .build();
+        Map<String, AttributeValue> map = document.toMap();
+        List<UnsupportedType> read = document.get("value", type);
+
+        assertThat(map.get("value").hasL()).isTrue();
+        assertThat(map.get("value").l()).containsExactly(AttributeValue.fromS("a"), AttributeValue.fromS("b"));
+        assertThat(read).isInstanceOf(ArrayList.class).isEqualTo(input);
+    }
+
+    @Test
+    @DisplayName("Document map recursion can use a custom value provider")
+    void putThenGet_whenMapOfUnsupportedTypeWithValueProvider_storesMWithSMemberAndReadsLinkedHashMap() {
+        EnhancedType<Map<String, UnsupportedType>> type =
+            EnhancedType.mapOf(String.class, UnsupportedType.class);
+        Map<String, UnsupportedType> input = new LinkedHashMap<>();
+        input.put("key", new UnsupportedType("a"));
+        AttributeConverterProvider memberProvider = new UnsupportedMemberProvider();
+
+        EnhancedDocument document = EnhancedDocument.builder()
+                                                    .attributeConverterProviders(memberProvider)
+                                                    .put("value", input, type)
+                                                    .build();
+        Map<String, AttributeValue> map = document.toMap();
+        Map<String, UnsupportedType> read = document.get("value", type);
+
+        assertThat(map.get("value").hasM()).isTrue();
+        assertThat(map.get("value").m().get("key")).isEqualTo(AttributeValue.fromS("a"));
+        assertThat(read).isInstanceOf(LinkedHashMap.class).isEqualTo(input);
+    }
+
+    @Test
+    @DisplayName("A document list of Object fails converter lookup for its member type")
+    void toMap_whenListOfObject_throwsConverterNotFoundForMemberType() {
+        EnhancedType<List<Object>> type = EnhancedType.listOf(Object.class);
+        List<Object> input = new ArrayList<>();
+        input.add("a");
+
+        assertThatThrownBy(() -> defaultBuilder().put("value", input, type).build().toMap())
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + EnhancedType.of(Object.class));
+    }
+
+    @Test
+    @DisplayName("An explicit document null is present without converter lookup")
+    void putNull_whenWithoutProvider_isPresentAndStoredAsNul() {
+        EnhancedDocument document = EnhancedDocument.builder().putNull("value").build();
+
+        assertThat(document.isPresent("value")).isTrue();
+        assertThat(document.isNull("value")).isTrue();
+        assertThat(document.toMap()).containsEntry("value", AttributeValue.fromNul(true));
+    }
+
+    @Test
+    @DisplayName("An absent document attribute differs from explicit null")
+    void get_whenAbsentAttribute_isNotPresentAndReturnsNull() {
+        EnhancedType<String> type = EnhancedType.of(String.class);
+        EnhancedDocument document = EnhancedDocument.builder().build();
+
+        assertThat(document.isPresent("value")).isFalse();
+        assertThat(document.isNull("value")).isFalse();
+        assertThat(document.get("value", type)).isNull();
+    }
+
+    @Test
+    @DisplayName("Typed put rejects a null Java value")
+    void put_whenNullJavaValue_throwsNullPointerExceptionWithPutNullGuidance() {
+        EnhancedType<String> type = EnhancedType.of(String.class);
+
+        assertThatThrownBy(() -> EnhancedDocument.builder().put("value", null, type))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessage("Value for value must not be null. Use putNull API to insert a Null value");
+    }
+
+    @Test
+    @DisplayName("Typed get maps explicit NULL to null while presence flags remain true")
+    void get_whenExplicitNulAttribute_returnsNullWhilePresentAndNullFlagsRemainTrue() {
+        EnhancedType<String> type = EnhancedType.of(String.class);
+        EnhancedDocument document = defaultBuilder()
+            .put("value", AttributeValue.fromNul(true), EnhancedType.of(AttributeValue.class))
+            .build();
+
+        assertThat(document.get("value", type)).isNull();
+        assertThat(document.isPresent("value")).isTrue();
+        assertThat(document.isNull("value")).isTrue();
+    }
+
+    @Test
+    @DisplayName("fromJson installs the shared default provider")
+    void fromJson_whenJsonObject_installsDefaultProviderAndReadsString() {
+        EnhancedType<String> type = EnhancedType.of(String.class);
+
+        EnhancedDocument document = EnhancedDocument.fromJson("{\"value\":\"text\"}");
+
+        assertThat(document.attributeConverterProviders())
+            .contains(AttributeConverterProvider.defaultProvider());
+        assertThat(document.get("value", type)).isEqualTo("text");
+    }
+
+    @Test
+    @DisplayName("fromAttributeValueMap installs the shared default provider")
+    void fromAttributeValueMap_whenNumericAttribute_installsDefaultProviderAndReadsInteger() {
+        EnhancedType<Integer> type = EnhancedType.of(Integer.class);
+        Map<String, AttributeValue> input = Collections.singletonMap("value", AttributeValue.fromN("7"));
+
+        EnhancedDocument document = EnhancedDocument.fromAttributeValueMap(input);
+
+        assertThat(document.attributeConverterProviders())
+            .contains(AttributeConverterProvider.defaultProvider());
+        assertThat(document.get("value", type)).isEqualTo(7);
+    }
+
+    @Test
+    @DisplayName("An AttributeValue escape path stores and returns the exact value without a provider")
+    void put_whenAttributeValueMap_storesAndReturnsExactValueWithoutProvider() {
+        AttributeValue input = AttributeValue.fromM(
+            Collections.singletonMap("inner", AttributeValue.fromS("text")));
+
+        EnhancedDocument document = EnhancedDocument.builder()
+                                                    .attributeValueMap(Collections.singletonMap("value", input))
+                                                    .build();
+
+        assertThat(document.toMap().get("value")).isEqualTo(input);
+        assertThat(document.get("value", EnhancedType.of(AttributeValue.class))).isEqualTo(input);
+    }
+
+    @Test
+    @DisplayName("A null EnhancedType fails only when lazy conversion runs")
+    void toMap_whenNullEnhancedType_buildSucceedsThenThrowsNullPointerException() {
+        EnhancedDocument document = EnhancedDocument.builder()
+                                                    .put("value", "text", (EnhancedType<String>) null)
+                                                    .build();
+
+        assertThat(document).isNotNull();
+        assertThatThrownBy(document::toMap)
+            .isInstanceOf(NullPointerException.class)
+            .satisfies(ex -> assertThat(ex.getMessage() == null || ex.getMessage().contains("null")).isTrue());
+    }
+
+    @Test
+    @DisplayName("A typed concrete HashMap differs from the base-map helper and remains unsupported")
+    void toMap_whenConcreteHashMap_throwsConverterNotFound() {
+        EnhancedType<HashMap<String, Integer>> type = new EnhancedType<HashMap<String, Integer>>() { };
+        HashMap<String, Integer> input = new HashMap<>();
+        input.put("count", 7);
+
+        assertThatThrownBy(() -> defaultBuilder().put("value", input, type).build().toMap())
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + type);
+    }
+
+    @Test
+    @DisplayName("Object lookup consults a custom provider before reporting a missing converter")
+    void toMap_whenObjectTypeWithObjectProvider_throwsConverterNotFoundAfterInvokingProvider() {
+        EnhancedType<Object> type = EnhancedType.of(Object.class);
+        AttributeConverterProvider objectProvider = mock(AttributeConverterProvider.class);
+
+        assertThatThrownBy(() -> EnhancedDocument.builder()
+                                                 .attributeConverterProviders(
+                                                     objectProvider,
+                                                     AttributeConverterProvider.defaultProvider())
+                                                 .put("value", new Object(), type)
+                                                 .build()
+                                                 .toMap())
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + EnhancedType.of(Object.class));
+        verify(objectProvider).converterFor(type);
+    }
+
+    @Test
+    @DisplayName("A custom provider intercepts a schema-bearing Object token")
+    void toMap_whenSchemaBearingObjectWithMatchingProvider_usesCustomConverter() {
+        TableSchema<Object> objectSchema = mock(TableSchema.class);
+        EnhancedType<Object> type = EnhancedType.documentOf(Object.class, objectSchema);
+        AttributeConverterProvider objectProvider = mock(AttributeConverterProvider.class);
+        AttributeConverter<Object> objectConverter = mock(AttributeConverter.class);
+        Object value = new Object();
+
+        when(objectProvider.converterFor(type)).thenReturn(objectConverter);
+        when(objectConverter.transformFrom(value)).thenReturn(AttributeValue.fromS("custom"));
+
+        Map<String, AttributeValue> result = EnhancedDocument.builder()
+                                                             .attributeConverterProviders(
+                                                                 objectProvider,
+                                                                 AttributeConverterProvider.defaultProvider())
+                                                             .put("value", value, type)
+                                                             .build()
+                                                             .toMap();
+
+        assertThat(result).containsEntry("value", AttributeValue.fromS("custom"));
+        verify(objectConverter).transformFrom(value);
+        verifyNoInteractions(objectSchema);
+    }
+
+    @Test
+    @DisplayName("A throwing list-member provider exception propagates")
+    void toMap_whenListOfUnsupportedTypeWithThrowingMemberProvider_propagatesNestedProviderFailure() {
+        EnhancedType<List<UnsupportedType>> type = EnhancedType.listOf(UnsupportedType.class);
+        List<UnsupportedType> input = new ArrayList<>();
+        input.add(new UnsupportedType("a"));
+        AttributeConverterProvider provider = new NestedThrowingProvider();
+
+        assertThatThrownBy(() -> EnhancedDocument.builder()
+                                                 .attributeConverterProviders(provider)
+                                                 .put("value", input, type)
+                                                 .build()
+                                                 .toMap())
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Attribute converter provider failed while looking up " + EnhancedType.of(UnsupportedType.class));
+    }
+
+    @Test
+    @DisplayName("A throwing map-value provider exception propagates")
+    void toMap_whenMapOfUnsupportedTypeWithThrowingValueProvider_propagatesNestedProviderFailure() {
+        EnhancedType<Map<String, UnsupportedType>> type =
+            EnhancedType.mapOf(String.class, UnsupportedType.class);
+        Map<String, UnsupportedType> input = Collections.singletonMap("key", new UnsupportedType("a"));
+        AttributeConverterProvider provider = new NestedThrowingProvider();
+
+        assertThatThrownBy(() -> EnhancedDocument.builder()
+                                                 .attributeConverterProviders(provider)
+                                                 .put("value", input, type)
+                                                 .build()
+                                                 .toMap())
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Attribute converter provider failed while looking up " + EnhancedType.of(UnsupportedType.class));
+    }
+
+    @Test
+    @DisplayName("A throwing set-member provider is not reached because default recursive lookup fails")
+    void toMap_whenSetOfUnsupportedTypeWithThrowingMemberProvider_recordsOnlyOuterSetAndNamesMemberType() {
+        EnhancedType<Set<UnsupportedType>> type = EnhancedType.setOf(UnsupportedType.class);
+        Set<UnsupportedType> input = new LinkedHashSet<>();
+        input.add(new UnsupportedType("a"));
+        NestedThrowingProvider provider = new NestedThrowingProvider();
+
+        assertThatThrownBy(() -> EnhancedDocument.builder()
+                                                 .attributeConverterProviders(
+                                                     provider,
+                                                     AttributeConverterProvider.defaultProvider())
+                                                 .put("value", input, type)
+                                                 .build()
+                                                 .toMap())
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + EnhancedType.of(UnsupportedType.class));
+        assertThat(provider.requestedTypes()).containsExactly(type);
+    }
+
+    @Test
+    @DisplayName("A null list-member provider result names the member type in the document error")
+    void toMap_whenListOfUnsupportedTypeWithNullMemberProvider_throwsDocumentConverterNotFoundForMember() {
+        EnhancedType<List<UnsupportedType>> type = EnhancedType.listOf(UnsupportedType.class);
+        EnhancedType<UnsupportedType> memberType = EnhancedType.of(UnsupportedType.class);
+        List<UnsupportedType> input = Collections.singletonList(new UnsupportedType("a"));
+        AttributeConverterProvider provider = new ReturningNullProvider();
+
+        assertThatThrownBy(() -> EnhancedDocument.builder()
+                                                 .attributeConverterProviders(provider)
+                                                 .put("value", input, type)
+                                                 .build()
+                                                 .toMap())
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage(documentConverterNotFoundMessage(memberType));
+    }
+
+    @Test
+    @DisplayName("A null map-value provider result names the value type in the document error")
+    void toMap_whenMapOfUnsupportedTypeWithNullValueProvider_throwsDocumentConverterNotFoundForValue() {
+        EnhancedType<Map<String, UnsupportedType>> type =
+            EnhancedType.mapOf(String.class, UnsupportedType.class);
+        EnhancedType<UnsupportedType> valueType = EnhancedType.of(UnsupportedType.class);
+        Map<String, UnsupportedType> input = Collections.singletonMap("key", new UnsupportedType("a"));
+        AttributeConverterProvider provider = new ReturningNullProvider();
+
+        assertThatThrownBy(() -> EnhancedDocument.builder()
+                                                 .attributeConverterProviders(provider)
+                                                 .put("value", input, type)
+                                                 .build()
+                                                 .toMap())
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage(documentConverterNotFoundMessage(valueType));
+    }
+
+    private static EnhancedDocument.Builder defaultBuilder() {
+        return EnhancedDocument.builder()
+                               .attributeConverterProviders(AttributeConverterProvider.defaultProvider());
+    }
+
+    private static TableSchema<DocumentType> documentSchema() {
+        return StaticTableSchema.builder(DocumentType.class)
+                                .newItemSupplier(DocumentType::new)
+                                .addAttribute(String.class, a -> a.name("name")
+                                                                  .getter(DocumentType::getName)
+                                                                  .setter(DocumentType::setName))
+                                .build();
+    }
+
+    private static String documentConverterNotFoundMessage(EnhancedType<?> type) {
+        return "AttributeConverter not found for class " + type
+               + ". Please add an AttributeConverterProvider for this type. If it is a default type, add the "
+               + "DefaultAttributeConverterProvider to the builder.";
+    }
+
+    enum TestEnum {
+        OPEN,
+        CLOSED
+    }
+
+    static final class CustomType {
+        private final String value;
+
+        CustomType(String value) {
+            this.value = value;
+        }
+
+        String value() {
+            return value;
+        }
+    }
+
+    static final class UnsupportedType {
+        private final String value;
+
+        UnsupportedType(String value) {
+            this.value = value;
+        }
+
+        String value() {
+            return value;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof UnsupportedType)) {
+                return false;
+            }
+            UnsupportedType that = (UnsupportedType) o;
+            return Objects.equals(value, that.value);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(value);
+        }
+    }
+
+    static final class DocumentType {
+        private String name;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+
+    static final class ReturningNullProvider implements AttributeConverterProvider {
+        private final List<EnhancedType<?>> requestedTypes = new ArrayList<>();
+
+        @Override
+        public <T> AttributeConverter<T> converterFor(EnhancedType<T> enhancedType) {
+            requestedTypes.add(enhancedType);
+            return null;
+        }
+
+        List<EnhancedType<?>> requestedTypes() {
+            return requestedTypes;
+        }
+    }
+
+    static final class NonCollectionIterable implements Iterable<String> {
+        @Override
+        public Iterator<String> iterator() {
+            return Collections.singletonList("a").iterator();
+        }
+    }
+
+    static final class CustomTypeConverter implements AttributeConverter<CustomType> {
+        private final String prefix;
+
+        CustomTypeConverter(String prefix) {
+            this.prefix = prefix;
+        }
+
+        @Override
+        public AttributeValue transformFrom(CustomType input) {
+            return AttributeValue.fromS(prefix + ":" + input.value());
+        }
+
+        @Override
+        public CustomType transformTo(AttributeValue input) {
+            String text = input.s();
+            return new CustomType(text.substring(prefix.length() + 1));
+        }
+
+        @Override
+        public EnhancedType<CustomType> type() {
+            return EnhancedType.of(CustomType.class);
+        }
+
+        @Override
+        public AttributeValueType attributeValueType() {
+            return AttributeValueType.S;
+        }
+    }
+
+    static final class UnsupportedStringConverter implements AttributeConverter<UnsupportedType> {
+        @Override
+        public AttributeValue transformFrom(UnsupportedType input) {
+            return AttributeValue.fromS(input.value());
+        }
+
+        @Override
+        public UnsupportedType transformTo(AttributeValue input) {
+            return new UnsupportedType(input.s());
+        }
+
+        @Override
+        public EnhancedType<UnsupportedType> type() {
+            return EnhancedType.of(UnsupportedType.class);
+        }
+
+        @Override
+        public AttributeValueType attributeValueType() {
+            return AttributeValueType.S;
+        }
+    }
+
+    static final class RecordingCustomProvider implements AttributeConverterProvider {
+        private final List<EnhancedType<?>> requestedTypes = new ArrayList<>();
+        private final CustomTypeConverter converter = new CustomTypeConverter("custom");
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> AttributeConverter<T> converterFor(EnhancedType<T> enhancedType) {
+            requestedTypes.add(enhancedType);
+            if (EnhancedType.of(CustomType.class).equals(enhancedType)) {
+                return (AttributeConverter<T>) converter;
+            }
+            return null;
+        }
+
+        List<EnhancedType<?>> requestedTypes() {
+            return requestedTypes;
+        }
+
+        CustomTypeConverter converter() {
+            return converter;
+        }
+    }
+
+    static final class UnsupportedMemberProvider implements AttributeConverterProvider {
+        private final UnsupportedStringConverter converter = new UnsupportedStringConverter();
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> AttributeConverter<T> converterFor(EnhancedType<T> enhancedType) {
+            if (EnhancedType.of(UnsupportedType.class).equals(enhancedType)) {
+                return (AttributeConverter<T>) converter;
+            }
+            return null;
+        }
+    }
+
+    static final class ThrowingProvider implements AttributeConverterProvider {
+        @Override
+        public <T> AttributeConverter<T> converterFor(EnhancedType<T> enhancedType) {
+            throw new IllegalArgumentException("Attribute converter provider failed while looking up " + enhancedType);
+        }
+    }
+
+    static final class NestedThrowingProvider implements AttributeConverterProvider {
+        private final List<EnhancedType<?>> requestedTypes = new ArrayList<>();
+
+        @Override
+        public <T> AttributeConverter<T> converterFor(EnhancedType<T> enhancedType) {
+            requestedTypes.add(enhancedType);
+            if (EnhancedType.of(UnsupportedType.class).equals(enhancedType)) {
+                throw new IllegalArgumentException("Attribute converter provider failed while looking up " + enhancedType);
+            }
+            return null;
+        }
+
+        List<EnhancedType<?>> requestedTypes() {
+            return requestedTypes;
+        }
+    }
+
+}

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/ImmutableSchemaConverterTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/ImmutableSchemaConverterTest.java
@@ -1,0 +1,1681 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.DocumentAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.IntegerAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.ListAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.MapAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.SetAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.StringAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.BeanTableSchema;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.ImmutableTableSchema;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbConvertedBy;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbImmutable;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+
+/**
+ * Tests converter selection and item conversion for immutable table schemas.
+ * <p>
+ * The tests cover scalar, enumeration, collection, map, and nested immutable attributes. They also verify null
+ * handling, schema caching, declared converter providers, attribute converters, provider precedence, and unsupported
+ * attribute types during schema creation and item conversion.
+ */
+public class ImmutableSchemaConverterTest {
+
+    @BeforeEach
+    void setUp() {
+        clearSchemaCache(BeanTableSchema.class);
+        clearSchemaCache(ImmutableTableSchema.class);
+        RecordingCustomProvider.reset();
+        ReturningNullProvider.reset();
+        ThrowingProvider.reset();
+        ObjectProvider.reset();
+        UnsupportedTypeOnlyProvider.reset();
+    }
+
+    private static void clearSchemaCache(Class<?> schemaClass) {
+        try {
+            Method method = schemaClass.getDeclaredMethod("clearSchemaCache");
+            method.setAccessible(true);
+            method.invoke(null);
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @Test
+    @DisplayName("A nonnull integer property selects IntegerAttributeConverter and round-trips")
+    void fromImmutableClass_whenNonnullInteger_selectsIntegerConverterAndRoundTrips() {
+        TableSchema<IntegerModel> schema = TableSchema.fromImmutableClass(IntegerModel.class);
+        IntegerModel model = IntegerModel.builder().id("id-1").value(42).build();
+
+        Map<String, AttributeValue> map = schema.itemToMap(model, true);
+        IntegerModel read = schema.mapToItem(map);
+
+        AttributeConverter<?> converter = schema.converterForAttribute("value");
+        assertThat(converter).isInstanceOf(IntegerAttributeConverter.class);
+        assertThat(converter.attributeValueType()).isEqualTo(AttributeValueType.N);
+        assertThat(map.get("value").n()).isEqualTo("42");
+        assertThat(read.value()).isEqualTo(42);
+    }
+
+    @Test
+    @DisplayName("A string set is stored as SS and rebuilt as a LinkedHashSet")
+    void fromImmutableClass_whenStringSet_selectsSetConverterAndRebuildsLinkedHashSet() {
+        TableSchema<StringSetModel> schema = TableSchema.fromImmutableClass(StringSetModel.class);
+        Set<String> input = new LinkedHashSet<>();
+        input.add("a");
+        input.add("b");
+        StringSetModel model = StringSetModel.builder().id("id-1").value(input).build();
+
+        Map<String, AttributeValue> map = schema.itemToMap(model, true);
+        StringSetModel read = schema.mapToItem(map);
+
+        AttributeConverter<?> converter = schema.converterForAttribute("value");
+        assertThat(converter).isInstanceOf(SetAttributeConverter.class);
+        assertThat(converter.attributeValueType()).isEqualTo(AttributeValueType.SS);
+        assertThat(read.value()).isInstanceOf(LinkedHashSet.class)
+                                .containsExactly("a", "b");
+    }
+
+    @Test
+    @DisplayName("A nested immutable property selects DocumentAttributeConverter and is rebuilt")
+    void fromImmutableClass_whenNestedImmutable_selectsDocumentConverterAndRebuildsNestedValue() {
+        TableSchema<NestedOuterModel> schema = TableSchema.fromImmutableClass(NestedOuterModel.class);
+        NestedInnerModel nested = NestedInnerModel.builder().nestedValue("inner").build();
+        NestedOuterModel model = NestedOuterModel.builder().id("id-1").value(nested).build();
+
+        Map<String, AttributeValue> map = schema.itemToMap(model, true);
+        NestedOuterModel read = schema.mapToItem(map);
+
+        AttributeConverter<?> converter = schema.converterForAttribute("value");
+        assertThat(converter).isInstanceOf(DocumentAttributeConverter.class);
+        assertThat(converter.attributeValueType()).isEqualTo(AttributeValueType.M);
+        assertThat(read.value().nestedValue()).isEqualTo("inner");
+    }
+
+    @Test
+    @DisplayName("itemToMap with ignoreNulls false stores a null string as DynamoDB NULL")
+    void itemToMap_whenNullStringIgnoreNullsFalse_includesNulValue() {
+        TableSchema<StringModel> schema = TableSchema.fromImmutableClass(StringModel.class);
+        StringModel model = StringModel.builder().id("id-1").build();
+
+        Map<String, AttributeValue> map = schema.itemToMap(model, false);
+
+        assertThat(map).containsEntry("value", AttributeValue.fromNul(true));
+    }
+
+    @Test
+    @DisplayName("itemToMap with ignoreNulls true omits a null string property")
+    void itemToMap_whenNullStringIgnoreNullsTrue_omitsValue() {
+        TableSchema<StringModel> schema = TableSchema.fromImmutableClass(StringModel.class);
+        StringModel model = StringModel.builder().id("id-1").build();
+
+        Map<String, AttributeValue> map = schema.itemToMap(model, true);
+
+        assertThat(map).doesNotContainKey("value");
+    }
+
+    @Test
+    @DisplayName("mapToItem skips the builder method for a DynamoDB NULL string property")
+    void mapToItem_whenNulString_doesNotCallBuilderValueAndLeavesValueNull() {
+        TableSchema<NullReadModel> schema = TableSchema.fromImmutableClass(NullReadModel.class);
+        Map<String, AttributeValue> map = new HashMap<>();
+        map.put("id", AttributeValue.fromS("id-1"));
+        map.put("value", AttributeValue.fromNul(true));
+        NullReadModel.Builder.resetValueCalls();
+
+        NullReadModel read = schema.mapToItem(map);
+
+        assertThat(read).isNotNull();
+        assertThat(NullReadModel.Builder.valueCalls()).isZero();
+        assertThat(read.value()).isNull();
+    }
+
+    @Test
+    @DisplayName("An unconverted Object property fails converter lookup")
+    void fromImmutableClass_whenUnconvertedObject_throwsConverterNotFound() {
+        assertThatThrownBy(() -> TableSchema.fromImmutableClass(ObjectModel.class))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + EnhancedType.of(Object.class));
+    }
+
+    @Test
+    @DisplayName("An unconverted UnsupportedType property fails converter lookup")
+    void fromImmutableClass_whenUnconvertedUnsupportedType_throwsIllegalStateException() {
+        EnhancedType<UnsupportedType> type = EnhancedType.of(UnsupportedType.class);
+
+        assertThatThrownBy(() -> TableSchema.fromImmutableClass(UnsupportedModel.class))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + type);
+    }
+
+    @Test
+    @DisplayName("A custom provider listed first is consulted twice and supplies CustomTypeConverter")
+    void fromImmutableClass_whenCustomProviderFirst_invokesCustomTwiceAndRoundTrips() {
+        TableSchema<CustomFirstModel> schema = TableSchema.fromImmutableClass(CustomFirstModel.class);
+        CustomType input = new CustomType("x");
+        CustomFirstModel model = CustomFirstModel.builder().value(input).build();
+
+        Map<String, AttributeValue> map = schema.itemToMap(model, true);
+        CustomFirstModel read = schema.mapToItem(map);
+
+        assertThat(RecordingCustomProvider.current().requestedTypes())
+            .hasSize(2)
+            .containsExactly(EnhancedType.of(CustomType.class), EnhancedType.of(CustomType.class));
+        AttributeConverter<?> converter = schema.converterForAttribute("value");
+        assertThat(converter).isInstanceOf(CustomTypeConverter.class);
+        assertThat(converter.attributeValueType()).isEqualTo(AttributeValueType.S);
+        assertThat(read.value()).isEqualTo(input);
+    }
+
+    @Test
+    @DisplayName("A null-returning provider is consulted once then the default string converter is used")
+    void fromImmutableClass_whenNullReturningProviderThenDefault_invokesProviderOnceAndSelectsStringConverter() {
+        TableSchema<NullThenDefaultModel> schema =
+            TableSchema.fromImmutableClass(NullThenDefaultModel.class);
+
+        assertThat(ReturningNullProvider.current().requestedTypes())
+            .containsExactly(EnhancedType.of(String.class));
+        AttributeConverter<?> converter = schema.converterForAttribute("value");
+        assertThat(converter).isInstanceOf(StringAttributeConverter.class);
+        assertThat(converter.attributeValueType()).isEqualTo(AttributeValueType.S);
+    }
+
+    @Test
+    @DisplayName("Default-first ordering throws before a later custom provider is consulted")
+    void fromImmutableClass_whenDefaultProviderFirst_throwsAndDoesNotInvokeCustomProvider() {
+        EnhancedType<CustomType> type = EnhancedType.of(CustomType.class);
+
+        assertThatThrownBy(() -> TableSchema.fromImmutableClass(DefaultThenCustomModel.class))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + type);
+        RecordingCustomProvider custom = RecordingCustomProvider.current();
+        assertThat(custom == null || custom.requestedTypes().isEmpty()).isTrue();
+    }
+
+    @Test
+    @DisplayName("A throwing provider failure is propagated without consulting the default provider")
+    void fromImmutableClass_whenThrowingProviderThenDefault_propagatesProviderFailure() {
+        EnhancedType<CustomType> type = EnhancedType.of(CustomType.class);
+
+        assertThatThrownBy(() -> TableSchema.fromImmutableClass(ThrowingThenDefaultModel.class))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Attribute converter provider failed while looking up " + type);
+    }
+
+    @Test
+    @DisplayName("Immutable schema factory caches by model class")
+    void fromImmutableClass_whenSameClassTwice_returnsSameImmutableTableSchemaReference() {
+        ImmutableTableSchema<StringModel> first = TableSchema.fromImmutableClass(StringModel.class);
+        ImmutableTableSchema<StringModel> second = TableSchema.fromImmutableClass(StringModel.class);
+
+        assertThat(first).isSameAs(second);
+        assertThat(first).isInstanceOf(ImmutableTableSchema.class);
+    }
+
+    @Test
+    @DisplayName("Generic schema factory dispatches an immutable class")
+    void fromClass_whenImmutableModel_returnsImmutableTableSchemaWithStringConverter() {
+        StringModel item = StringModel.builder().id("id-1").value("text").build();
+
+        TableSchema<StringModel> schema = TableSchema.fromClass(StringModel.class);
+        Map<String, AttributeValue> map = schema.itemToMap(item, true);
+
+        assertThat(schema).isInstanceOf(ImmutableTableSchema.class);
+        assertThat(schema.converterForAttribute("value")).isInstanceOf(StringAttributeConverter.class);
+        assertThat(map.get("value").s()).isEqualTo("text");
+    }
+
+    @Test
+    @DisplayName("Immutable ObjectProvider before default selects ObjectStringConverter")
+    void fromImmutableClass_whenObjectProviderBeforeDefault_selectsObjectStringConverter() {
+        ObjectProviderModel item = ObjectProviderModel.builder().value(new Object()).build();
+
+        TableSchema<ObjectProviderModel> schema = TableSchema.fromImmutableClass(ObjectProviderModel.class);
+        Map<String, AttributeValue> map = schema.itemToMap(item, true);
+        ObjectProviderModel read = schema.mapToItem(map);
+
+        int objectRequestCount = 0;
+        for (EnhancedType<?> requestedType : ObjectProvider.current().requestedTypes()) {
+            if (EnhancedType.of(Object.class).equals(requestedType)) {
+                objectRequestCount++;
+            }
+        }
+        assertThat(objectRequestCount).isEqualTo(2);
+        assertThat(schema.converterForAttribute("value")).isInstanceOf(ObjectStringConverter.class);
+        assertThat(schema.converterForAttribute("value").attributeValueType()).isEqualTo(AttributeValueType.S);
+        assertThat(read.value()).isEqualTo("custom");
+    }
+
+    @Test
+    @DisplayName("ConvertedBy intercepts Object and does not consult the schema provider for that type")
+    void fromImmutableClass_whenObjectConvertedBy_selectsObjectStringConverterAndSkipsProvider() {
+        TableSchema<ConvertedObjectModel> schema =
+            TableSchema.fromImmutableClass(ConvertedObjectModel.class);
+        ConvertedObjectModel model = ConvertedObjectModel.builder().value(new Object()).build();
+
+        Map<String, AttributeValue> map = schema.itemToMap(model, true);
+        ConvertedObjectModel read = schema.mapToItem(map);
+
+        AttributeConverter<?> converter = schema.converterForAttribute("value");
+        assertThat(converter).isInstanceOf(ObjectStringConverter.class);
+        assertThat(converter.attributeValueType()).isEqualTo(AttributeValueType.S);
+        assertThat(ObjectProvider.current().requestedTypes()).doesNotContain(EnhancedType.of(Object.class));
+        assertThat(read.value()).isEqualTo("custom");
+    }
+
+    @Test
+    @DisplayName("ConvertedBy intercepts UnsupportedType with UnsupportedStringConverter")
+    void fromImmutableClass_whenUnsupportedConvertedBy_selectsUnsupportedStringConverterAndRoundTrips() {
+        TableSchema<ConvertedUnsupportedModel> schema =
+            TableSchema.fromImmutableClass(ConvertedUnsupportedModel.class);
+        UnsupportedType input = new UnsupportedType();
+        ConvertedUnsupportedModel model = ConvertedUnsupportedModel.builder().value(input).build();
+
+        Map<String, AttributeValue> map = schema.itemToMap(model, true);
+        ConvertedUnsupportedModel read = schema.mapToItem(map);
+
+        AttributeConverter<?> converter = schema.converterForAttribute("value");
+        assertThat(converter).isInstanceOf(UnsupportedStringConverter.class);
+        assertThat(converter.attributeValueType()).isEqualTo(AttributeValueType.S);
+        assertThat(read.value()).isEqualTo(input);
+    }
+
+    @Test
+    @DisplayName("ConvertedBy intercepts HashSet and the builder receives a HashSet")
+    void fromImmutableClass_whenHashSetConvertedBy_selectsHashSetConverterAndBuilderReceivesHashSet() {
+        TableSchema<ConvertedHashSetModel> schema =
+            TableSchema.fromImmutableClass(ConvertedHashSetModel.class);
+        HashSet<String> input = new HashSet<>();
+        input.add("a");
+        input.add("b");
+        ConvertedHashSetModel model = ConvertedHashSetModel.builder().value(input).build();
+
+        Map<String, AttributeValue> map = schema.itemToMap(model, true);
+        ConvertedHashSetModel read = schema.mapToItem(map);
+
+        AttributeConverter<?> converter = schema.converterForAttribute("value");
+        assertThat(converter).isInstanceOf(HashSetConverter.class);
+        assertThat(converter.attributeValueType()).isEqualTo(AttributeValueType.SS);
+        assertThat(read.value()).isInstanceOf(HashSet.class)
+                                .containsExactlyInAnyOrder("a", "b");
+    }
+
+    @Test
+    @DisplayName("An empty provider list fails with NPE when no attribute converter is present")
+    void fromImmutableClass_whenEmptyProvidersWithoutConvertedBy_throwsNullPointerException() {
+        assertThatThrownBy(() -> TableSchema.fromImmutableClass(EmptyProvidersModel.class))
+            .isInstanceOf(NullPointerException.class)
+            .satisfies(ex -> assertThat(ex.getMessage() == null || ex.getMessage().contains("null")).isTrue());
+    }
+
+    @Test
+    @DisplayName("ConvertedBy still works when the immutable type declares an empty provider list")
+    void fromImmutableClass_whenEmptyProvidersWithConvertedBy_usesCustomStringConverter() {
+        TableSchema<EmptyProvidersConvertedModel> schema =
+            TableSchema.fromImmutableClass(EmptyProvidersConvertedModel.class);
+        EmptyProvidersConvertedModel model = EmptyProvidersConvertedModel.builder().value("text").build();
+
+        Map<String, AttributeValue> map = schema.itemToMap(model, true);
+        EmptyProvidersConvertedModel read = schema.mapToItem(map);
+
+        AttributeConverter<?> converter = schema.converterForAttribute("value");
+        assertThat(converter).isInstanceOf(CustomStringConverter.class);
+        assertThat(converter.attributeValueType()).isEqualTo(AttributeValueType.S);
+        assertThat(map.get("value").s()).isEqualTo("custom:text");
+        assertThat(read.value()).isEqualTo("text");
+    }
+
+    @Test
+    @DisplayName("An unconverted HashSet property fails lookup before builder assignment")
+    void fromImmutableClass_whenUnconvertedHashSet_throwsIllegalStateException() {
+        EnhancedType<HashSet<String>> type = new EnhancedType<HashSet<String>>() {
+        };
+
+        assertThatThrownBy(() -> TableSchema.fromImmutableClass(HashSetModel.class))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + type);
+    }
+
+    @Test
+    @DisplayName("A custom provider is not consulted for set members during default fallback")
+    void fromImmutableClass_whenUnsupportedSetWithCustomMemberProvider_throwsForMemberType() {
+
+        assertThatThrownBy(() -> TableSchema.fromImmutableClass(UnsupportedSetModel.class))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + EnhancedType.of(UnsupportedType.class));
+        assertThat(UnsupportedTypeOnlyProvider.current().requestedTypes()).hasSize(1);
+        EnhancedType<?> requestedType = UnsupportedTypeOnlyProvider.current().requestedTypes().get(0);
+        assertThat(requestedType.rawClass()).isEqualTo(Set.class);
+        assertThat(requestedType.rawClassParameters()).containsExactly(EnhancedType.of(UnsupportedType.class));
+    }
+
+    @Test
+    @DisplayName("A Collection of String is stored as SS and rebuilt as a LinkedHashSet")
+    void fromImmutableClass_whenStringCollection_selectsSetConverterAndRebuildsLinkedHashSet() {
+        TableSchema<StringCollectionModel> schema = TableSchema.fromImmutableClass(StringCollectionModel.class);
+        Collection<String> input = new LinkedHashSet<>();
+        input.add("a");
+        input.add("b");
+        StringCollectionModel model = StringCollectionModel.builder().value(input).build();
+
+        Map<String, AttributeValue> map = schema.itemToMap(model, true);
+        StringCollectionModel read = schema.mapToItem(map);
+
+        AttributeConverter<?> converter = schema.converterForAttribute("value");
+        assertThat(converter).isInstanceOf(SetAttributeConverter.class);
+        assertThat(converter.attributeValueType()).isEqualTo(AttributeValueType.SS);
+        assertThat(read.value()).isInstanceOf(LinkedHashSet.class)
+                                .containsExactly("a", "b");
+    }
+
+    @Test
+    @DisplayName("A string list with a duplicate is stored as L and rebuilt as an ArrayList")
+    void fromImmutableClass_whenStringListWithDuplicate_preservesOrderAndDuplicateAsArrayList() {
+        TableSchema<StringListModel> schema = TableSchema.fromImmutableClass(StringListModel.class);
+        List<String> input = new ArrayList<>();
+        input.add("a");
+        input.add("b");
+        input.add("a");
+        StringListModel model = StringListModel.builder().id("id-1").value(input).build();
+
+        Map<String, AttributeValue> map = schema.itemToMap(model, true);
+        StringListModel read = schema.mapToItem(map);
+
+        AttributeConverter<?> converter = schema.converterForAttribute("value");
+        assertThat(converter).isInstanceOf(ListAttributeConverter.class);
+        assertThat(converter.attributeValueType()).isEqualTo(AttributeValueType.L);
+        assertThat(read.value()).isInstanceOf(ArrayList.class)
+                                .containsExactly("a", "b", "a");
+    }
+
+    @Test
+    @DisplayName("A string-to-integer map is stored as M and rebuilt as a LinkedHashMap")
+    void fromImmutableClass_whenStringIntegerMap_selectsMapConverterAndRebuildsLinkedHashMap() {
+        TableSchema<StringIntegerMapModel> schema =
+            TableSchema.fromImmutableClass(StringIntegerMapModel.class);
+        Map<String, Integer> input = new LinkedHashMap<>();
+        input.put("a", 1);
+        input.put("b", 2);
+        StringIntegerMapModel model = StringIntegerMapModel.builder().id("id-1").value(input).build();
+
+        Map<String, AttributeValue> map = schema.itemToMap(model, true);
+        StringIntegerMapModel read = schema.mapToItem(map);
+
+        AttributeConverter<?> converter = schema.converterForAttribute("value");
+        assertThat(converter).isInstanceOf(MapAttributeConverter.class);
+        assertThat(converter.attributeValueType()).isEqualTo(AttributeValueType.M);
+        assertThat(read.value()).isEqualTo(input).isInstanceOf(LinkedHashMap.class);
+    }
+
+    @Test
+    @DisplayName("An enum property selects EnumAttributeConverter and round-trips")
+    void fromImmutableClass_whenEnumProperty_selectsEnumConverterAndRoundTrips() {
+        TableSchema<EnumModel> schema = TableSchema.fromImmutableClass(EnumModel.class);
+        EnumModel model = EnumModel.builder().id("id-1").value(TestEnum.OPEN).build();
+
+        Map<String, AttributeValue> map = schema.itemToMap(model, true);
+        EnumModel read = schema.mapToItem(map);
+
+        AttributeConverter<?> converter = schema.converterForAttribute("value");
+        assertThat(converter).isInstanceOf(EnumAttributeConverter.class);
+        assertThat(converter.attributeValueType()).isEqualTo(AttributeValueType.S);
+        assertThat(map.get("value").s()).isEqualTo("OPEN");
+        assertThat(read.value()).isEqualTo(TestEnum.OPEN);
+    }
+
+    @Test
+    @DisplayName("An unconverted HashMap property fails lookup before builder assignment")
+    void fromImmutableClass_whenUnconvertedHashMap_throwsIllegalStateException() {
+        EnhancedType<HashMap<String, Integer>> type = new EnhancedType<HashMap<String, Integer>>() {
+        };
+
+        assertThatThrownBy(() -> TableSchema.fromImmutableClass(HashMapModel.class))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + type);
+    }
+
+    @DynamoDbImmutable(builder = IntegerModel.Builder.class)
+    public static final class IntegerModel {
+        private final String id;
+        private final Integer value;
+
+        private IntegerModel(Builder b) {
+            this.id = b.id;
+            this.value = b.value;
+        }
+
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        @DynamoDbPartitionKey
+        public String id() {
+            return id;
+        }
+
+        public Integer value() {
+            return value;
+        }
+
+        public static final class Builder {
+            private String id;
+            private Integer value;
+
+            public Builder id(String id) {
+                this.id = id;
+                return this;
+            }
+
+            public Builder value(Integer value) {
+                this.value = value;
+                return this;
+            }
+
+            public IntegerModel build() {
+                return new IntegerModel(this);
+            }
+        }
+    }
+
+    @DynamoDbImmutable(builder = StringSetModel.Builder.class)
+    public static final class StringSetModel {
+        private final String id;
+        private final Set<String> value;
+
+        private StringSetModel(Builder b) {
+            this.id = b.id;
+            this.value = b.value;
+        }
+
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        @DynamoDbPartitionKey
+        public String id() {
+            return id;
+        }
+
+        public Set<String> value() {
+            return value;
+        }
+
+        public static final class Builder {
+            private String id;
+            private Set<String> value;
+
+            public Builder id(String id) {
+                this.id = id;
+                return this;
+            }
+
+            public Builder value(Set<String> value) {
+                this.value = value;
+                return this;
+            }
+
+            public StringSetModel build() {
+                return new StringSetModel(this);
+            }
+        }
+    }
+
+    @DynamoDbImmutable(builder = NestedInnerModel.Builder.class)
+    public static final class NestedInnerModel {
+        private final String nestedValue;
+
+        private NestedInnerModel(Builder b) {
+            this.nestedValue = b.nestedValue;
+        }
+
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        public String nestedValue() {
+            return nestedValue;
+        }
+
+        public static final class Builder {
+            private String nestedValue;
+
+            public Builder nestedValue(String nestedValue) {
+                this.nestedValue = nestedValue;
+                return this;
+            }
+
+            public NestedInnerModel build() {
+                return new NestedInnerModel(this);
+            }
+        }
+    }
+
+    @DynamoDbImmutable(builder = NestedOuterModel.Builder.class)
+    public static final class NestedOuterModel {
+        private final String id;
+        private final NestedInnerModel value;
+
+        private NestedOuterModel(Builder b) {
+            this.id = b.id;
+            this.value = b.value;
+        }
+
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        @DynamoDbPartitionKey
+        public String id() {
+            return id;
+        }
+
+        public NestedInnerModel value() {
+            return value;
+        }
+
+        public static final class Builder {
+            private String id;
+            private NestedInnerModel value;
+
+            public Builder id(String id) {
+                this.id = id;
+                return this;
+            }
+
+            public Builder value(NestedInnerModel value) {
+                this.value = value;
+                return this;
+            }
+
+            public NestedOuterModel build() {
+                return new NestedOuterModel(this);
+            }
+        }
+    }
+
+    @DynamoDbImmutable(builder = StringModel.Builder.class)
+    public static final class StringModel {
+        private final String id;
+        private final String value;
+
+        private StringModel(Builder b) {
+            this.id = b.id;
+            this.value = b.value;
+        }
+
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        @DynamoDbPartitionKey
+        public String id() {
+            return id;
+        }
+
+        public String value() {
+            return value;
+        }
+
+        public static final class Builder {
+            private String id;
+            private String value;
+
+            public Builder id(String id) {
+                this.id = id;
+                return this;
+            }
+
+            public Builder value(String value) {
+                this.value = value;
+                return this;
+            }
+
+            public StringModel build() {
+                return new StringModel(this);
+            }
+        }
+    }
+
+    @DynamoDbImmutable(builder = NullReadModel.Builder.class)
+    public static final class NullReadModel {
+        private final String id;
+        private final String value;
+
+        private NullReadModel(Builder b) {
+            this.id = b.id;
+            this.value = b.value;
+        }
+
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        @DynamoDbPartitionKey
+        public String id() {
+            return id;
+        }
+
+        public String value() {
+            return value;
+        }
+
+        public static final class Builder {
+            private static final ThreadLocal<Integer> VALUE_CALLS = ThreadLocal.withInitial(() -> 0);
+            private String id;
+            private String value;
+
+            public Builder id(String id) {
+                this.id = id;
+                return this;
+            }
+
+            public Builder value(String value) {
+                VALUE_CALLS.set(VALUE_CALLS.get() + 1);
+                this.value = value;
+                return this;
+            }
+
+            static int valueCalls() {
+                return VALUE_CALLS.get();
+            }
+
+            static void resetValueCalls() {
+                VALUE_CALLS.remove();
+            }
+
+            public NullReadModel build() {
+                return new NullReadModel(this);
+            }
+        }
+    }
+
+    @DynamoDbImmutable(builder = ObjectModel.Builder.class)
+    public static final class ObjectModel {
+        private final Object value;
+
+        private ObjectModel(Builder b) {
+            this.value = b.value;
+        }
+
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        public Object value() {
+            return value;
+        }
+
+        public static final class Builder {
+            private Object value;
+
+            public Builder value(Object value) {
+                this.value = value;
+                return this;
+            }
+
+            public ObjectModel build() {
+                return new ObjectModel(this);
+            }
+        }
+    }
+
+    @DynamoDbImmutable(builder = UnsupportedModel.Builder.class)
+    public static final class UnsupportedModel {
+        private final UnsupportedType value;
+
+        private UnsupportedModel(Builder b) {
+            this.value = b.value;
+        }
+
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        public UnsupportedType value() {
+            return value;
+        }
+
+        public static final class Builder {
+            private UnsupportedType value;
+
+            public Builder value(UnsupportedType value) {
+                this.value = value;
+                return this;
+            }
+
+            public UnsupportedModel build() {
+                return new UnsupportedModel(this);
+            }
+        }
+    }
+
+    @DynamoDbImmutable(builder = CustomFirstModel.Builder.class, converterProviders = {
+        RecordingCustomProvider.class,
+        DefaultAttributeConverterProvider.class
+    })
+    public static final class CustomFirstModel {
+        private final CustomType value;
+
+        private CustomFirstModel(Builder b) {
+            this.value = b.value;
+        }
+
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        public CustomType value() {
+            return value;
+        }
+
+        public static final class Builder {
+            private CustomType value;
+
+            public Builder value(CustomType value) {
+                this.value = value;
+                return this;
+            }
+
+            public CustomFirstModel build() {
+                return new CustomFirstModel(this);
+            }
+        }
+    }
+
+    @DynamoDbImmutable(builder = NullThenDefaultModel.Builder.class, converterProviders = {
+        ReturningNullProvider.class,
+        DefaultAttributeConverterProvider.class
+    })
+    public static final class NullThenDefaultModel {
+        private final String value;
+
+        private NullThenDefaultModel(Builder b) {
+            this.value = b.value;
+        }
+
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        public String value() {
+            return value;
+        }
+
+        public static final class Builder {
+            private String value;
+
+            public Builder value(String value) {
+                this.value = value;
+                return this;
+            }
+
+            public NullThenDefaultModel build() {
+                return new NullThenDefaultModel(this);
+            }
+        }
+    }
+
+    @DynamoDbImmutable(builder = DefaultThenCustomModel.Builder.class, converterProviders = {
+        DefaultAttributeConverterProvider.class,
+        RecordingCustomProvider.class
+    })
+    public static final class DefaultThenCustomModel {
+        private final CustomType value;
+
+        private DefaultThenCustomModel(Builder b) {
+            this.value = b.value;
+        }
+
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        public CustomType value() {
+            return value;
+        }
+
+        public static final class Builder {
+            private CustomType value;
+
+            public Builder value(CustomType value) {
+                this.value = value;
+                return this;
+            }
+
+            public DefaultThenCustomModel build() {
+                return new DefaultThenCustomModel(this);
+            }
+        }
+    }
+
+    @DynamoDbImmutable(builder = ThrowingThenDefaultModel.Builder.class, converterProviders = {
+        ThrowingProvider.class,
+        DefaultAttributeConverterProvider.class
+    })
+    public static final class ThrowingThenDefaultModel {
+        private final CustomType value;
+
+        private ThrowingThenDefaultModel(Builder b) {
+            this.value = b.value;
+        }
+
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        public CustomType value() {
+            return value;
+        }
+
+        public static final class Builder {
+            private CustomType value;
+
+            public Builder value(CustomType value) {
+                this.value = value;
+                return this;
+            }
+
+            public ThrowingThenDefaultModel build() {
+                return new ThrowingThenDefaultModel(this);
+            }
+        }
+    }
+
+    @DynamoDbImmutable(builder = ObjectProviderModel.Builder.class, converterProviders = {
+        ObjectProvider.class,
+        DefaultAttributeConverterProvider.class
+    })
+    public static final class ObjectProviderModel {
+        private final Object value;
+
+        private ObjectProviderModel(Builder b) {
+            this.value = b.value;
+        }
+
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        @DynamoDbPartitionKey
+        public Object value() {
+            return value;
+        }
+
+        public static final class Builder {
+            private Object value;
+
+            public Builder value(Object value) {
+                this.value = value;
+                return this;
+            }
+
+            public ObjectProviderModel build() {
+                return new ObjectProviderModel(this);
+            }
+        }
+    }
+
+    @DynamoDbImmutable(builder = ConvertedObjectModel.Builder.class, converterProviders = {
+        ObjectProvider.class,
+        DefaultAttributeConverterProvider.class
+    })
+    public static final class ConvertedObjectModel {
+        private final Object value;
+
+        private ConvertedObjectModel(Builder b) {
+            this.value = b.value;
+        }
+
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        @DynamoDbConvertedBy(ObjectStringConverter.class)
+        public Object value() {
+            return value;
+        }
+
+        public static final class Builder {
+            private Object value;
+
+            public Builder value(Object value) {
+                this.value = value;
+                return this;
+            }
+
+            public ConvertedObjectModel build() {
+                return new ConvertedObjectModel(this);
+            }
+        }
+    }
+
+    @DynamoDbImmutable(builder = ConvertedUnsupportedModel.Builder.class)
+    public static final class ConvertedUnsupportedModel {
+        private final UnsupportedType value;
+
+        private ConvertedUnsupportedModel(Builder b) {
+            this.value = b.value;
+        }
+
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        @DynamoDbConvertedBy(UnsupportedStringConverter.class)
+        public UnsupportedType value() {
+            return value;
+        }
+
+        public static final class Builder {
+            private UnsupportedType value;
+
+            public Builder value(UnsupportedType value) {
+                this.value = value;
+                return this;
+            }
+
+            public ConvertedUnsupportedModel build() {
+                return new ConvertedUnsupportedModel(this);
+            }
+        }
+    }
+
+    @DynamoDbImmutable(builder = ConvertedHashSetModel.Builder.class)
+    public static final class ConvertedHashSetModel {
+        private final HashSet<String> value;
+
+        private ConvertedHashSetModel(Builder b) {
+            this.value = b.value;
+        }
+
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        @DynamoDbConvertedBy(HashSetConverter.class)
+        public HashSet<String> value() {
+            return value;
+        }
+
+        public static final class Builder {
+            private HashSet<String> value;
+
+            public Builder value(HashSet<String> value) {
+                this.value = value;
+                return this;
+            }
+
+            public ConvertedHashSetModel build() {
+                return new ConvertedHashSetModel(this);
+            }
+        }
+    }
+
+    @DynamoDbImmutable(builder = EmptyProvidersModel.Builder.class, converterProviders = {})
+    public static final class EmptyProvidersModel {
+        private final String value;
+
+        private EmptyProvidersModel(Builder b) {
+            this.value = b.value;
+        }
+
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        public String value() {
+            return value;
+        }
+
+        public static final class Builder {
+            private String value;
+
+            public Builder value(String value) {
+                this.value = value;
+                return this;
+            }
+
+            public EmptyProvidersModel build() {
+                return new EmptyProvidersModel(this);
+            }
+        }
+    }
+
+    @DynamoDbImmutable(builder = EmptyProvidersConvertedModel.Builder.class, converterProviders = {})
+    public static final class EmptyProvidersConvertedModel {
+        private final String value;
+
+        private EmptyProvidersConvertedModel(Builder b) {
+            this.value = b.value;
+        }
+
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        @DynamoDbConvertedBy(CustomStringConverter.class)
+        public String value() {
+            return value;
+        }
+
+        public static final class Builder {
+            private String value;
+
+            public Builder value(String value) {
+                this.value = value;
+                return this;
+            }
+
+            public EmptyProvidersConvertedModel build() {
+                return new EmptyProvidersConvertedModel(this);
+            }
+        }
+    }
+
+    @DynamoDbImmutable(builder = HashSetModel.Builder.class)
+    public static final class HashSetModel {
+        private final HashSet<String> value;
+
+        private HashSetModel(Builder b) {
+            this.value = b.value;
+        }
+
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        public HashSet<String> value() {
+            return value;
+        }
+
+        public static final class Builder {
+            private HashSet<String> value;
+
+            public Builder value(HashSet<String> value) {
+                this.value = value;
+                return this;
+            }
+
+            public HashSetModel build() {
+                return new HashSetModel(this);
+            }
+        }
+    }
+
+    @DynamoDbImmutable(builder = UnsupportedSetModel.Builder.class, converterProviders = {
+        UnsupportedTypeOnlyProvider.class,
+        DefaultAttributeConverterProvider.class
+    })
+    public static final class UnsupportedSetModel {
+        private final Set<UnsupportedType> value;
+
+        private UnsupportedSetModel(Builder b) {
+            this.value = b.value;
+        }
+
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        public Set<UnsupportedType> value() {
+            return value;
+        }
+
+        public static final class Builder {
+            private Set<UnsupportedType> value;
+
+            public Builder value(Set<UnsupportedType> value) {
+                this.value = value;
+                return this;
+            }
+
+            public UnsupportedSetModel build() {
+                return new UnsupportedSetModel(this);
+            }
+        }
+    }
+
+    @DynamoDbImmutable(builder = StringCollectionModel.Builder.class)
+    public static final class StringCollectionModel {
+        private final Collection<String> value;
+
+        private StringCollectionModel(Builder b) {
+            this.value = b.value;
+        }
+
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        public Collection<String> value() {
+            return value;
+        }
+
+        public static final class Builder {
+            private Collection<String> value;
+
+            public Builder value(Collection<String> value) {
+                this.value = value;
+                return this;
+            }
+
+            public StringCollectionModel build() {
+                return new StringCollectionModel(this);
+            }
+        }
+    }
+
+    @DynamoDbImmutable(builder = StringListModel.Builder.class)
+    public static final class StringListModel {
+        private final String id;
+        private final List<String> value;
+
+        private StringListModel(Builder b) {
+            this.id = b.id;
+            this.value = b.value;
+        }
+
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        @DynamoDbPartitionKey
+        public String id() {
+            return id;
+        }
+
+        public List<String> value() {
+            return value;
+        }
+
+        public static final class Builder {
+            private String id;
+            private List<String> value;
+
+            public Builder id(String id) {
+                this.id = id;
+                return this;
+            }
+
+            public Builder value(List<String> value) {
+                this.value = value;
+                return this;
+            }
+
+            public StringListModel build() {
+                return new StringListModel(this);
+            }
+        }
+    }
+
+    @DynamoDbImmutable(builder = StringIntegerMapModel.Builder.class)
+    public static final class StringIntegerMapModel {
+        private final String id;
+        private final Map<String, Integer> value;
+
+        private StringIntegerMapModel(Builder b) {
+            this.id = b.id;
+            this.value = b.value;
+        }
+
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        @DynamoDbPartitionKey
+        public String id() {
+            return id;
+        }
+
+        public Map<String, Integer> value() {
+            return value;
+        }
+
+        public static final class Builder {
+            private String id;
+            private Map<String, Integer> value;
+
+            public Builder id(String id) {
+                this.id = id;
+                return this;
+            }
+
+            public Builder value(Map<String, Integer> value) {
+                this.value = value;
+                return this;
+            }
+
+            public StringIntegerMapModel build() {
+                return new StringIntegerMapModel(this);
+            }
+        }
+    }
+
+    @DynamoDbImmutable(builder = EnumModel.Builder.class)
+    public static final class EnumModel {
+        private final String id;
+        private final TestEnum value;
+
+        private EnumModel(Builder b) {
+            this.id = b.id;
+            this.value = b.value;
+        }
+
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        @DynamoDbPartitionKey
+        public String id() {
+            return id;
+        }
+
+        public TestEnum value() {
+            return value;
+        }
+
+        public static final class Builder {
+            private String id;
+            private TestEnum value;
+
+            public Builder id(String id) {
+                this.id = id;
+                return this;
+            }
+
+            public Builder value(TestEnum value) {
+                this.value = value;
+                return this;
+            }
+
+            public EnumModel build() {
+                return new EnumModel(this);
+            }
+        }
+    }
+
+    @DynamoDbImmutable(builder = HashMapModel.Builder.class)
+    public static final class HashMapModel {
+        private final HashMap<String, Integer> value;
+
+        private HashMapModel(Builder b) {
+            this.value = b.value;
+        }
+
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        public HashMap<String, Integer> value() {
+            return value;
+        }
+
+        public static final class Builder {
+            private HashMap<String, Integer> value;
+
+            public Builder value(HashMap<String, Integer> value) {
+                this.value = value;
+                return this;
+            }
+
+            public HashMapModel build() {
+                return new HashMapModel(this);
+            }
+        }
+    }
+
+    public enum TestEnum {
+        OPEN,
+        CLOSED
+    }
+
+    public static final class CustomType {
+        private final String value;
+
+        public CustomType(String value) {
+            this.value = value;
+        }
+
+        public String value() {
+            return value;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof CustomType)) {
+                return false;
+            }
+            CustomType that = (CustomType) o;
+            return Objects.equals(value, that.value);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(value);
+        }
+    }
+
+    public static final class UnsupportedType {
+        @Override
+        public boolean equals(Object o) {
+            return o instanceof UnsupportedType;
+        }
+
+        @Override
+        public int hashCode() {
+            return 1;
+        }
+    }
+
+    public static class CustomTypeConverter implements AttributeConverter<CustomType> {
+        public CustomTypeConverter() {
+        }
+
+        @Override
+        public AttributeValue transformFrom(CustomType input) {
+            return AttributeValue.fromS("custom:" + input.value());
+        }
+
+        @Override
+        public CustomType transformTo(AttributeValue input) {
+            String stored = input.s();
+            return new CustomType(stored.substring("custom:".length()));
+        }
+
+        @Override
+        public EnhancedType<CustomType> type() {
+            return EnhancedType.of(CustomType.class);
+        }
+
+        @Override
+        public AttributeValueType attributeValueType() {
+            return AttributeValueType.S;
+        }
+    }
+
+    public static class CustomStringConverter implements AttributeConverter<String> {
+        public CustomStringConverter() {
+        }
+
+        @Override
+        public AttributeValue transformFrom(String input) {
+            return AttributeValue.fromS("custom:" + input);
+        }
+
+        @Override
+        public String transformTo(AttributeValue input) {
+            String stored = input.s();
+            if (stored != null && stored.startsWith("custom:")) {
+                return stored.substring("custom:".length());
+            }
+            return stored;
+        }
+
+        @Override
+        public EnhancedType<String> type() {
+            return EnhancedType.of(String.class);
+        }
+
+        @Override
+        public AttributeValueType attributeValueType() {
+            return AttributeValueType.S;
+        }
+    }
+
+    public static class ObjectStringConverter implements AttributeConverter<Object> {
+        public ObjectStringConverter() {
+        }
+
+        @Override
+        public AttributeValue transformFrom(Object input) {
+            return AttributeValue.fromS("custom");
+        }
+
+        @Override
+        public Object transformTo(AttributeValue input) {
+            return "custom";
+        }
+
+        @Override
+        public EnhancedType<Object> type() {
+            return EnhancedType.of(Object.class);
+        }
+
+        @Override
+        public AttributeValueType attributeValueType() {
+            return AttributeValueType.S;
+        }
+    }
+
+    public static class UnsupportedStringConverter implements AttributeConverter<UnsupportedType> {
+        public UnsupportedStringConverter() {
+        }
+
+        @Override
+        public AttributeValue transformFrom(UnsupportedType input) {
+            return AttributeValue.fromS("custom");
+        }
+
+        @Override
+        public UnsupportedType transformTo(AttributeValue input) {
+            return new UnsupportedType();
+        }
+
+        @Override
+        public EnhancedType<UnsupportedType> type() {
+            return EnhancedType.of(UnsupportedType.class);
+        }
+
+        @Override
+        public AttributeValueType attributeValueType() {
+            return AttributeValueType.S;
+        }
+    }
+
+    public static class HashSetConverter implements AttributeConverter<HashSet<String>> {
+        public HashSetConverter() {
+        }
+
+        @Override
+        public AttributeValue transformFrom(HashSet<String> input) {
+            return AttributeValue.fromSs(new ArrayList<>(input));
+        }
+
+        @Override
+        public HashSet<String> transformTo(AttributeValue input) {
+            return new HashSet<>(input.ss());
+        }
+
+        @Override
+        public EnhancedType<HashSet<String>> type() {
+            return new EnhancedType<HashSet<String>>() {
+            };
+        }
+
+        @Override
+        public AttributeValueType attributeValueType() {
+            return AttributeValueType.SS;
+        }
+    }
+
+    public static class RecordingCustomProvider implements AttributeConverterProvider {
+        private static final ThreadLocal<RecordingCustomProvider> CURRENT =
+            new ThreadLocal<>();
+        private final List<EnhancedType<?>> requestedTypes = new ArrayList<>();
+
+        public RecordingCustomProvider() {
+            CURRENT.set(this);
+        }
+
+        public static RecordingCustomProvider current() {
+            return CURRENT.get();
+        }
+
+        public static void reset() {
+            CURRENT.remove();
+        }
+
+        public List<EnhancedType<?>> requestedTypes() {
+            return requestedTypes;
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> AttributeConverter<T> converterFor(EnhancedType<T> enhancedType) {
+            requestedTypes.add(enhancedType);
+            if (EnhancedType.of(CustomType.class).equals(enhancedType)) {
+                return (AttributeConverter<T>) new CustomTypeConverter();
+            }
+            return null;
+        }
+    }
+
+    public static class ReturningNullProvider implements AttributeConverterProvider {
+        private static final ThreadLocal<ReturningNullProvider> CURRENT =
+            new ThreadLocal<>();
+        private final List<EnhancedType<?>> requestedTypes = new ArrayList<>();
+
+        public ReturningNullProvider() {
+            CURRENT.set(this);
+        }
+
+        public static ReturningNullProvider current() {
+            return CURRENT.get();
+        }
+
+        public static void reset() {
+            CURRENT.remove();
+        }
+
+        public List<EnhancedType<?>> requestedTypes() {
+            return requestedTypes;
+        }
+
+        @Override
+        public <T> AttributeConverter<T> converterFor(EnhancedType<T> enhancedType) {
+            requestedTypes.add(enhancedType);
+            return null;
+        }
+    }
+
+    public static class ThrowingProvider implements AttributeConverterProvider {
+        private static final ThreadLocal<ThrowingProvider> CURRENT = new ThreadLocal<>();
+
+        public ThrowingProvider() {
+            CURRENT.set(this);
+        }
+
+        public static ThrowingProvider current() {
+            return CURRENT.get();
+        }
+
+        public static void reset() {
+            CURRENT.remove();
+        }
+
+        @Override
+        public <T> AttributeConverter<T> converterFor(EnhancedType<T> enhancedType) {
+            throw new IllegalArgumentException("Attribute converter provider failed while looking up " + enhancedType);
+        }
+    }
+
+    public static class ObjectProvider implements AttributeConverterProvider {
+        private static final ThreadLocal<ObjectProvider> CURRENT = new ThreadLocal<>();
+        private final List<EnhancedType<?>> requestedTypes = new ArrayList<>();
+
+        public ObjectProvider() {
+            CURRENT.set(this);
+        }
+
+        public static ObjectProvider current() {
+            return CURRENT.get();
+        }
+
+        public static void reset() {
+            CURRENT.remove();
+        }
+
+        public List<EnhancedType<?>> requestedTypes() {
+            return requestedTypes;
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> AttributeConverter<T> converterFor(EnhancedType<T> enhancedType) {
+            requestedTypes.add(enhancedType);
+            if (EnhancedType.of(Object.class).equals(enhancedType)) {
+                return (AttributeConverter<T>) new ObjectStringConverter();
+            }
+            return null;
+        }
+    }
+
+    public static class UnsupportedTypeOnlyProvider implements AttributeConverterProvider {
+        private static final ThreadLocal<UnsupportedTypeOnlyProvider> CURRENT =
+            new ThreadLocal<>();
+        private final List<EnhancedType<?>> requestedTypes = new ArrayList<>();
+
+        public UnsupportedTypeOnlyProvider() {
+            CURRENT.set(this);
+        }
+
+        public static UnsupportedTypeOnlyProvider current() {
+            return CURRENT.get();
+        }
+
+        public static void reset() {
+            CURRENT.remove();
+        }
+
+        public List<EnhancedType<?>> requestedTypes() {
+            return requestedTypes;
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> AttributeConverter<T> converterFor(EnhancedType<T> enhancedType) {
+            requestedTypes.add(enhancedType);
+            if (EnhancedType.of(UnsupportedType.class).equals(enhancedType)) {
+                return (AttributeConverter<T>) new UnsupportedStringConverter();
+            }
+            return null;
+        }
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/KeyConverterTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/KeyConverterTest.java
@@ -1,0 +1,441 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URL;
+import java.nio.ByteBuffer;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.MonthDay;
+import java.time.OffsetDateTime;
+import java.time.Period;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.OptionalDouble;
+import java.util.OptionalInt;
+import java.util.OptionalLong;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.core.SdkNumber;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+
+/**
+ * Tests conversion of partition and sort key values supplied to a key builder.
+ * <p>
+ * The tests cover supported scalar objects, runtime type selection, primitive optional values, null inputs, and
+ * unsupported application or collection types. They also verify that preconverted attribute values bypass provider
+ * lookup and retain scalar or nonscalar DynamoDB forms accepted by the builder.
+ */
+public class KeyConverterTest {
+
+    @ParameterizedTest(name = "{0} object key stores the converted AttributeValue")
+    @MethodSource("supportedObjectKeys")
+    @DisplayName("Supported built-in object keys convert through addPartitionValue and addSortValue")
+    void addPartitionValue_whenSupportedBuiltInType_storesConvertedPartitionAndSortValues(
+        String typeName, Object input, AttributeValue expected) {
+        Key key = Key.builder().addPartitionValue(input).addSortValue(input).build();
+
+        assertThat(key.partitionKeyValue()).as(typeName).isEqualTo(expected);
+        assertThat(key.sortKeyValue()).as(typeName).contains(expected);
+    }
+
+    @Test
+    @DisplayName("A ByteBuffer runtime subclass is rejected as a partition object key")
+    void addPartitionValue_whenByteBufferRuntimeSubclass_throwsUnsupportedTypeWithIllegalStateCause() {
+        ByteBuffer input = ByteBuffer.wrap(new byte[] {1, 2});
+
+        assertThatThrownBy(() -> Key.builder().addPartitionValue(input))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Unsupported type: " + input.getClass().getName())
+            .hasCauseInstanceOf(IllegalStateException.class)
+            .getCause()
+            .hasMessage("Converter not found for " + EnhancedType.of(input.getClass()));
+    }
+
+    @Test
+    @DisplayName("A CharSequence reference selects conversion by the runtime String class")
+    void addPartitionValue_whenCharSequenceReferringToString_storesSTextOnPartitionAndSort() {
+        CharSequence input = "text";
+
+        Key key = Key.builder().addPartitionValue(input).addSortValue(input).build();
+
+        assertThat(key.partitionKeyValue()).isEqualTo(AttributeValue.fromS("text"));
+        assertThat(key.sortKeyValue()).contains(AttributeValue.fromS("text"));
+    }
+
+    @Test
+    @DisplayName("A ZoneId runtime subclass is rejected as a partition object key")
+    void addPartitionValue_whenZoneIdRuntimeSubclass_throwsUnsupportedTypeWithIllegalStateCause() {
+        ZoneId input = ZoneId.of("Europe/Paris");
+
+        assertThatThrownBy(() -> Key.builder().addPartitionValue(input))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Unsupported type: " + input.getClass().getName())
+            .hasCauseInstanceOf(IllegalStateException.class)
+            .getCause()
+            .hasMessage("Converter not found for " + EnhancedType.of(input.getClass()));
+    }
+
+    @Test
+    @DisplayName("The sort object overload also rejects a ByteBuffer runtime subclass")
+    void addSortValue_whenByteBufferRuntimeSubclass_throwsUnsupportedType() {
+        ByteBuffer input = ByteBuffer.wrap(new byte[] {1, 2});
+
+        assertThatThrownBy(() -> Key.builder().partitionValue("pk").addSortValue(input))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Unsupported type: " + input.getClass().getName())
+            .hasCauseInstanceOf(IllegalStateException.class)
+            .getCause()
+            .hasMessage("Converter not found for " + EnhancedType.of(input.getClass()));
+    }
+
+    @Test
+    @DisplayName("The sort object overload also rejects a ZoneId runtime subclass")
+    void addSortValue_whenZoneIdRuntimeSubclass_throwsUnsupportedType() {
+        ZoneId input = ZoneId.of("Europe/Paris");
+
+        assertThatThrownBy(() -> Key.builder().partitionValue("pk").addSortValue(input))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Unsupported type: " + input.getClass().getName())
+            .hasCauseInstanceOf(IllegalStateException.class)
+            .getCause()
+            .hasMessage("Converter not found for " + EnhancedType.of(input.getClass()));
+    }
+
+    @Test
+    @DisplayName("A custom CharSequence implementation does not inherit the interface registration")
+    void addPartitionValue_whenCustomCharSequence_throwsUnsupportedType() {
+        CustomCharSequence input = new CustomCharSequence("text");
+
+        assertThatThrownBy(() -> Key.builder().addPartitionValue(input))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Unsupported type: " + CustomCharSequence.class.getName());
+    }
+
+    @Test
+    @DisplayName("The sort overload also rejects a custom CharSequence implementation")
+    void addSortValue_whenCustomCharSequence_throwsUnsupportedType() {
+        CustomCharSequence input = new CustomCharSequence("text");
+
+        assertThatThrownBy(() -> Key.builder().partitionValue("pk").addSortValue(input))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Unsupported type: " + CustomCharSequence.class.getName());
+    }
+
+    @Test
+    @DisplayName("An Object partition value is rejected as unsupported")
+    void addPartitionValue_whenObject_throwsUnsupportedType() {
+        assertThatThrownBy(() -> Key.builder().addPartitionValue(new Object()))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Unsupported type: " + Object.class.getName());
+    }
+
+    @Test
+    @DisplayName("An Object sort value is rejected as unsupported")
+    void addSortValue_whenObject_throwsUnsupportedType() {
+        assertThatThrownBy(() -> Key.builder().partitionValue("pk").addSortValue(new Object()))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Unsupported type: " + Object.class.getName());
+    }
+
+    @Test
+    @DisplayName("A List object key is looked up as its concrete runtime class")
+    void addPartitionValue_whenArrayList_throwsUnsupportedTypeForConcreteClass() {
+        ArrayList<String> input = new ArrayList<>();
+
+        assertThatThrownBy(() -> Key.builder().addPartitionValue(input))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Unsupported type: java.util.ArrayList");
+    }
+
+    @Test
+    @DisplayName("A Set object sort key is looked up as its concrete runtime class")
+    void addSortValue_whenHashSet_throwsUnsupportedTypeForConcreteClass() {
+        HashSet<String> input = new HashSet<>();
+
+        assertThatThrownBy(() -> Key.builder().partitionValue("pk").addSortValue(input))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Unsupported type: java.util.HashSet");
+    }
+
+    @Test
+    @DisplayName("A Map object key is looked up as its concrete runtime class")
+    void addPartitionValue_whenHashMap_throwsUnsupportedTypeForConcreteClass() {
+        HashMap<String, Integer> input = new HashMap<>();
+
+        assertThatThrownBy(() -> Key.builder().addPartitionValue(input))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Unsupported type: java.util.HashMap");
+    }
+
+    @Test
+    @DisplayName("An object key cannot attach a document schema")
+    void addPartitionValue_whenDocumentType_throwsUnsupportedType() {
+        DocumentType input = new DocumentType();
+
+        assertThatThrownBy(() -> Key.builder().addPartitionValue(input))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Unsupported type: " + DocumentType.class.getName());
+    }
+
+    @Test
+    @DisplayName("An unsupported application key is wrapped with the provider failure as cause")
+    void addPartitionValue_whenUnsupportedType_throwsUnsupportedTypeWithConverterNotFoundCause() {
+        UnsupportedType input = new UnsupportedType();
+
+        Throwable thrown = catchThrowable(() -> Key.builder().addPartitionValue(input));
+
+        assertThat(thrown).isInstanceOf(IllegalArgumentException.class)
+                          .hasMessage("Unsupported type: " + UnsupportedType.class.getName())
+                          .hasCauseInstanceOf(IllegalStateException.class);
+        assertThat(thrown.getCause())
+            .hasMessage("Converter not found for " + EnhancedType.of(UnsupportedType.class));
+    }
+
+    @Test
+    @DisplayName("An object key ignores an attribute-level-only converter")
+    void addPartitionValue_whenAttributeOnlyKey_throwsUnsupportedType() {
+        AttributeOnlyKey input = new AttributeOnlyKey();
+
+        assertThatThrownBy(() -> Key.builder().addPartitionValue(input))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Unsupported type: " + AttributeOnlyKey.class.getName());
+    }
+
+    @Test
+    @DisplayName("A null object partition value has a dedicated message")
+    void addPartitionValue_whenNull_throwsPartitionKeyValueCannotBeNull() {
+        assertThatThrownBy(() -> Key.builder().addPartitionValue(null))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Partition key value cannot be null");
+    }
+
+    @Test
+    @DisplayName("A null object sort value has a dedicated message")
+    void addSortValue_whenNull_throwsSortKeyValueCannotBeNull() {
+        assertThatThrownBy(() -> Key.builder().partitionValue("pk").addSortValue(null))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Sort key value cannot be null");
+    }
+
+    @Test
+    @DisplayName("A preconverted partition value bypasses provider selection")
+    void partitionValue_whenPreconvertedStringAttributeValue_storesSameSValue() {
+        AttributeValue custom = AttributeValue.fromS("custom");
+
+        Key key = Key.builder().partitionValue(custom).build();
+
+        assertThat(key.partitionKeyValue()).isEqualTo(custom);
+    }
+
+    @Test
+    @DisplayName("A preconverted sort value bypasses provider selection")
+    void sortValue_whenPreconvertedBinaryAttributeValue_storesSameBValue() {
+        AttributeValue custom = AttributeValue.fromB(SdkBytes.fromUtf8String("ab"));
+
+        Key key = Key.builder().partitionValue("pk").sortValue(custom).build();
+
+        assertThat(key.sortKeyValue()).contains(custom);
+    }
+
+    @Test
+    @DisplayName("A preconverted partition overload accepts a non-scalar map")
+    void partitionValue_whenPreconvertedMapAttributeValue_storesMapWithoutScalarValidation() {
+        AttributeValue custom = AttributeValue.fromM(
+            Collections.singletonMap("inner", AttributeValue.fromS("text")));
+
+        Key key = Key.builder().partitionValue(custom).build();
+
+        assertThat(key.partitionKeyValue().hasM()).isTrue();
+    }
+
+    @Test
+    @DisplayName("A preconverted NULL partition value is rejected")
+    void partitionValue_whenNulAttributeValue_throwsPartitionValueShouldNotBeNull() {
+        AttributeValue custom = AttributeValue.fromNul(true);
+
+        assertThatThrownBy(() -> Key.builder().partitionValue(custom))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("partitionValue should not be null");
+    }
+
+    @Test
+    @DisplayName("A preconverted NULL sort value is retained")
+    void sortValue_whenNulAttributeValue_retainsNul() {
+        AttributeValue custom = AttributeValue.fromNul(true);
+
+        Key key = Key.builder().partitionValue("pk").sortValue(custom).build();
+
+        assertThat(key.sortKeyValue()).contains(AttributeValue.fromNul(true));
+    }
+
+    @Test
+    @DisplayName("A null AttributeValue partition overload is rejected")
+    void partitionValue_whenNullAttributeValue_throwsPartitionValueShouldNotBeNull() {
+        assertThatThrownBy(() -> Key.builder().partitionValue((AttributeValue) null))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("partitionValue should not be null");
+    }
+
+    @Test
+    @DisplayName("A null AttributeValue sort overload means no sort value")
+    void sortValue_whenNullAttributeValue_leavesSortKeyEmpty() {
+        Key key = Key.builder().partitionValue("pk").sortValue((AttributeValue) null).build();
+
+        assertThat(key.sortKeyValue()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("An empty primitive optional produces a NULL object key value")
+    void addPartitionValue_whenEmptyOptionalInt_storesNul() {
+        OptionalInt input = OptionalInt.empty();
+
+        Key key = Key.builder().addPartitionValue(input).build();
+
+        assertThat(key.partitionKeyValue()).isEqualTo(AttributeValue.fromNul(true));
+    }
+
+    static Stream<Arguments> supportedObjectKeys() {
+        byte[] bytes = new byte[] {1, 2};
+        SdkBytes sdkBytes = SdkBytes.fromUtf8String("ab");
+        TestEnum enumConstant = TestEnum.OPEN;
+        Instant instant = Instant.parse("2020-01-02T03:04:05Z");
+        OffsetDateTime offsetDateTime = OffsetDateTime.parse("2020-01-02T03:04:05+02:00");
+        ZonedDateTime zonedDateTime = ZonedDateTime.parse("2020-01-02T03:04:05+01:00[Europe/Paris]");
+
+        return Stream.of(
+            Arguments.of("AtomicBoolean", new AtomicBoolean(true), AttributeValue.fromBool(true)),
+            Arguments.of("AtomicInteger", new AtomicInteger(7), AttributeValue.fromN("7")),
+            Arguments.of("AtomicLong", new AtomicLong(7L), AttributeValue.fromN("7")),
+            Arguments.of("BigDecimal", new BigDecimal("1.25"), AttributeValue.fromN("1.25")),
+            Arguments.of("BigInteger", new BigInteger("12345678901234567890"),
+                         AttributeValue.fromN("12345678901234567890")),
+            Arguments.of("Boolean", Boolean.TRUE, AttributeValue.fromBool(true)),
+            Arguments.of("byte[]", bytes, AttributeValue.fromB(SdkBytes.fromByteArray(bytes))),
+            Arguments.of("Byte", Byte.valueOf((byte) 7), AttributeValue.fromN("7")),
+            Arguments.of("char[]", new char[] {'a', 'b'}, AttributeValue.fromS("ab")),
+            Arguments.of("Character", Character.valueOf('x'), AttributeValue.fromS("x")),
+            Arguments.of("Double", Double.valueOf(1.5d), AttributeValue.fromN("1.5")),
+            Arguments.of("Duration", Duration.ofSeconds(90), AttributeValue.fromN("90")),
+            Arguments.of("Float", Float.valueOf(1.5f), AttributeValue.fromN("1.5")),
+            Arguments.of("Instant", instant, AttributeValue.fromS("2020-01-02T03:04:05Z")),
+            Arguments.of("Integer", Integer.valueOf(7), AttributeValue.fromN("7")),
+            Arguments.of("LocalDate", LocalDate.parse("2020-01-02"), AttributeValue.fromS("2020-01-02")),
+            Arguments.of("LocalDateTime", LocalDateTime.parse("2020-01-02T03:04:05"),
+                         AttributeValue.fromS("2020-01-02T03:04:05")),
+            Arguments.of("Locale", Locale.forLanguageTag("en-US"), AttributeValue.fromS("en-US")),
+            Arguments.of("LocalTime", LocalTime.parse("03:04:05"), AttributeValue.fromS("03:04:05")),
+            Arguments.of("Long", Long.valueOf(7L), AttributeValue.fromN("7")),
+            Arguments.of("MonthDay", MonthDay.of(1, 2), AttributeValue.fromS("--01-02")),
+            Arguments.of("OffsetDateTime", offsetDateTime, AttributeValue.fromS("2020-01-02T03:04:05+02:00")),
+            Arguments.of("OptionalDouble", OptionalDouble.of(1.5d), AttributeValue.fromN("1.5")),
+            Arguments.of("OptionalInt", OptionalInt.of(7), AttributeValue.fromN("7")),
+            Arguments.of("OptionalLong", OptionalLong.of(7L), AttributeValue.fromN("7")),
+            Arguments.of("Period", Period.of(1, 2, 3), AttributeValue.fromS("P1Y2M3D")),
+            Arguments.of("SdkBytes", sdkBytes, AttributeValue.fromB(sdkBytes)),
+            Arguments.of("Short", Short.valueOf((short) 7), AttributeValue.fromN("7")),
+            Arguments.of("String", "text", AttributeValue.fromS("text")),
+            Arguments.of("StringBuffer", new StringBuffer("text"), AttributeValue.fromS("text")),
+            Arguments.of("StringBuilder", new StringBuilder("text"), AttributeValue.fromS("text")),
+            Arguments.of("URI", URI.create("https://example.com/a"),
+                         AttributeValue.fromS("https://example.com/a")),
+            Arguments.of("URL", url("https://example.com/a"), AttributeValue.fromS("https://example.com/a")),
+            Arguments.of("UUID", UUID.fromString("123e4567-e89b-12d3-a456-426614174000"),
+                         AttributeValue.fromS("123e4567-e89b-12d3-a456-426614174000")),
+            Arguments.of("ZonedDateTime", zonedDateTime,
+                         AttributeValue.fromS("2020-01-02T03:04:05+01:00[Europe/Paris]")),
+            Arguments.of("ZoneOffset", ZoneOffset.ofHours(2), AttributeValue.fromS("+02:00")),
+            Arguments.of("SdkNumber", SdkNumber.fromString("1.25"), AttributeValue.fromN("1.25")),
+            Arguments.of("TestEnum", enumConstant, AttributeValue.fromS(enumConstant.toString()))
+        );
+    }
+
+    private static URL url(String value) {
+        try {
+            return new URL(value);
+        } catch (MalformedURLException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    enum TestEnum {
+        OPEN,
+        CLOSED
+    }
+
+    static final class CustomCharSequence implements CharSequence {
+        private final String value;
+
+        CustomCharSequence(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public int length() {
+            return value.length();
+        }
+
+        @Override
+        public char charAt(int index) {
+            return value.charAt(index);
+        }
+
+        @Override
+        public CharSequence subSequence(int start, int end) {
+            return value.subSequence(start, end);
+        }
+
+        @Override
+        public String toString() {
+            return value;
+        }
+    }
+
+    static final class DocumentType {
+    }
+
+    static final class UnsupportedType {
+    }
+
+    static final class AttributeOnlyKey {
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/NestedSchemaConverterTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/NestedSchemaConverterTest.java
@@ -1,0 +1,1497 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static software.amazon.awssdk.enhanced.dynamodb.mapper.StaticAttributeTags.primaryPartitionKey;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.ListAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.MapAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.SetAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.StringAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.BeanTableSchema;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.ImmutableTableSchema;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.StaticTableSchema;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbFlatten;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbImmutable;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+
+/**
+ * Tests converter resolution and item conversion for nested and flattened schema attributes.
+ * <p>
+ * The tests combine bean, immutable, and static schemas with nested collections and null child values. They verify
+ * converter provider ownership, failure during child schema construction, flattened child conversion, and flattened
+ * string maps that do not require converter provider lookup.
+ */
+public class NestedSchemaConverterTest {
+
+    @BeforeEach
+    void clearSchemaCaches() {
+        invokeClearSchemaCache(BeanTableSchema.class);
+        invokeClearSchemaCache(ImmutableTableSchema.class);
+        NestedNullBeanOuter.childSetterCalls.set(0);
+        NestedBeanOuterWithNullImmutable.childSetterCalls.set(0);
+        NestedImmutableOuterWithNullBean.Builder.childSetterCalls.set(0);
+        RecordingCustomProvider.reset();
+        RecordingRequestedTypesProvider.reset();
+    }
+
+    @Test
+    @DisplayName("Nested bean list of unsupported type reports the missing member converter")
+    void fromBean_whenNestedBeanWithUnsupportedList_throwsConverterNotFoundForMemberType() {
+
+        assertThatThrownBy(() -> TableSchema.fromBean(OuterBeanWithUnsupportedList.class))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + EnhancedType.of(UnsupportedType.class));
+    }
+
+    @Test
+    @DisplayName("Nested immutable list of Object fails converter lookup for its member type")
+    void fromImmutableClass_whenNestedImmutableWithObjectList_throwsConverterNotFoundForMemberType() {
+        assertThatThrownBy(() -> TableSchema.fromImmutableClass(OuterImmutableWithObjectList.class))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + EnhancedType.of(Object.class));
+    }
+
+    @Test
+    @DisplayName("Bean containing a nonnull bean round-trips nested collections")
+    void itemToMapThenMapToItem_whenBeanContainingNonnullBean_roundTripsNestedCollections() {
+        NestedBeanChild child = populatedChildBean("child-1", 7, "nested", "clicked");
+        NestedBeanOuter item = populatedOuterBean("id-1", 3, "root", "opened", child);
+
+        TableSchema<NestedBeanOuter> schema = TableSchema.fromBean(NestedBeanOuter.class);
+        Map<String, AttributeValue> map = schema.itemToMap(item, true);
+        NestedBeanOuter read = schema.mapToItem(map);
+
+        assertThat(map.get("child").hasM()).isTrue();
+        assertCollectionAttributeTypes(map);
+        assertCollectionAttributeTypes(map.get("child").m());
+        assertThat(read).isEqualTo(item);
+        assertReconstructedCollections(read.getCounters(), read.getLabels(), read.getEvents(),
+                                       item.getCounters(), item.getLabels(), item.getEvents());
+        assertReconstructedCollections(read.getChild().getCounters(), read.getChild().getLabels(),
+                                       read.getChild().getEvents(), child.getCounters(), child.getLabels(),
+                                       child.getEvents());
+    }
+
+    @Test
+    @DisplayName("Bean containing a nonnull immutable round-trips nested collections")
+    void itemToMapThenMapToItem_whenBeanContainingNonnullImmutable_roundTripsNestedCollections() {
+        NestedImmutableChild child = populatedImmutableChild("child-1", 7, "nested", "clicked");
+        NestedBeanOuterWithImmutable item = new NestedBeanOuterWithImmutable();
+        item.setId("id-1");
+        item.setCounters(counters(3));
+        item.setLabels(labels("root"));
+        item.setEvents(events("opened"));
+        item.setChild(child);
+
+        TableSchema<NestedBeanOuterWithImmutable> schema = TableSchema.fromBean(NestedBeanOuterWithImmutable.class);
+        TableSchema.fromImmutableClass(NestedImmutableChild.class);
+        Map<String, AttributeValue> map = schema.itemToMap(item, true);
+        NestedBeanOuterWithImmutable read = schema.mapToItem(map);
+
+        assertThat(map.get("child").hasM()).isTrue();
+        assertCollectionAttributeTypes(map.get("child").m());
+        assertReconstructedCollections(read.getChild().counters(), read.getChild().labels(),
+                                       read.getChild().events(), child.counters(), child.labels(),
+                                       child.events());
+    }
+
+    @Test
+    @DisplayName("Immutable containing a nonnull bean round-trips nested collections")
+    void itemToMapThenMapToItem_whenImmutableContainingNonnullBean_roundTripsNestedCollections() {
+        NestedBeanChildForImmutable child = populatedChildForImmutable("child-1", 7, "nested", "clicked");
+        NestedImmutableOuter item = NestedImmutableOuter.builder()
+            .id("id-1")
+            .counters(counters(3))
+            .labels(labels("root"))
+            .events(events("opened"))
+            .child(child)
+            .build();
+
+        TableSchema<NestedImmutableOuter> schema = TableSchema.fromImmutableClass(NestedImmutableOuter.class);
+        TableSchema.fromBean(NestedBeanChildForImmutable.class);
+        Map<String, AttributeValue> map = schema.itemToMap(item, true);
+        NestedImmutableOuter read = schema.mapToItem(map);
+
+        assertThat(map.get("child").hasM()).isTrue();
+        assertCollectionAttributeTypes(map.get("child").m());
+        assertReconstructedCollections(read.child().getCounters(), read.child().getLabels(),
+                                       read.child().getEvents(), child.getCounters(), child.getLabels(),
+                                       child.getEvents());
+    }
+
+    @Test
+    @DisplayName("Bean containing a null bean writes NULL and skips the child setter")
+    void itemToMapThenMapToItem_whenBeanContainingNullBean_writesNulAndSkipsChildSetter() {
+        NestedNullBeanOuter item = new NestedNullBeanOuter();
+        item.setId("id-1");
+        item.setCounters(counters(3));
+        item.setLabels(labels("root"));
+        item.setEvents(events("opened"));
+        NestedNullBeanOuter.childSetterCalls.set(0);
+
+        TableSchema<NestedNullBeanOuter> schema = TableSchema.fromBean(NestedNullBeanOuter.class);
+        Map<String, AttributeValue> map = schema.itemToMap(item, false);
+        NestedNullBeanOuter read = schema.mapToItem(map);
+
+        assertThat(map.get("child")).isEqualTo(AttributeValue.fromNul(true));
+        assertCollectionAttributeTypes(map);
+        assertThat(NestedNullBeanOuter.childSetterCalls.get()).isZero();
+        assertThat(read.getChild()).isNull();
+        assertReconstructedCollections(read.getCounters(), read.getLabels(), read.getEvents(),
+                                       item.getCounters(), item.getLabels(), item.getEvents());
+    }
+
+    @Test
+    @DisplayName("Bean containing a null immutable writes NULL and leaves the child null")
+    void itemToMapThenMapToItem_whenBeanContainingNullImmutable_writesNulAndLeavesChildNull() {
+        NestedBeanOuterWithNullImmutable item = new NestedBeanOuterWithNullImmutable();
+        item.setId("id-1");
+        item.setCounters(counters(3));
+        item.setLabels(labels("root"));
+        item.setEvents(events("opened"));
+        NestedBeanOuterWithNullImmutable.childSetterCalls.set(0);
+
+        TableSchema<NestedBeanOuterWithNullImmutable> schema = TableSchema.fromBean(NestedBeanOuterWithNullImmutable.class);
+        TableSchema.fromImmutableClass(NestedNullImmutableChild.class);
+        Map<String, AttributeValue> map = schema.itemToMap(item, false);
+        NestedBeanOuterWithNullImmutable read = schema.mapToItem(map);
+
+        assertThat(map.get("child")).isEqualTo(AttributeValue.fromNul(true));
+        assertThat(NestedBeanOuterWithNullImmutable.childSetterCalls.get()).isZero();
+        assertThat(read.getChild()).isNull();
+        assertReconstructedCollections(read.getCounters(), read.getLabels(), read.getEvents(),
+                                       item.getCounters(), item.getLabels(), item.getEvents());
+    }
+
+    @Test
+    @DisplayName("Immutable containing a null bean writes NULL and skips the child builder method")
+    void itemToMapThenMapToItem_whenImmutableContainingNullBean_writesNulAndSkipsChildBuilder() {
+        NestedImmutableOuterWithNullBean item = NestedImmutableOuterWithNullBean.builder()
+            .id("id-1")
+            .counters(counters(3))
+            .labels(labels("root"))
+            .events(events("opened"))
+            .build();
+        NestedImmutableOuterWithNullBean.Builder.childSetterCalls.set(0);
+
+        TableSchema<NestedImmutableOuterWithNullBean> schema =
+            TableSchema.fromImmutableClass(NestedImmutableOuterWithNullBean.class);
+        TableSchema.fromBean(NestedBeanChildForNullImmutable.class);
+        Map<String, AttributeValue> map = schema.itemToMap(item, false);
+        NestedImmutableOuterWithNullBean read = schema.mapToItem(map);
+
+        assertThat(map.get("child")).isEqualTo(AttributeValue.fromNul(true));
+        assertThat(NestedImmutableOuterWithNullBean.Builder.childSetterCalls.get()).isZero();
+        assertThat(read.child()).isNull();
+        assertReconstructedCollections(read.counters(), read.labels(), read.events(),
+                                       item.counters(), item.labels(), item.events());
+    }
+
+    @Test
+    @DisplayName("Flattened bean child attributes use the child's default converters")
+    void itemToMapThenMapToItem_whenFlattenedBeanChild_usesChildCollectionConverters() {
+        FlattenedChildBean child = new FlattenedChildBean();
+        child.setCounters(counters(3));
+        child.setLabels(labels("root"));
+        child.setEvents(events("opened"));
+        OuterFlattenedBean item = new OuterFlattenedBean();
+        item.setId("id-1");
+        item.setChild(child);
+
+        TableSchema<OuterFlattenedBean> schema = TableSchema.fromBean(OuterFlattenedBean.class);
+        Map<String, AttributeValue> map = schema.itemToMap(item, true);
+        OuterFlattenedBean read = schema.mapToItem(map);
+
+        assertThat(schema.converterForAttribute("child")).isNull();
+        assertThat(schema.converterForAttribute("counters")).isInstanceOf(MapAttributeConverter.class);
+        assertThat(schema.converterForAttribute("counters").attributeValueType()).isEqualTo(AttributeValueType.M);
+        assertThat(schema.converterForAttribute("labels")).isInstanceOf(SetAttributeConverter.class);
+        assertThat(schema.converterForAttribute("labels").attributeValueType()).isEqualTo(AttributeValueType.SS);
+        assertThat(schema.converterForAttribute("events")).isInstanceOf(ListAttributeConverter.class);
+        assertThat(schema.converterForAttribute("events").attributeValueType()).isEqualTo(AttributeValueType.L);
+        assertThat(map.get("counters").hasM()).isTrue();
+        assertThat(map.get("labels").hasSs()).isTrue();
+        assertThat(map.get("events").hasL()).isTrue();
+        assertThat(read.getChild().getCounters()).isEqualTo(child.getCounters()).isInstanceOf(LinkedHashMap.class);
+        assertThat(read.getChild().getLabels()).isEqualTo(child.getLabels()).isInstanceOf(LinkedHashSet.class);
+        assertThat(read.getChild().getEvents()).isEqualTo(child.getEvents()).isInstanceOf(ArrayList.class);
+    }
+
+    @Test
+    @DisplayName("Flattened bean construction fails when the child converter lookup fails")
+    void fromBean_whenFlattenedBeanChildWithUnsupportedType_throwsConverterNotFound() {
+        EnhancedType<UnsupportedType> type = EnhancedType.of(UnsupportedType.class);
+
+        assertThatThrownBy(() -> TableSchema.fromBean(OuterFlattenedUnsupportedBean.class))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + type);
+    }
+
+    @Test
+    @DisplayName("Flattened bean child uses the child's custom provider")
+    void itemToMapThenMapToItem_whenFlattenedBeanChildCustomProvider_selectsCustomTypeConverter() {
+        EnhancedType<CustomType> type = EnhancedType.of(CustomType.class);
+        FlattenedCustomChild child = new FlattenedCustomChild();
+        child.setValue(new CustomType("x"));
+        OuterFlattenedCustomBean item = new OuterFlattenedCustomBean();
+        item.setId("id-1");
+        item.setChild(child);
+
+        TableSchema<OuterFlattenedCustomBean> schema = TableSchema.fromBean(OuterFlattenedCustomBean.class);
+        Map<String, AttributeValue> map = schema.itemToMap(item, true);
+        OuterFlattenedCustomBean read = schema.mapToItem(map);
+
+        assertThat(RecordingCustomProvider.current().requestedTypes()).contains(type);
+        assertThat(schema.converterForAttribute("value")).isInstanceOf(CustomTypeConverter.class);
+        assertThat(schema.converterForAttribute("value").attributeValueType()).isEqualTo(AttributeValueType.S);
+        assertThat(map.get("value").s()).isEqualTo("custom:x");
+        assertThat(read.getChild().getValue()).isEqualTo(child.getValue());
+    }
+
+    @Test
+    @DisplayName("Flattened string map does not consult a converter provider")
+    void itemToMapThenMapToItem_whenFlattenedStringMap_doesNotConsultProviderForMapType() {
+        EnhancedType<Map<String, String>> type = EnhancedType.mapOf(String.class, String.class);
+        Map<String, String> attributes = new LinkedHashMap<>();
+        attributes.put("attr1", "value1");
+        FlattenMapBean item = new FlattenMapBean();
+        item.setId("id-1");
+        item.setAttributes(attributes);
+
+        TableSchema<FlattenMapBean> schema = TableSchema.fromBean(FlattenMapBean.class);
+        Map<String, AttributeValue> map = schema.itemToMap(item, true);
+        FlattenMapBean read = schema.mapToItem(map);
+
+        assertThat(RecordingRequestedTypesProvider.current().requestedTypes()).doesNotContain(type);
+        assertThat(schema.converterForAttribute("attr1")).isNull();
+        assertThat(map.get("attr1").s()).isEqualTo("value1");
+        assertThat(map.get("attr1").hasM()).isFalse();
+        assertThat(read.getAttributes()).isEqualTo(attributes);
+    }
+
+    @Test
+    @DisplayName("Static flattened string map does not consult a converter provider")
+    void itemToMapThenMapToItem_whenStaticFlattenedStringMap_doesNotConsultProviderForMapType() {
+        EnhancedType<Map<String, String>> type = EnhancedType.mapOf(String.class, String.class);
+        Map<String, String> attributes = new LinkedHashMap<>();
+        attributes.put("attr1", "value1");
+        FlattenMapItem item = new FlattenMapItem();
+        item.setId("id-1");
+        item.setAttributes(attributes);
+        RecordingRequestedTypesProvider provider = new RecordingRequestedTypesProvider();
+
+        StaticTableSchema<FlattenMapItem> schema = StaticTableSchema.builder(FlattenMapItem.class)
+            .newItemSupplier(FlattenMapItem::new)
+            .attributeConverterProviders(provider, DefaultAttributeConverterProvider.create())
+            .addAttribute(EnhancedType.of(String.class), a -> a.name("id")
+                .getter(FlattenMapItem::getId).setter(FlattenMapItem::setId).tags(primaryPartitionKey())
+                .attributeConverter(new StringAttributeConverter()))
+            .flatten("attributes", FlattenMapItem::getAttributes, FlattenMapItem::setAttributes)
+            .build();
+
+        Map<String, AttributeValue> map = schema.itemToMap(item, true);
+        FlattenMapItem read = schema.mapToItem(map);
+
+        assertThat(provider.requestedTypes()).doesNotContain(type);
+        assertThat(schema.converterForAttribute("attr1")).isNull();
+        assertThat(map.get("attr1").s()).isEqualTo("value1");
+        assertThat(read.getAttributes()).isEqualTo(attributes);
+    }
+
+    @Test
+    @DisplayName("Static flattened child schema uses the supplied schema converters")
+    void itemToMapThenMapToItem_whenStaticFlattenedChildSchema_usesChildCollectionConverters() {
+        FlattenedChildItem child = new FlattenedChildItem();
+        child.setCounters(counters(3));
+        child.setLabels(labels("root"));
+        child.setEvents(events("opened"));
+        FlattenedOuterItem item = new FlattenedOuterItem();
+        item.setId("id-1");
+        item.setChild(child);
+
+        StaticTableSchema<FlattenedChildItem> childSchema = StaticTableSchema.builder(FlattenedChildItem.class)
+            .newItemSupplier(FlattenedChildItem::new)
+            .addAttribute(EnhancedType.mapOf(String.class, Integer.class), a -> a.name("counters")
+                .getter(FlattenedChildItem::getCounters).setter(FlattenedChildItem::setCounters))
+            .addAttribute(EnhancedType.setOf(String.class), a -> a.name("labels")
+                .getter(FlattenedChildItem::getLabels).setter(FlattenedChildItem::setLabels))
+            .addAttribute(EnhancedType.listOf(String.class), a -> a.name("events")
+                .getter(FlattenedChildItem::getEvents).setter(FlattenedChildItem::setEvents))
+            .build();
+
+        StaticTableSchema<FlattenedOuterItem> schema = StaticTableSchema.builder(FlattenedOuterItem.class)
+            .newItemSupplier(FlattenedOuterItem::new)
+            .addAttribute(EnhancedType.of(String.class), a -> a.name("id")
+                .getter(FlattenedOuterItem::getId).setter(FlattenedOuterItem::setId).tags(primaryPartitionKey()))
+            .flatten(childSchema, FlattenedOuterItem::getChild, FlattenedOuterItem::setChild)
+            .build();
+
+        Map<String, AttributeValue> map = schema.itemToMap(item, true);
+        FlattenedOuterItem read = schema.mapToItem(map);
+
+        assertThat(schema.converterForAttribute("counters")).isInstanceOf(MapAttributeConverter.class);
+        assertThat(schema.converterForAttribute("counters").attributeValueType()).isEqualTo(AttributeValueType.M);
+        assertThat(schema.converterForAttribute("labels")).isInstanceOf(SetAttributeConverter.class);
+        assertThat(schema.converterForAttribute("labels").attributeValueType()).isEqualTo(AttributeValueType.SS);
+        assertThat(schema.converterForAttribute("events")).isInstanceOf(ListAttributeConverter.class);
+        assertThat(schema.converterForAttribute("events").attributeValueType()).isEqualTo(AttributeValueType.L);
+        assertThat(map.get("counters").hasM()).isTrue();
+        assertThat(map.get("labels").hasSs()).isTrue();
+        assertThat(map.get("events").hasL()).isTrue();
+        assertThat(read.getChild().getCounters()).isEqualTo(child.getCounters()).isInstanceOf(LinkedHashMap.class);
+        assertThat(read.getChild().getLabels()).isEqualTo(child.getLabels()).isInstanceOf(LinkedHashSet.class);
+        assertThat(read.getChild().getEvents()).isEqualTo(child.getEvents()).isInstanceOf(ArrayList.class);
+    }
+
+    private static void invokeClearSchemaCache(Class<?> schemaClass) {
+        try {
+            Method method = schemaClass.getDeclaredMethod("clearSchemaCache");
+            method.setAccessible(true);
+            method.invoke(null);
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private static Map<String, Integer> counters(int value) {
+        Map<String, Integer> counters = new LinkedHashMap<>();
+        counters.put("count", value);
+        return counters;
+    }
+
+    private static Set<String> labels(String label) {
+        Set<String> labels = new LinkedHashSet<>();
+        labels.add(label);
+        return labels;
+    }
+
+    private static List<String> events(String event) {
+        List<String> events = new ArrayList<>();
+        events.add(event);
+        return events;
+    }
+
+    private static void assertCollectionAttributeTypes(Map<String, AttributeValue> map) {
+        assertThat(map.get("counters").hasM()).isTrue();
+        assertThat(map.get("labels").hasSs()).isTrue();
+        assertThat(map.get("events").hasL()).isTrue();
+    }
+
+    private static void assertReconstructedCollections(Map<String, Integer> counters, Set<String> labels,
+                                                       List<String> events, Map<String, Integer> expectedCounters,
+                                                       Set<String> expectedLabels, List<String> expectedEvents) {
+        assertThat(counters).isEqualTo(expectedCounters).isInstanceOf(LinkedHashMap.class);
+        assertThat(labels).isEqualTo(expectedLabels).isInstanceOf(LinkedHashSet.class);
+        assertThat(events).isEqualTo(expectedEvents).isInstanceOf(ArrayList.class);
+    }
+
+    private static NestedBeanChild populatedChildBean(String id, int count, String label, String event) {
+        NestedBeanChild child = new NestedBeanChild();
+        child.setId(id);
+        child.setCounters(counters(count));
+        child.setLabels(labels(label));
+        child.setEvents(events(event));
+        return child;
+    }
+
+    private static NestedBeanOuter populatedOuterBean(String id, int count, String label, String event,
+                                                  NestedBeanChild child) {
+        NestedBeanOuter item = new NestedBeanOuter();
+        item.setId(id);
+        item.setCounters(counters(count));
+        item.setLabels(labels(label));
+        item.setEvents(events(event));
+        item.setChild(child);
+        return item;
+    }
+
+    private static NestedImmutableChild populatedImmutableChild(String id, int count, String label, String event) {
+        return NestedImmutableChild.builder()
+            .id(id)
+            .counters(counters(count))
+            .labels(labels(label))
+            .events(events(event))
+            .build();
+    }
+
+    private static NestedBeanChildForImmutable populatedChildForImmutable(String id, int count, String label,
+                                                                      String event) {
+        NestedBeanChildForImmutable child = new NestedBeanChildForImmutable();
+        child.setId(id);
+        child.setCounters(counters(count));
+        child.setLabels(labels(label));
+        child.setEvents(events(event));
+        return child;
+    }
+
+    @DynamoDbBean
+    public static class OuterBeanWithUnsupportedList {
+        private NestedBeanWithUnsupportedList child;
+
+        public NestedBeanWithUnsupportedList getChild() {
+            return child;
+        }
+
+        public void setChild(NestedBeanWithUnsupportedList child) {
+            this.child = child;
+        }
+    }
+
+    @DynamoDbBean
+    public static class NestedBeanWithUnsupportedList {
+        private List<UnsupportedType> value;
+
+        public List<UnsupportedType> getValue() {
+            return value;
+        }
+
+        public void setValue(List<UnsupportedType> value) {
+            this.value = value;
+        }
+    }
+
+    @DynamoDbImmutable(builder = OuterImmutableWithObjectList.Builder.class)
+    public static final class OuterImmutableWithObjectList {
+        private final NestedImmutableWithObjectList child;
+
+        private OuterImmutableWithObjectList(Builder b) {
+            this.child = b.child;
+        }
+
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        public NestedImmutableWithObjectList child() {
+            return child;
+        }
+
+        public static final class Builder {
+            private NestedImmutableWithObjectList child;
+
+            public Builder child(NestedImmutableWithObjectList child) {
+                this.child = child;
+                return this;
+            }
+
+            public OuterImmutableWithObjectList build() {
+                return new OuterImmutableWithObjectList(this);
+            }
+        }
+    }
+
+    @DynamoDbImmutable(builder = NestedImmutableWithObjectList.Builder.class)
+    public static final class NestedImmutableWithObjectList {
+        private final List<Object> value;
+
+        private NestedImmutableWithObjectList(Builder b) {
+            this.value = b.value;
+        }
+
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        public List<Object> value() {
+            return value;
+        }
+
+        public static final class Builder {
+            private List<Object> value;
+
+            public Builder value(List<Object> value) {
+                this.value = value;
+                return this;
+            }
+
+            public NestedImmutableWithObjectList build() {
+                return new NestedImmutableWithObjectList(this);
+            }
+        }
+    }
+
+    @DynamoDbBean
+    public static class NestedBeanChild {
+        private String id;
+        private Map<String, Integer> counters;
+        private Set<String> labels;
+        private List<String> events;
+
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        public Map<String, Integer> getCounters() {
+            return counters;
+        }
+
+        public void setCounters(Map<String, Integer> counters) {
+            this.counters = counters;
+        }
+
+        public Set<String> getLabels() {
+            return labels;
+        }
+
+        public void setLabels(Set<String> labels) {
+            this.labels = labels;
+        }
+
+        public List<String> getEvents() {
+            return events;
+        }
+
+        public void setEvents(List<String> events) {
+            this.events = events;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof NestedBeanChild)) {
+                return false;
+            }
+            NestedBeanChild that = (NestedBeanChild) o;
+            return Objects.equals(id, that.id)
+                   && Objects.equals(counters, that.counters)
+                   && Objects.equals(labels, that.labels)
+                   && Objects.equals(events, that.events);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(id, counters, labels, events);
+        }
+    }
+
+    @DynamoDbBean
+    public static class NestedBeanOuter {
+        private String id;
+        private Map<String, Integer> counters;
+        private Set<String> labels;
+        private List<String> events;
+        private NestedBeanChild child;
+
+        @DynamoDbPartitionKey
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        public Map<String, Integer> getCounters() {
+            return counters;
+        }
+
+        public void setCounters(Map<String, Integer> counters) {
+            this.counters = counters;
+        }
+
+        public Set<String> getLabels() {
+            return labels;
+        }
+
+        public void setLabels(Set<String> labels) {
+            this.labels = labels;
+        }
+
+        public List<String> getEvents() {
+            return events;
+        }
+
+        public void setEvents(List<String> events) {
+            this.events = events;
+        }
+
+        public NestedBeanChild getChild() {
+            return child;
+        }
+
+        public void setChild(NestedBeanChild child) {
+            this.child = child;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof NestedBeanOuter)) {
+                return false;
+            }
+            NestedBeanOuter that = (NestedBeanOuter) o;
+            return Objects.equals(id, that.id)
+                   && Objects.equals(counters, that.counters)
+                   && Objects.equals(labels, that.labels)
+                   && Objects.equals(events, that.events)
+                   && Objects.equals(child, that.child);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(id, counters, labels, events, child);
+        }
+    }
+
+    @DynamoDbImmutable(builder = NestedImmutableChild.Builder.class)
+    public static final class NestedImmutableChild {
+        private final String id;
+        private final Map<String, Integer> counters;
+        private final Set<String> labels;
+        private final List<String> events;
+
+        private NestedImmutableChild(Builder b) {
+            this.id = b.id;
+            this.counters = b.counters;
+            this.labels = b.labels;
+            this.events = b.events;
+        }
+
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        public String id() {
+            return id;
+        }
+
+        public Map<String, Integer> counters() {
+            return counters;
+        }
+
+        public Set<String> labels() {
+            return labels;
+        }
+
+        public List<String> events() {
+            return events;
+        }
+
+        public static final class Builder {
+            private String id;
+            private Map<String, Integer> counters;
+            private Set<String> labels;
+            private List<String> events;
+
+            public Builder id(String id) {
+                this.id = id;
+                return this;
+            }
+
+            public Builder counters(Map<String, Integer> counters) {
+                this.counters = counters;
+                return this;
+            }
+
+            public Builder labels(Set<String> labels) {
+                this.labels = labels;
+                return this;
+            }
+
+            public Builder events(List<String> events) {
+                this.events = events;
+                return this;
+            }
+
+            public NestedImmutableChild build() {
+                return new NestedImmutableChild(this);
+            }
+        }
+    }
+
+    @DynamoDbBean
+    public static class NestedBeanOuterWithImmutable {
+        private String id;
+        private Map<String, Integer> counters;
+        private Set<String> labels;
+        private List<String> events;
+        private NestedImmutableChild child;
+
+        @DynamoDbPartitionKey
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        public Map<String, Integer> getCounters() {
+            return counters;
+        }
+
+        public void setCounters(Map<String, Integer> counters) {
+            this.counters = counters;
+        }
+
+        public Set<String> getLabels() {
+            return labels;
+        }
+
+        public void setLabels(Set<String> labels) {
+            this.labels = labels;
+        }
+
+        public List<String> getEvents() {
+            return events;
+        }
+
+        public void setEvents(List<String> events) {
+            this.events = events;
+        }
+
+        public NestedImmutableChild getChild() {
+            return child;
+        }
+
+        public void setChild(NestedImmutableChild child) {
+            this.child = child;
+        }
+    }
+
+    @DynamoDbBean
+    public static class NestedBeanChildForImmutable {
+        private String id;
+        private Map<String, Integer> counters;
+        private Set<String> labels;
+        private List<String> events;
+
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        public Map<String, Integer> getCounters() {
+            return counters;
+        }
+
+        public void setCounters(Map<String, Integer> counters) {
+            this.counters = counters;
+        }
+
+        public Set<String> getLabels() {
+            return labels;
+        }
+
+        public void setLabels(Set<String> labels) {
+            this.labels = labels;
+        }
+
+        public List<String> getEvents() {
+            return events;
+        }
+
+        public void setEvents(List<String> events) {
+            this.events = events;
+        }
+    }
+
+    @DynamoDbImmutable(builder = NestedImmutableOuter.Builder.class)
+    public static final class NestedImmutableOuter {
+        private final String id;
+        private final Map<String, Integer> counters;
+        private final Set<String> labels;
+        private final List<String> events;
+        private final NestedBeanChildForImmutable child;
+
+        private NestedImmutableOuter(Builder b) {
+            this.id = b.id;
+            this.counters = b.counters;
+            this.labels = b.labels;
+            this.events = b.events;
+            this.child = b.child;
+        }
+
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        @DynamoDbPartitionKey
+        public String id() {
+            return id;
+        }
+
+        public Map<String, Integer> counters() {
+            return counters;
+        }
+
+        public Set<String> labels() {
+            return labels;
+        }
+
+        public List<String> events() {
+            return events;
+        }
+
+        public NestedBeanChildForImmutable child() {
+            return child;
+        }
+
+        public static final class Builder {
+            private String id;
+            private Map<String, Integer> counters;
+            private Set<String> labels;
+            private List<String> events;
+            private NestedBeanChildForImmutable child;
+
+            public Builder id(String id) {
+                this.id = id;
+                return this;
+            }
+
+            public Builder counters(Map<String, Integer> counters) {
+                this.counters = counters;
+                return this;
+            }
+
+            public Builder labels(Set<String> labels) {
+                this.labels = labels;
+                return this;
+            }
+
+            public Builder events(List<String> events) {
+                this.events = events;
+                return this;
+            }
+
+            public Builder child(NestedBeanChildForImmutable child) {
+                this.child = child;
+                return this;
+            }
+
+            public NestedImmutableOuter build() {
+                return new NestedImmutableOuter(this);
+            }
+        }
+    }
+
+    @DynamoDbBean
+    public static class NestedNullBeanChild {
+        private String id;
+
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+    }
+
+    @DynamoDbBean
+    public static class NestedNullBeanOuter {
+        static final AtomicInteger childSetterCalls = new AtomicInteger();
+        private String id;
+        private Map<String, Integer> counters;
+        private Set<String> labels;
+        private List<String> events;
+        private NestedNullBeanChild child;
+
+        @DynamoDbPartitionKey
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        public Map<String, Integer> getCounters() {
+            return counters;
+        }
+
+        public void setCounters(Map<String, Integer> counters) {
+            this.counters = counters;
+        }
+
+        public Set<String> getLabels() {
+            return labels;
+        }
+
+        public void setLabels(Set<String> labels) {
+            this.labels = labels;
+        }
+
+        public List<String> getEvents() {
+            return events;
+        }
+
+        public void setEvents(List<String> events) {
+            this.events = events;
+        }
+
+        public NestedNullBeanChild getChild() {
+            return child;
+        }
+
+        public void setChild(NestedNullBeanChild child) {
+            childSetterCalls.incrementAndGet();
+            this.child = child;
+        }
+    }
+
+    @DynamoDbImmutable(builder = NestedNullImmutableChild.Builder.class)
+    public static final class NestedNullImmutableChild {
+        private final String id;
+
+        private NestedNullImmutableChild(Builder b) {
+            this.id = b.id;
+        }
+
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        public String id() {
+            return id;
+        }
+
+        public static final class Builder {
+            private String id;
+
+            public Builder id(String id) {
+                this.id = id;
+                return this;
+            }
+
+            public NestedNullImmutableChild build() {
+                return new NestedNullImmutableChild(this);
+            }
+        }
+    }
+
+    @DynamoDbBean
+    public static class NestedBeanOuterWithNullImmutable {
+        static final AtomicInteger childSetterCalls = new AtomicInteger();
+        private String id;
+        private Map<String, Integer> counters;
+        private Set<String> labels;
+        private List<String> events;
+        private NestedNullImmutableChild child;
+
+        @DynamoDbPartitionKey
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        public Map<String, Integer> getCounters() {
+            return counters;
+        }
+
+        public void setCounters(Map<String, Integer> counters) {
+            this.counters = counters;
+        }
+
+        public Set<String> getLabels() {
+            return labels;
+        }
+
+        public void setLabels(Set<String> labels) {
+            this.labels = labels;
+        }
+
+        public List<String> getEvents() {
+            return events;
+        }
+
+        public void setEvents(List<String> events) {
+            this.events = events;
+        }
+
+        public NestedNullImmutableChild getChild() {
+            return child;
+        }
+
+        public void setChild(NestedNullImmutableChild child) {
+            childSetterCalls.incrementAndGet();
+            this.child = child;
+        }
+    }
+
+    @DynamoDbBean
+    public static class NestedBeanChildForNullImmutable {
+        private String id;
+
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+    }
+
+    @DynamoDbImmutable(builder = NestedImmutableOuterWithNullBean.Builder.class)
+    public static final class NestedImmutableOuterWithNullBean {
+        private final String id;
+        private final Map<String, Integer> counters;
+        private final Set<String> labels;
+        private final List<String> events;
+        private final NestedBeanChildForNullImmutable child;
+
+        private NestedImmutableOuterWithNullBean(Builder b) {
+            this.id = b.id;
+            this.counters = b.counters;
+            this.labels = b.labels;
+            this.events = b.events;
+            this.child = b.child;
+        }
+
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        @DynamoDbPartitionKey
+        public String id() {
+            return id;
+        }
+
+        public Map<String, Integer> counters() {
+            return counters;
+        }
+
+        public Set<String> labels() {
+            return labels;
+        }
+
+        public List<String> events() {
+            return events;
+        }
+
+        public NestedBeanChildForNullImmutable child() {
+            return child;
+        }
+
+        public static final class Builder {
+            static final AtomicInteger childSetterCalls = new AtomicInteger();
+            private String id;
+            private Map<String, Integer> counters;
+            private Set<String> labels;
+            private List<String> events;
+            private NestedBeanChildForNullImmutable child;
+
+            public Builder id(String id) {
+                this.id = id;
+                return this;
+            }
+
+            public Builder counters(Map<String, Integer> counters) {
+                this.counters = counters;
+                return this;
+            }
+
+            public Builder labels(Set<String> labels) {
+                this.labels = labels;
+                return this;
+            }
+
+            public Builder events(List<String> events) {
+                this.events = events;
+                return this;
+            }
+
+            public Builder child(NestedBeanChildForNullImmutable child) {
+                childSetterCalls.incrementAndGet();
+                this.child = child;
+                return this;
+            }
+
+            public NestedImmutableOuterWithNullBean build() {
+                return new NestedImmutableOuterWithNullBean(this);
+            }
+        }
+    }
+
+    @DynamoDbBean
+    public static class FlattenedChildBean {
+        private Map<String, Integer> counters;
+        private Set<String> labels;
+        private List<String> events;
+
+        public Map<String, Integer> getCounters() {
+            return counters;
+        }
+
+        public void setCounters(Map<String, Integer> counters) {
+            this.counters = counters;
+        }
+
+        public Set<String> getLabels() {
+            return labels;
+        }
+
+        public void setLabels(Set<String> labels) {
+            this.labels = labels;
+        }
+
+        public List<String> getEvents() {
+            return events;
+        }
+
+        public void setEvents(List<String> events) {
+            this.events = events;
+        }
+    }
+
+    @DynamoDbBean
+    public static class OuterFlattenedBean {
+        private String id;
+        private FlattenedChildBean child;
+
+        @DynamoDbPartitionKey
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        @DynamoDbFlatten
+        public FlattenedChildBean getChild() {
+            return child;
+        }
+
+        public void setChild(FlattenedChildBean child) {
+            this.child = child;
+        }
+    }
+
+    @DynamoDbBean
+    public static class FlattenedUnsupportedChild {
+        private UnsupportedType value;
+
+        public UnsupportedType getValue() {
+            return value;
+        }
+
+        public void setValue(UnsupportedType value) {
+            this.value = value;
+        }
+    }
+
+    @DynamoDbBean
+    public static class OuterFlattenedUnsupportedBean {
+        private String id;
+        private FlattenedUnsupportedChild child;
+
+        @DynamoDbPartitionKey
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        @DynamoDbFlatten
+        public FlattenedUnsupportedChild getChild() {
+            return child;
+        }
+
+        public void setChild(FlattenedUnsupportedChild child) {
+            this.child = child;
+        }
+    }
+
+    @DynamoDbBean(converterProviders = {
+        RecordingCustomProvider.class,
+        DefaultAttributeConverterProvider.class
+    })
+    public static class FlattenedCustomChild {
+        private CustomType value;
+
+        public CustomType getValue() {
+            return value;
+        }
+
+        public void setValue(CustomType value) {
+            this.value = value;
+        }
+    }
+
+    @DynamoDbBean
+    public static class OuterFlattenedCustomBean {
+        private String id;
+        private FlattenedCustomChild child;
+
+        @DynamoDbPartitionKey
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        @DynamoDbFlatten
+        public FlattenedCustomChild getChild() {
+            return child;
+        }
+
+        public void setChild(FlattenedCustomChild child) {
+            this.child = child;
+        }
+    }
+
+    @DynamoDbBean(converterProviders = {
+        RecordingRequestedTypesProvider.class,
+        DefaultAttributeConverterProvider.class
+    })
+    public static class FlattenMapBean {
+        private String id;
+        private Map<String, String> attributes;
+
+        @DynamoDbPartitionKey
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        @DynamoDbFlatten
+        public Map<String, String> getAttributes() {
+            return attributes;
+        }
+
+        public void setAttributes(Map<String, String> attributes) {
+            this.attributes = attributes;
+        }
+    }
+
+    static final class FlattenMapItem {
+        private String id;
+        private Map<String, String> attributes;
+
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        public Map<String, String> getAttributes() {
+            return attributes;
+        }
+
+        public void setAttributes(Map<String, String> attributes) {
+            this.attributes = attributes;
+        }
+    }
+
+    static final class FlattenedChildItem {
+        private Map<String, Integer> counters;
+        private Set<String> labels;
+        private List<String> events;
+
+        public Map<String, Integer> getCounters() {
+            return counters;
+        }
+
+        public void setCounters(Map<String, Integer> counters) {
+            this.counters = counters;
+        }
+
+        public Set<String> getLabels() {
+            return labels;
+        }
+
+        public void setLabels(Set<String> labels) {
+            this.labels = labels;
+        }
+
+        public List<String> getEvents() {
+            return events;
+        }
+
+        public void setEvents(List<String> events) {
+            this.events = events;
+        }
+    }
+
+    static final class FlattenedOuterItem {
+        private String id;
+        private FlattenedChildItem child;
+
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        public FlattenedChildItem getChild() {
+            return child;
+        }
+
+        public void setChild(FlattenedChildItem child) {
+            this.child = child;
+        }
+    }
+
+    public static final class UnsupportedType {
+    }
+
+    public static final class CustomType {
+        private final String value;
+
+        public CustomType(String value) {
+            this.value = value;
+        }
+
+        public String value() {
+            return value;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof CustomType)) {
+                return false;
+            }
+            CustomType that = (CustomType) o;
+            return Objects.equals(value, that.value);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(value);
+        }
+    }
+
+    public static final class CustomTypeConverter implements AttributeConverter<CustomType> {
+        public CustomTypeConverter() {
+        }
+
+        @Override
+        public AttributeValue transformFrom(CustomType input) {
+            return AttributeValue.fromS("custom:" + input.value());
+        }
+
+        @Override
+        public CustomType transformTo(AttributeValue input) {
+            return new CustomType(input.s().substring("custom:".length()));
+        }
+
+        @Override
+        public EnhancedType<CustomType> type() {
+            return EnhancedType.of(CustomType.class);
+        }
+
+        @Override
+        public AttributeValueType attributeValueType() {
+            return AttributeValueType.S;
+        }
+    }
+
+    public static final class RecordingCustomProvider implements AttributeConverterProvider {
+        private static final ThreadLocal<RecordingCustomProvider> CURRENT =
+            new ThreadLocal<>();
+        private final List<EnhancedType<?>> requestedTypes = new ArrayList<>();
+
+        public RecordingCustomProvider() {
+            CURRENT.set(this);
+        }
+
+        public static RecordingCustomProvider current() {
+            return CURRENT.get();
+        }
+
+        public static void reset() {
+            CURRENT.remove();
+        }
+
+        public List<EnhancedType<?>> requestedTypes() {
+            return requestedTypes;
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> AttributeConverter<T> converterFor(EnhancedType<T> enhancedType) {
+            requestedTypes.add(enhancedType);
+            if (EnhancedType.of(CustomType.class).equals(enhancedType)) {
+                return (AttributeConverter<T>) new CustomTypeConverter();
+            }
+            return null;
+        }
+    }
+
+    public static final class RecordingRequestedTypesProvider implements AttributeConverterProvider {
+        private static final ThreadLocal<RecordingRequestedTypesProvider> CURRENT =
+            new ThreadLocal<>();
+        private final List<EnhancedType<?>> requestedTypes = new ArrayList<>();
+
+        public RecordingRequestedTypesProvider() {
+            CURRENT.set(this);
+        }
+
+        public static RecordingRequestedTypesProvider current() {
+            return CURRENT.get();
+        }
+
+        public static void reset() {
+            CURRENT.remove();
+        }
+
+        public List<EnhancedType<?>> requestedTypes() {
+            return requestedTypes;
+        }
+
+        @Override
+        public <T> AttributeConverter<T> converterFor(EnhancedType<T> enhancedType) {
+            requestedTypes.add(enhancedType);
+            return null;
+        }
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/SecondaryIndexConverterTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/SecondaryIndexConverterTest.java
@@ -1,0 +1,1040 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static software.amazon.awssdk.enhanced.dynamodb.mapper.StaticAttributeTags.primaryPartitionKey;
+import static software.amazon.awssdk.enhanced.dynamodb.mapper.StaticAttributeTags.secondaryPartitionKey;
+import static software.amazon.awssdk.enhanced.dynamodb.mapper.StaticAttributeTags.secondarySortKey;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.IntegerAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.SdkBytesAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.StringAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.StaticTableSchema;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType;
+
+/**
+ * Tests converter validation for global and local secondary index key attributes.
+ * <p>
+ * The tests accept scalar string, number, and binary converter types from default providers, custom providers, and
+ * attribute converters. They reject nonscalar converter types and unsupported attributes during schema construction,
+ * while also verifying that custom conversion can make an otherwise unsupported key type scalar.
+ */
+public class SecondaryIndexConverterTest {
+
+    @Test
+    @DisplayName("A built-in S converter is valid for a GSI partition key")
+    void build_whenStringGsiPartitionKey_selectsStringConverterWithTypeS() {
+        StaticTableSchema<StringGsiItem> schema = stringGsiSchema();
+
+        assertThat(schema.converterForAttribute("gsiPk")).isInstanceOf(StringAttributeConverter.class);
+        assertThat(schema.tableMetadata().scalarAttributeType("gsiPk")).contains(ScalarAttributeType.S);
+    }
+
+    @Test
+    @DisplayName("A built-in N converter is valid for a GSI sort key")
+    void build_whenIntegerGsiSortKey_selectsIntegerConverterWithTypeN() {
+        StaticTableSchema<IntegerGsiSortItem> schema =
+            StaticTableSchema.builder(IntegerGsiSortItem.class)
+                             .newItemSupplier(IntegerGsiSortItem::new)
+                             .addAttribute(String.class, a -> a.name("pk")
+                                                               .getter(IntegerGsiSortItem::getPk)
+                                                               .setter(IntegerGsiSortItem::setPk)
+                                                               .tags(primaryPartitionKey()))
+                             .addAttribute(String.class, a -> a.name("gsiPk")
+                                                               .getter(IntegerGsiSortItem::getGsiPk)
+                                                               .setter(IntegerGsiSortItem::setGsiPk)
+                                                               .tags(secondaryPartitionKey("gsi")))
+                             .addAttribute(Integer.class, a -> a.name("gsiSk")
+                                                                .getter(IntegerGsiSortItem::getGsiSk)
+                                                                .setter(IntegerGsiSortItem::setGsiSk)
+                                                                .tags(secondarySortKey("gsi")))
+                             .build();
+
+        assertThat(schema.converterForAttribute("gsiSk")).isInstanceOf(IntegerAttributeConverter.class);
+        assertThat(schema.tableMetadata().scalarAttributeType("gsiSk")).contains(ScalarAttributeType.N);
+    }
+
+    @Test
+    @DisplayName("A built-in B converter is valid for a GSI partition key")
+    void build_whenSdkBytesGsiPartitionKey_selectsSdkBytesConverterWithTypeB() {
+        StaticTableSchema<SdkBytesGsiItem> schema =
+            StaticTableSchema.builder(SdkBytesGsiItem.class)
+                             .newItemSupplier(SdkBytesGsiItem::new)
+                             .addAttribute(String.class, a -> a.name("pk")
+                                                               .getter(SdkBytesGsiItem::getPk)
+                                                               .setter(SdkBytesGsiItem::setPk)
+                                                               .tags(primaryPartitionKey()))
+                             .addAttribute(SdkBytes.class, a -> a.name("gsiPk")
+                                                                 .getter(SdkBytesGsiItem::getGsiPk)
+                                                                 .setter(SdkBytesGsiItem::setGsiPk)
+                                                                 .tags(secondaryPartitionKey("gsi")))
+                             .build();
+
+        assertThat(schema.converterForAttribute("gsiPk")).isInstanceOf(SdkBytesAttributeConverter.class);
+        assertThat(schema.tableMetadata().scalarAttributeType("gsiPk")).contains(ScalarAttributeType.B);
+    }
+
+    @Test
+    @DisplayName("A built-in S converter is valid for an LSI sort key")
+    void build_whenStringLsiSortKey_selectsStringConverterWithTypeS() {
+        StaticTableSchema<LsiItem> schema = lsiSchema();
+
+        assertThat(schema.converterForAttribute("lsiSk")).isInstanceOf(StringAttributeConverter.class);
+        assertThat(schema.tableMetadata().scalarAttributeType("lsiSk")).contains(ScalarAttributeType.S);
+    }
+
+    @Test
+    @DisplayName("A provider-selected custom S converter is valid for a GSI key")
+    void build_whenCustomStringConverterForGsiKey_selectsCustomConverterWithTypeS() {
+        RecordingCustomProvider customProvider = new RecordingCustomProvider(AttributeValueType.S);
+        StaticTableSchema<CustomTypeGsiItem> schema =
+            customTypeGsiSchema(customProvider, AttributeConverterProvider.defaultProvider(), null);
+
+        assertThat(customProvider.requestedTypes())
+            .filteredOn(type -> type.equals(EnhancedType.of(CustomType.class)))
+            .hasSize(2);
+        assertThat(schema.converterForAttribute("gsiPk")).isInstanceOf(CustomTypeConverter.class);
+        assertThat(schema.tableMetadata().scalarAttributeType("gsiPk")).contains(ScalarAttributeType.S);
+    }
+
+    @Test
+    @DisplayName("An attribute-level custom B converter is valid for a GSI key")
+    void build_whenAttributeLevelBinaryConverterForGsiKey_skipsProviderAndSelectsTypeB() {
+        RecordingCustomProvider schemaProvider = new RecordingCustomProvider(AttributeValueType.S);
+        CustomTypeConverter binaryConverter = new CustomTypeConverter(AttributeValueType.B);
+        StaticTableSchema<CustomTypeGsiItem> schema =
+            customTypeGsiSchema(schemaProvider, AttributeConverterProvider.defaultProvider(), binaryConverter);
+
+        assertThat(schemaProvider.requestedTypes())
+            .filteredOn(type -> type.equals(EnhancedType.of(CustomType.class)))
+            .isEmpty();
+        assertThat(schema.converterForAttribute("gsiPk")).isSameAs(binaryConverter);
+        assertThat(schema.tableMetadata().scalarAttributeType("gsiPk")).contains(ScalarAttributeType.B);
+    }
+
+    @Test
+    @DisplayName("A BOOL converter is rejected as a GSI key")
+    void build_whenBooleanGsiPartitionKey_throwsUnsuitableKeyType() {
+        StaticTableSchema.Builder<BooleanGsiItem> builder =
+            StaticTableSchema.builder(BooleanGsiItem.class)
+                             .newItemSupplier(BooleanGsiItem::new)
+                             .addAttribute(String.class, a -> a.name("pk")
+                                                               .getter(BooleanGsiItem::getPk)
+                                                               .setter(BooleanGsiItem::setPk)
+                                                               .tags(primaryPartitionKey()))
+                             .addAttribute(Boolean.class, a -> a.name("gsiPk")
+                                                                .getter(BooleanGsiItem::getGsiPk)
+                                                                .setter(BooleanGsiItem::setGsiPk)
+                                                                .tags(secondaryPartitionKey("gsi")));
+
+        assertThatThrownBy(builder::build)
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Attribute 'gsiPk' of type BOOL is not a suitable type to be used as a key.");
+    }
+
+    @Test
+    @DisplayName("An L converter is rejected as an LSI key")
+    void build_whenStringListLsiSortKey_throwsUnsuitableKeyType() {
+        StaticTableSchema.Builder<ListLsiItem> builder =
+            StaticTableSchema.builder(ListLsiItem.class)
+                             .newItemSupplier(ListLsiItem::new)
+                             .addAttribute(String.class, a -> a.name("pk")
+                                                               .getter(ListLsiItem::getPk)
+                                                               .setter(ListLsiItem::setPk)
+                                                               .tags(primaryPartitionKey()))
+                             .addAttribute(EnhancedType.listOf(String.class),
+                                           a -> a.name("lsiSk")
+                                                 .getter(ListLsiItem::getLsiSk)
+                                                 .setter(ListLsiItem::setLsiSk)
+                                                 .tags(secondarySortKey("lsi")));
+
+        assertThatThrownBy(builder::build)
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Attribute 'lsiSk' of type L is not a suitable type to be used as a key.");
+    }
+
+    @Test
+    @DisplayName("An M map converter is rejected as a GSI key")
+    void build_whenStringToIntegerMapGsiPartitionKey_throwsUnsuitableKeyType() {
+        StaticTableSchema.Builder<MapGsiItem> builder =
+            StaticTableSchema.builder(MapGsiItem.class)
+                             .newItemSupplier(MapGsiItem::new)
+                             .addAttribute(String.class, a -> a.name("pk")
+                                                               .getter(MapGsiItem::getPk)
+                                                               .setter(MapGsiItem::setPk)
+                                                               .tags(primaryPartitionKey()))
+                             .addAttribute(EnhancedType.mapOf(String.class, Integer.class),
+                                           a -> a.name("gsiPk")
+                                                 .getter(MapGsiItem::getGsiPk)
+                                                 .setter(MapGsiItem::setGsiPk)
+                                                 .tags(secondaryPartitionKey("gsi")));
+
+        assertThatThrownBy(builder::build)
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Attribute 'gsiPk' of type M is not a suitable type to be used as a key.");
+    }
+
+    @Test
+    @DisplayName("An SS converter is rejected as a GSI key")
+    void build_whenStringSetGsiPartitionKey_throwsUnsuitableKeyType() {
+        StaticTableSchema.Builder<StringSetGsiItem> builder =
+            StaticTableSchema.builder(StringSetGsiItem.class)
+                             .newItemSupplier(StringSetGsiItem::new)
+                             .addAttribute(String.class, a -> a.name("pk")
+                                                               .getter(StringSetGsiItem::getPk)
+                                                               .setter(StringSetGsiItem::setPk)
+                                                               .tags(primaryPartitionKey()))
+                             .addAttribute(EnhancedType.setOf(String.class),
+                                           a -> a.name("gsiPk")
+                                                 .getter(StringSetGsiItem::getGsiPk)
+                                                 .setter(StringSetGsiItem::setGsiPk)
+                                                 .tags(secondaryPartitionKey("gsi")));
+
+        assertThatThrownBy(builder::build)
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Attribute 'gsiPk' of type SS is not a suitable type to be used as a key.");
+    }
+
+    @Test
+    @DisplayName("An NS converter is rejected as a GSI key")
+    void build_whenIntegerSetGsiPartitionKey_throwsUnsuitableKeyType() {
+        StaticTableSchema.Builder<IntegerSetGsiItem> builder =
+            StaticTableSchema.builder(IntegerSetGsiItem.class)
+                             .newItemSupplier(IntegerSetGsiItem::new)
+                             .addAttribute(String.class, a -> a.name("pk")
+                                                               .getter(IntegerSetGsiItem::getPk)
+                                                               .setter(IntegerSetGsiItem::setPk)
+                                                               .tags(primaryPartitionKey()))
+                             .addAttribute(EnhancedType.setOf(Integer.class),
+                                           a -> a.name("gsiPk")
+                                                 .getter(IntegerSetGsiItem::getGsiPk)
+                                                 .setter(IntegerSetGsiItem::setGsiPk)
+                                                 .tags(secondaryPartitionKey("gsi")));
+
+        assertThatThrownBy(builder::build)
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Attribute 'gsiPk' of type NS is not a suitable type to be used as a key.");
+    }
+
+    @Test
+    @DisplayName("A BS converter is rejected as a GSI key")
+    void build_whenSdkBytesSetGsiPartitionKey_throwsUnsuitableKeyType() {
+        StaticTableSchema.Builder<SdkBytesSetGsiItem> builder =
+            StaticTableSchema.builder(SdkBytesSetGsiItem.class)
+                             .newItemSupplier(SdkBytesSetGsiItem::new)
+                             .addAttribute(String.class, a -> a.name("pk")
+                                                               .getter(SdkBytesSetGsiItem::getPk)
+                                                               .setter(SdkBytesSetGsiItem::setPk)
+                                                               .tags(primaryPartitionKey()))
+                             .addAttribute(EnhancedType.setOf(SdkBytes.class),
+                                           a -> a.name("gsiPk")
+                                                 .getter(SdkBytesSetGsiItem::getGsiPk)
+                                                 .setter(SdkBytesSetGsiItem::setGsiPk)
+                                                 .tags(secondaryPartitionKey("gsi")));
+
+        assertThatThrownBy(builder::build)
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Attribute 'gsiPk' of type BS is not a suitable type to be used as a key.");
+    }
+
+    @Test
+    @DisplayName("An M document converter is rejected as a GSI key")
+    void build_whenSchemaBearingDocumentGsiPartitionKey_throwsUnsuitableKeyType() {
+        TableSchema<DocumentType> documentSchema =
+            StaticTableSchema.builder(DocumentType.class).newItemSupplier(DocumentType::new).build();
+        StaticTableSchema.Builder<DocumentGsiItem> builder =
+            StaticTableSchema.builder(DocumentGsiItem.class)
+                             .newItemSupplier(DocumentGsiItem::new)
+                             .addAttribute(String.class, a -> a.name("pk")
+                                                               .getter(DocumentGsiItem::getPk)
+                                                               .setter(DocumentGsiItem::setPk)
+                                                               .tags(primaryPartitionKey()))
+                             .addAttribute(EnhancedType.documentOf(DocumentType.class, documentSchema),
+                                           a -> a.name("gsiPk")
+                                                 .getter(DocumentGsiItem::getGsiPk)
+                                                 .setter(DocumentGsiItem::setGsiPk)
+                                                 .tags(secondaryPartitionKey("gsi")));
+
+        assertThatThrownBy(builder::build)
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Attribute 'gsiPk' of type M is not a suitable type to be used as a key.");
+    }
+
+    @Test
+    @DisplayName("A provider-selected custom M converter is rejected as a GSI key")
+    void build_whenCustomMapConverterForGsiKey_callsProviderTwiceThenThrowsUnsuitableKeyType() {
+        RecordingCustomProvider customProvider = new RecordingCustomProvider(AttributeValueType.M);
+        StaticTableSchema.Builder<CustomTypeGsiItem> builder =
+            customTypeGsiBuilder(customProvider, AttributeConverterProvider.defaultProvider(), null);
+
+        assertThatThrownBy(builder::build)
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Attribute 'gsiPk' of type M is not a suitable type to be used as a key.");
+        assertThat(customProvider.requestedTypes())
+            .filteredOn(type -> type.equals(EnhancedType.of(CustomType.class)))
+            .hasSize(2);
+    }
+
+    @Test
+    @DisplayName("An attribute-level custom M converter is rejected as a GSI key")
+    void build_whenAttributeLevelMapConverterForGsiKey_skipsProviderAndThrowsUnsuitableKeyType() {
+        ReturningNullProvider schemaProvider = new ReturningNullProvider();
+        CustomTypeConverter mapConverter = new CustomTypeConverter(AttributeValueType.M);
+        StaticTableSchema.Builder<CustomTypeGsiItem> builder =
+            customTypeGsiBuilder(schemaProvider, AttributeConverterProvider.defaultProvider(), mapConverter);
+
+        assertThatThrownBy(builder::build)
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Attribute 'gsiPk' of type M is not a suitable type to be used as a key.");
+        assertThat(schemaProvider.requestedTypes()).doesNotContain(EnhancedType.of(CustomType.class));
+    }
+
+    @Test
+    @DisplayName("An Object index attribute fails converter lookup")
+    void build_whenObjectGsiPartitionKey_throwsConverterNotFound() {
+        StaticTableSchema.Builder<ObjectGsiItem> builder =
+            StaticTableSchema.builder(ObjectGsiItem.class)
+                             .newItemSupplier(ObjectGsiItem::new)
+                             .addAttribute(String.class, a -> a.name("pk")
+                                                               .getter(ObjectGsiItem::getPk)
+                                                               .setter(ObjectGsiItem::setPk)
+                                                               .tags(primaryPartitionKey()))
+                             .addAttribute(Object.class, a -> a.name("gsiPk")
+                                                               .getter(ObjectGsiItem::getGsiPk)
+                                                               .setter(ObjectGsiItem::setGsiPk)
+                                                               .tags(secondaryPartitionKey("gsi")));
+
+        assertThatThrownBy(builder::build)
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + EnhancedType.of(Object.class));
+    }
+
+    @Test
+    @DisplayName("An unsupported index attribute fails during converter selection")
+    void build_whenUnsupportedTypeGsiPartitionKey_throwsConverterNotFound() {
+        EnhancedType<UnsupportedType> type = EnhancedType.of(UnsupportedType.class);
+        StaticTableSchema.Builder<UnsupportedGsiItem> builder =
+            StaticTableSchema.builder(UnsupportedGsiItem.class)
+                             .newItemSupplier(UnsupportedGsiItem::new)
+                             .addAttribute(String.class, a -> a.name("pk")
+                                                               .getter(UnsupportedGsiItem::getPk)
+                                                               .setter(UnsupportedGsiItem::setPk)
+                                                               .tags(primaryPartitionKey()))
+                             .addAttribute(UnsupportedType.class, a -> a.name("gsiPk")
+                                                                        .getter(UnsupportedGsiItem::getGsiPk)
+                                                                        .setter(UnsupportedGsiItem::setGsiPk)
+                                                                        .tags(secondaryPartitionKey("gsi")));
+
+        assertThatThrownBy(builder::build)
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + type);
+    }
+
+    @Test
+    @DisplayName("A concrete list index attribute fails during converter selection")
+    void build_whenConcreteArrayListGsiPartitionKey_throwsConverterNotFound() {
+        EnhancedType<ArrayList<String>> type = new EnhancedType<ArrayList<String>>() { };
+        StaticTableSchema.Builder<ArrayListGsiItem> builder =
+            StaticTableSchema.builder(ArrayListGsiItem.class)
+                             .newItemSupplier(ArrayListGsiItem::new)
+                             .addAttribute(String.class, a -> a.name("pk")
+                                                               .getter(ArrayListGsiItem::getPk)
+                                                               .setter(ArrayListGsiItem::setPk)
+                                                               .tags(primaryPartitionKey()))
+                             .addAttribute(type, a -> a.name("gsiPk")
+                                                       .getter(ArrayListGsiItem::getGsiPk)
+                                                       .setter(ArrayListGsiItem::setGsiPk)
+                                                       .tags(secondaryPartitionKey("gsi")));
+
+        assertThatThrownBy(builder::build)
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + type);
+    }
+
+    @Test
+    @DisplayName("A custom provider makes an Object GSI key scalar")
+    void build_whenObjectGsiKeyWithObjectProvider_selectsStringConverterWithTypeS() {
+        ObjectProvider objectProvider = new ObjectProvider();
+        StaticTableSchema<ObjectGsiItem> schema =
+            StaticTableSchema.builder(ObjectGsiItem.class)
+                             .newItemSupplier(ObjectGsiItem::new)
+                             .attributeConverterProviders(objectProvider,
+                                                          AttributeConverterProvider.defaultProvider())
+                             .addAttribute(String.class, a -> a.name("pk")
+                                                               .getter(ObjectGsiItem::getPk)
+                                                               .setter(ObjectGsiItem::setPk)
+                                                               .tags(primaryPartitionKey()))
+                             .addAttribute(Object.class, a -> a.name("gsiPk")
+                                                               .getter(ObjectGsiItem::getGsiPk)
+                                                               .setter(ObjectGsiItem::setGsiPk)
+                                                               .tags(secondaryPartitionKey("gsi")))
+                             .build();
+
+        assertThat(schema.converterForAttribute("gsiPk")).isInstanceOf(ObjectStringConverter.class);
+        assertThat(objectProvider.requestedTypes())
+            .filteredOn(type -> type.equals(EnhancedType.of(Object.class)))
+            .hasSize(2);
+        assertThat(schema.tableMetadata().scalarAttributeType("gsiPk")).contains(ScalarAttributeType.S);
+    }
+
+    @Test
+    @DisplayName("An attribute-level converter makes an Object GSI key scalar")
+    void build_whenObjectGsiKeyWithAttributeLevelConverter_skipsProviderAndSelectsTypeB() {
+        ReturningNullProvider schemaProvider = new ReturningNullProvider();
+        ObjectBinaryConverter binaryConverter = new ObjectBinaryConverter();
+        StaticTableSchema<ObjectGsiItem> schema =
+            StaticTableSchema.builder(ObjectGsiItem.class)
+                             .newItemSupplier(ObjectGsiItem::new)
+                             .attributeConverterProviders(schemaProvider,
+                                                          AttributeConverterProvider.defaultProvider())
+                             .addAttribute(String.class, a -> a.name("pk")
+                                                               .getter(ObjectGsiItem::getPk)
+                                                               .setter(ObjectGsiItem::setPk)
+                                                               .tags(primaryPartitionKey()))
+                             .addAttribute(Object.class, a -> a.name("gsiPk")
+                                                               .getter(ObjectGsiItem::getGsiPk)
+                                                               .setter(ObjectGsiItem::setGsiPk)
+                                                               .attributeConverter(binaryConverter)
+                                                               .tags(secondaryPartitionKey("gsi")))
+                             .build();
+
+        assertThat(schemaProvider.requestedTypes()).doesNotContain(EnhancedType.of(Object.class));
+        assertThat(schema.converterForAttribute("gsiPk")).isSameAs(binaryConverter);
+        assertThat(schema.tableMetadata().scalarAttributeType("gsiPk")).contains(ScalarAttributeType.B);
+    }
+
+    @Test
+    @DisplayName("A Collection index attribute is rejected because SS is not a suitable key type")
+    void build_whenStringCollectionGsiPartitionKey_throwsIllegalArgumentExceptionForSsKey() {
+        EnhancedType<Collection<String>> type = EnhancedType.collectionOf(String.class);
+        StaticTableSchema.Builder<CollectionGsiItem> builder =
+            StaticTableSchema.builder(CollectionGsiItem.class)
+                             .newItemSupplier(CollectionGsiItem::new)
+                             .addAttribute(String.class, a -> a.name("pk")
+                                                               .getter(CollectionGsiItem::getPk)
+                                                               .setter(CollectionGsiItem::setPk)
+                                                               .tags(primaryPartitionKey()))
+                             .addAttribute(type,
+                                           a -> a.name("gsiPk")
+                                                 .getter(CollectionGsiItem::getGsiPk)
+                                                 .setter(CollectionGsiItem::setGsiPk)
+                                                 .tags(secondaryPartitionKey("gsi")));
+
+        assertThatThrownBy(builder::build)
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Attribute 'gsiPk' of type SS is not a suitable type to be used as a key.");
+    }
+
+    @Test
+    @DisplayName("An Iterable index attribute is rejected because SS is not a suitable key type")
+    void build_whenStringIterableGsiPartitionKey_throwsIllegalArgumentExceptionForSsKey() {
+        EnhancedType<Iterable<String>> type = new EnhancedType<Iterable<String>>() { };
+        StaticTableSchema.Builder<IterableGsiItem> builder =
+            StaticTableSchema.builder(IterableGsiItem.class)
+                             .newItemSupplier(IterableGsiItem::new)
+                             .addAttribute(String.class, a -> a.name("pk")
+                                                               .getter(IterableGsiItem::getPk)
+                                                               .setter(IterableGsiItem::setPk)
+                                                               .tags(primaryPartitionKey()))
+                             .addAttribute(type,
+                                           a -> a.name("gsiPk")
+                                                 .getter(IterableGsiItem::getGsiPk)
+                                                 .setter(IterableGsiItem::setGsiPk)
+                                                 .tags(secondaryPartitionKey("gsi")));
+
+        assertThatThrownBy(builder::build)
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Attribute 'gsiPk' of type SS is not a suitable type to be used as a key.");
+    }
+
+    private static StaticTableSchema<StringGsiItem> stringGsiSchema() {
+        return StaticTableSchema.builder(StringGsiItem.class)
+                                .newItemSupplier(StringGsiItem::new)
+                                .addAttribute(String.class, a -> a.name("pk")
+                                                                  .getter(StringGsiItem::getPk)
+                                                                  .setter(StringGsiItem::setPk)
+                                                                  .tags(primaryPartitionKey()))
+                                .addAttribute(String.class, a -> a.name("gsiPk")
+                                                                  .getter(StringGsiItem::getGsiPk)
+                                                                  .setter(StringGsiItem::setGsiPk)
+                                                                  .tags(secondaryPartitionKey("gsi")))
+                                .build();
+    }
+
+    private static StaticTableSchema<LsiItem> lsiSchema() {
+        return StaticTableSchema.builder(LsiItem.class)
+                                .newItemSupplier(LsiItem::new)
+                                .addAttribute(String.class, a -> a.name("pk")
+                                                                  .getter(LsiItem::getPk)
+                                                                  .setter(LsiItem::setPk)
+                                                                  .tags(primaryPartitionKey()))
+                                .addAttribute(String.class, a -> a.name("lsiSk")
+                                                                  .getter(LsiItem::getLsiSk)
+                                                                  .setter(LsiItem::setLsiSk)
+                                                                  .tags(secondarySortKey("lsi")))
+                                .build();
+    }
+
+    private static StaticTableSchema<CustomTypeGsiItem> customTypeGsiSchema(
+        AttributeConverterProvider first,
+        AttributeConverterProvider second,
+        AttributeConverter<CustomType> attributeConverter) {
+        return customTypeGsiBuilder(first, second, attributeConverter).build();
+    }
+
+    private static StaticTableSchema.Builder<CustomTypeGsiItem> customTypeGsiBuilder(
+        AttributeConverterProvider first,
+        AttributeConverterProvider second,
+        AttributeConverter<CustomType> attributeConverter) {
+        return StaticTableSchema.builder(CustomTypeGsiItem.class)
+                                .newItemSupplier(CustomTypeGsiItem::new)
+                                .attributeConverterProviders(first, second)
+                                .addAttribute(String.class, a -> a.name("pk")
+                                                                  .getter(CustomTypeGsiItem::getPk)
+                                                                  .setter(CustomTypeGsiItem::setPk)
+                                                                  .tags(primaryPartitionKey()))
+                                .addAttribute(CustomType.class, a -> {
+                                    a.name("gsiPk")
+                                     .getter(CustomTypeGsiItem::getGsiPk)
+                                     .setter(CustomTypeGsiItem::setGsiPk)
+                                     .tags(secondaryPartitionKey("gsi"));
+                                    if (attributeConverter != null) {
+                                        a.attributeConverter(attributeConverter);
+                                    }
+                                });
+    }
+
+    static final class StringGsiItem {
+        private String pk;
+        private String gsiPk;
+
+        public String getPk() {
+            return pk;
+        }
+
+        public void setPk(String pk) {
+            this.pk = pk;
+        }
+
+        public String getGsiPk() {
+            return gsiPk;
+        }
+
+        public void setGsiPk(String gsiPk) {
+            this.gsiPk = gsiPk;
+        }
+    }
+
+    static final class IntegerGsiSortItem {
+        private String pk;
+        private String gsiPk;
+        private Integer gsiSk;
+
+        public String getPk() {
+            return pk;
+        }
+
+        public void setPk(String pk) {
+            this.pk = pk;
+        }
+
+        public String getGsiPk() {
+            return gsiPk;
+        }
+
+        public void setGsiPk(String gsiPk) {
+            this.gsiPk = gsiPk;
+        }
+
+        public Integer getGsiSk() {
+            return gsiSk;
+        }
+
+        public void setGsiSk(Integer gsiSk) {
+            this.gsiSk = gsiSk;
+        }
+    }
+
+    static final class SdkBytesGsiItem {
+        private String pk;
+        private SdkBytes gsiPk;
+
+        public String getPk() {
+            return pk;
+        }
+
+        public void setPk(String pk) {
+            this.pk = pk;
+        }
+
+        public SdkBytes getGsiPk() {
+            return gsiPk;
+        }
+
+        public void setGsiPk(SdkBytes gsiPk) {
+            this.gsiPk = gsiPk;
+        }
+    }
+
+    static final class LsiItem {
+        private String pk;
+        private String lsiSk;
+
+        public String getPk() {
+            return pk;
+        }
+
+        public void setPk(String pk) {
+            this.pk = pk;
+        }
+
+        public String getLsiSk() {
+            return lsiSk;
+        }
+
+        public void setLsiSk(String lsiSk) {
+            this.lsiSk = lsiSk;
+        }
+    }
+
+    static final class CustomTypeGsiItem {
+        private String pk;
+        private CustomType gsiPk;
+
+        public String getPk() {
+            return pk;
+        }
+
+        public void setPk(String pk) {
+            this.pk = pk;
+        }
+
+        public CustomType getGsiPk() {
+            return gsiPk;
+        }
+
+        public void setGsiPk(CustomType gsiPk) {
+            this.gsiPk = gsiPk;
+        }
+    }
+
+    static final class BooleanGsiItem {
+        private String pk;
+        private Boolean gsiPk;
+
+        public String getPk() {
+            return pk;
+        }
+
+        public void setPk(String pk) {
+            this.pk = pk;
+        }
+
+        public Boolean getGsiPk() {
+            return gsiPk;
+        }
+
+        public void setGsiPk(Boolean gsiPk) {
+            this.gsiPk = gsiPk;
+        }
+    }
+
+    static final class ListLsiItem {
+        private String pk;
+        private List<String> lsiSk;
+
+        public String getPk() {
+            return pk;
+        }
+
+        public void setPk(String pk) {
+            this.pk = pk;
+        }
+
+        public List<String> getLsiSk() {
+            return lsiSk;
+        }
+
+        public void setLsiSk(List<String> lsiSk) {
+            this.lsiSk = lsiSk;
+        }
+    }
+
+    static final class MapGsiItem {
+        private String pk;
+        private Map<String, Integer> gsiPk;
+
+        public String getPk() {
+            return pk;
+        }
+
+        public void setPk(String pk) {
+            this.pk = pk;
+        }
+
+        public Map<String, Integer> getGsiPk() {
+            return gsiPk;
+        }
+
+        public void setGsiPk(Map<String, Integer> gsiPk) {
+            this.gsiPk = gsiPk;
+        }
+    }
+
+    static final class StringSetGsiItem {
+        private String pk;
+        private Set<String> gsiPk;
+
+        public String getPk() {
+            return pk;
+        }
+
+        public void setPk(String pk) {
+            this.pk = pk;
+        }
+
+        public Set<String> getGsiPk() {
+            return gsiPk;
+        }
+
+        public void setGsiPk(Set<String> gsiPk) {
+            this.gsiPk = gsiPk;
+        }
+    }
+
+    static final class IntegerSetGsiItem {
+        private String pk;
+        private Set<Integer> gsiPk;
+
+        public String getPk() {
+            return pk;
+        }
+
+        public void setPk(String pk) {
+            this.pk = pk;
+        }
+
+        public Set<Integer> getGsiPk() {
+            return gsiPk;
+        }
+
+        public void setGsiPk(Set<Integer> gsiPk) {
+            this.gsiPk = gsiPk;
+        }
+    }
+
+    static final class SdkBytesSetGsiItem {
+        private String pk;
+        private Set<SdkBytes> gsiPk;
+
+        public String getPk() {
+            return pk;
+        }
+
+        public void setPk(String pk) {
+            this.pk = pk;
+        }
+
+        public Set<SdkBytes> getGsiPk() {
+            return gsiPk;
+        }
+
+        public void setGsiPk(Set<SdkBytes> gsiPk) {
+            this.gsiPk = gsiPk;
+        }
+    }
+
+    static final class DocumentGsiItem {
+        private String pk;
+        private DocumentType gsiPk;
+
+        public String getPk() {
+            return pk;
+        }
+
+        public void setPk(String pk) {
+            this.pk = pk;
+        }
+
+        public DocumentType getGsiPk() {
+            return gsiPk;
+        }
+
+        public void setGsiPk(DocumentType gsiPk) {
+            this.gsiPk = gsiPk;
+        }
+    }
+
+    static final class ObjectGsiItem {
+        private String pk;
+        private Object gsiPk;
+
+        public String getPk() {
+            return pk;
+        }
+
+        public void setPk(String pk) {
+            this.pk = pk;
+        }
+
+        public Object getGsiPk() {
+            return gsiPk;
+        }
+
+        public void setGsiPk(Object gsiPk) {
+            this.gsiPk = gsiPk;
+        }
+    }
+
+    static final class UnsupportedGsiItem {
+        private String pk;
+        private UnsupportedType gsiPk;
+
+        public String getPk() {
+            return pk;
+        }
+
+        public void setPk(String pk) {
+            this.pk = pk;
+        }
+
+        public UnsupportedType getGsiPk() {
+            return gsiPk;
+        }
+
+        public void setGsiPk(UnsupportedType gsiPk) {
+            this.gsiPk = gsiPk;
+        }
+    }
+
+    static final class ArrayListGsiItem {
+        private String pk;
+        private ArrayList<String> gsiPk;
+
+        public String getPk() {
+            return pk;
+        }
+
+        public void setPk(String pk) {
+            this.pk = pk;
+        }
+
+        public ArrayList<String> getGsiPk() {
+            return gsiPk;
+        }
+
+        public void setGsiPk(ArrayList<String> gsiPk) {
+            this.gsiPk = gsiPk;
+        }
+    }
+
+    static final class CollectionGsiItem {
+        private String pk;
+        private Collection<String> gsiPk;
+
+        public String getPk() {
+            return pk;
+        }
+
+        public void setPk(String pk) {
+            this.pk = pk;
+        }
+
+        public Collection<String> getGsiPk() {
+            return gsiPk;
+        }
+
+        public void setGsiPk(Collection<String> gsiPk) {
+            this.gsiPk = gsiPk;
+        }
+    }
+
+    static final class IterableGsiItem {
+        private String pk;
+        private Iterable<String> gsiPk;
+
+        public String getPk() {
+            return pk;
+        }
+
+        public void setPk(String pk) {
+            this.pk = pk;
+        }
+
+        public Iterable<String> getGsiPk() {
+            return gsiPk;
+        }
+
+        public void setGsiPk(Iterable<String> gsiPk) {
+            this.gsiPk = gsiPk;
+        }
+    }
+
+    static final class CustomType {
+    }
+
+    static final class UnsupportedType {
+    }
+
+    static final class DocumentType {
+    }
+
+    static final class CustomTypeConverter implements AttributeConverter<CustomType> {
+        private final AttributeValueType attributeValueType;
+
+        CustomTypeConverter(AttributeValueType attributeValueType) {
+            this.attributeValueType = attributeValueType;
+        }
+
+        @Override
+        public AttributeValue transformFrom(CustomType input) {
+            if (attributeValueType == AttributeValueType.M) {
+                return AttributeValue.fromM(Collections.singletonMap("v", AttributeValue.fromS("x")));
+            }
+            if (attributeValueType == AttributeValueType.B) {
+                return AttributeValue.fromB(SdkBytes.fromUtf8String("x"));
+            }
+            return AttributeValue.fromS("custom:x");
+        }
+
+        @Override
+        public CustomType transformTo(AttributeValue input) {
+            return new CustomType();
+        }
+
+        @Override
+        public EnhancedType<CustomType> type() {
+            return EnhancedType.of(CustomType.class);
+        }
+
+        @Override
+        public AttributeValueType attributeValueType() {
+            return attributeValueType;
+        }
+    }
+
+    static final class RecordingCustomProvider implements AttributeConverterProvider {
+        private final List<EnhancedType<?>> requestedTypes = new ArrayList<>();
+        private final CustomTypeConverter converter;
+
+        RecordingCustomProvider(AttributeValueType attributeValueType) {
+            this.converter = new CustomTypeConverter(attributeValueType);
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> AttributeConverter<T> converterFor(EnhancedType<T> enhancedType) {
+            requestedTypes.add(enhancedType);
+            if (EnhancedType.of(CustomType.class).equals(enhancedType)) {
+                return (AttributeConverter<T>) converter;
+            }
+            return null;
+        }
+
+        List<EnhancedType<?>> requestedTypes() {
+            return requestedTypes;
+        }
+    }
+
+    static final class ObjectStringConverter implements AttributeConverter<Object> {
+        @Override
+        public AttributeValue transformFrom(Object input) {
+            return AttributeValue.fromS(String.valueOf(input));
+        }
+
+        @Override
+        public Object transformTo(AttributeValue input) {
+            return input.s();
+        }
+
+        @Override
+        public EnhancedType<Object> type() {
+            return EnhancedType.of(Object.class);
+        }
+
+        @Override
+        public AttributeValueType attributeValueType() {
+            return AttributeValueType.S;
+        }
+    }
+
+    static final class ObjectBinaryConverter implements AttributeConverter<Object> {
+        @Override
+        public AttributeValue transformFrom(Object input) {
+            return AttributeValue.fromB(SdkBytes.fromUtf8String(String.valueOf(input)));
+        }
+
+        @Override
+        public Object transformTo(AttributeValue input) {
+            return input.b().asUtf8String();
+        }
+
+        @Override
+        public EnhancedType<Object> type() {
+            return EnhancedType.of(Object.class);
+        }
+
+        @Override
+        public AttributeValueType attributeValueType() {
+            return AttributeValueType.B;
+        }
+    }
+
+    static final class ObjectProvider implements AttributeConverterProvider {
+        private final List<EnhancedType<?>> requestedTypes = new ArrayList<>();
+        private final ObjectStringConverter converter = new ObjectStringConverter();
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> AttributeConverter<T> converterFor(EnhancedType<T> enhancedType) {
+            requestedTypes.add(enhancedType);
+            if (EnhancedType.of(Object.class).equals(enhancedType)) {
+                return (AttributeConverter<T>) converter;
+            }
+            return null;
+        }
+
+        List<EnhancedType<?>> requestedTypes() {
+            return requestedTypes;
+        }
+    }
+
+    static final class ReturningNullProvider implements AttributeConverterProvider {
+        private final List<EnhancedType<?>> requestedTypes = new ArrayList<>();
+
+        @Override
+        public <T> AttributeConverter<T> converterFor(EnhancedType<T> enhancedType) {
+            requestedTypes.add(enhancedType);
+            return null;
+        }
+
+        List<EnhancedType<?>> requestedTypes() {
+            return requestedTypes;
+        }
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/StaticImmutableSchemaConverterTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/StaticImmutableSchemaConverterTest.java
@@ -1,0 +1,1606 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static software.amazon.awssdk.enhanced.dynamodb.mapper.StaticAttributeTags.primaryPartitionKey;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.DocumentAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.InstantAsStringAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.ListAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.MapAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.SetAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.StringAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.StaticImmutableTableSchema;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.StaticTableSchema;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+
+/**
+ * Tests converter selection and item conversion for static immutable table schemas.
+ * <p>
+ * The tests cover scalar, enumeration, collection, map, and schema backed document attributes. They also verify null
+ * handling, configured provider precedence, attribute converters, empty provider lists, recursive member lookup, and
+ * unsupported attribute declarations during schema construction.
+ */
+public class StaticImmutableSchemaConverterTest {
+
+    @Test
+    @DisplayName("Instant attribute selects InstantAsStringAttributeConverter and round-trips the input")
+    void converterForAttribute_whenInstantValue_selectsInstantConverterAndRebuildsEqualValue() {
+        Instant input = Instant.parse("2020-01-02T03:04:05Z");
+        InstantItem item = InstantItem.builder().id("id-1").value(input).build();
+        EnhancedType<Instant> type = EnhancedType.of(Instant.class);
+
+        StaticImmutableTableSchema<InstantItem, InstantItem.Builder> schema =
+            StaticImmutableTableSchema.builder(InstantItem.class, InstantItem.Builder.class)
+                .newItemBuilder(InstantItem.Builder::new, InstantItem.Builder::build)
+                .addAttribute(EnhancedType.of(String.class), a -> a.name("id")
+                    .getter(InstantItem::id).setter(InstantItem.Builder::id).tags(primaryPartitionKey()))
+                .addAttribute(type, a -> a.name("value")
+                    .getter(InstantItem::value).setter(InstantItem.Builder::value))
+                .build();
+
+        Map<String, AttributeValue> map = schema.itemToMap(item, true);
+        InstantItem read = schema.mapToItem(map);
+
+        assertThat(schema.converterForAttribute("value")).isInstanceOf(InstantAsStringAttributeConverter.class);
+        assertThat(schema.converterForAttribute("value").attributeValueType()).isEqualTo(AttributeValueType.S);
+        assertThat(read.value()).isEqualTo(input);
+    }
+
+    @Test
+    @DisplayName("List of String selects ListAttributeConverter and rebuilds an equal ArrayList")
+    void converterForAttribute_whenStringList_selectsListConverterAndRebuildsArrayList() {
+        List<String> input = new ArrayList<>(Arrays.asList("a", "a", "b"));
+        ListItem item = ListItem.builder().id("id-1").value(input).build();
+        EnhancedType<List<String>> type = EnhancedType.listOf(String.class);
+
+        StaticImmutableTableSchema<ListItem, ListItem.Builder> schema =
+            StaticImmutableTableSchema.builder(ListItem.class, ListItem.Builder.class)
+                .newItemBuilder(ListItem.Builder::new, ListItem.Builder::build)
+                .addAttribute(EnhancedType.of(String.class), a -> a.name("id")
+                    .getter(ListItem::id).setter(ListItem.Builder::id).tags(primaryPartitionKey()))
+                .addAttribute(type, a -> a.name("value")
+                    .getter(ListItem::value).setter(ListItem.Builder::value))
+                .build();
+
+        Map<String, AttributeValue> map = schema.itemToMap(item, true);
+        ListItem read = schema.mapToItem(map);
+
+        assertThat(schema.converterForAttribute("value")).isInstanceOf(ListAttributeConverter.class);
+        assertThat(schema.converterForAttribute("value").attributeValueType()).isEqualTo(AttributeValueType.L);
+        assertThat(read.value()).isEqualTo(input).isInstanceOf(ArrayList.class);
+    }
+
+    @Test
+    @DisplayName("Schema-bearing document attribute selects DocumentAttributeConverter and reconstructs")
+    void converterForAttribute_whenDocumentType_selectsDocumentConverterAndReconstructs() {
+        TableSchema<DocumentType> documentSchema = documentSchema();
+        DocumentType input = new DocumentType();
+        input.setName("doc");
+        DocumentItem item = DocumentItem.builder().id("id-1").value(input).build();
+        EnhancedType<DocumentType> type = EnhancedType.documentOf(DocumentType.class, documentSchema);
+
+        StaticImmutableTableSchema<DocumentItem, DocumentItem.Builder> schema =
+            StaticImmutableTableSchema.builder(DocumentItem.class, DocumentItem.Builder.class)
+                .newItemBuilder(DocumentItem.Builder::new, DocumentItem.Builder::build)
+                .addAttribute(EnhancedType.of(String.class), a -> a.name("id")
+                    .getter(DocumentItem::id).setter(DocumentItem.Builder::id).tags(primaryPartitionKey()))
+                .addAttribute(type, a -> a.name("value")
+                    .getter(DocumentItem::value).setter(DocumentItem.Builder::value))
+                .build();
+
+        Map<String, AttributeValue> map = schema.itemToMap(item, true);
+        DocumentItem read = schema.mapToItem(map);
+
+        assertThat(schema.converterForAttribute("value")).isInstanceOf(DocumentAttributeConverter.class);
+        assertThat(schema.converterForAttribute("value").attributeValueType()).isEqualTo(AttributeValueType.M);
+        assertThat(map.get("value").m()).containsEntry("name", AttributeValue.fromS("doc"));
+        assertThat(read.value().getName()).isEqualTo("doc");
+    }
+
+    @Test
+    @DisplayName("Null string is stored as DynamoDB NULL when ignore-nulls is false")
+    void itemToMap_whenNullStringIgnoreNullsFalse_containsNulValue() {
+        StringItem item = StringItem.builder().id("id-1").build();
+
+        Map<String, AttributeValue> map = stringSchema().itemToMap(item, false);
+
+        assertThat(map).containsEntry("value", AttributeValue.fromNul(true));
+    }
+
+    @Test
+    @DisplayName("Null string is omitted when ignore-nulls is true")
+    void itemToMap_whenNullStringIgnoreNullsTrue_omitsValue() {
+        StringItem item = StringItem.builder().id("id-1").build();
+
+        Map<String, AttributeValue> map = stringSchema().itemToMap(item, true);
+
+        assertThat(map).doesNotContainKey("value");
+    }
+
+    @Test
+    @DisplayName("DynamoDB NULL is skipped on read and leaves the builder method uncalled")
+    void mapToItem_whenNulValue_doesNotCallBuilderMethodAndLeavesValueNull() {
+        AtomicInteger valueCalls = new AtomicInteger();
+        StaticImmutableTableSchema<StringItem, StringItem.Builder> schema =
+            StaticImmutableTableSchema.builder(StringItem.class, StringItem.Builder.class)
+                .newItemBuilder(StringItem.Builder::new, StringItem.Builder::build)
+                .addAttribute(EnhancedType.of(String.class), a -> a.name("id")
+                    .getter(StringItem::id).setter(StringItem.Builder::id).tags(primaryPartitionKey()))
+                .addAttribute(EnhancedType.of(String.class), a -> a.name("value")
+                    .getter(StringItem::value)
+                    .setter((builder, value) -> {
+                        valueCalls.incrementAndGet();
+                        builder.value(value);
+                    }))
+                .build();
+        Map<String, AttributeValue> map = new LinkedHashMap<>();
+        map.put("id", AttributeValue.fromS("id-1"));
+        map.put("value", AttributeValue.fromNul(true));
+
+        StringItem read = schema.mapToItem(map);
+
+        assertThat(read).isNotNull();
+        assertThat(valueCalls.get()).isZero();
+        assertThat(read.value()).isNull();
+    }
+
+    @Test
+    @DisplayName("Unconverted Object attribute fails converter lookup")
+    void build_whenUnconvertedObject_throwsConverterNotFound() {
+        EnhancedType<Object> type = EnhancedType.of(Object.class);
+
+        assertThatThrownBy(() -> StaticImmutableTableSchema.builder(ObjectItem.class, ObjectItem.Builder.class)
+            .newItemBuilder(ObjectItem.Builder::new, ObjectItem.Builder::build)
+            .addAttribute(EnhancedType.of(String.class), a -> a.name("id")
+                .getter(ObjectItem::id).setter(ObjectItem.Builder::id).tags(primaryPartitionKey()))
+            .addAttribute(type, a -> a.name("value")
+                .getter(ObjectItem::value).setter(ObjectItem.Builder::value))
+            .build())
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + type);
+    }
+
+    @Test
+    @DisplayName("Unsupported attribute fails lookup with the enclosing type in the message")
+    void build_whenUnsupportedType_throwsConverterNotFound() {
+        EnhancedType<UnsupportedType> type = EnhancedType.of(UnsupportedType.class);
+
+        assertThatThrownBy(() ->
+            StaticImmutableTableSchema.builder(UnsupportedItem.class, UnsupportedItem.Builder.class)
+                .newItemBuilder(UnsupportedItem.Builder::new, UnsupportedItem.Builder::build)
+                .addAttribute(EnhancedType.of(String.class), a -> a.name("id")
+                    .getter(UnsupportedItem::id).setter(UnsupportedItem.Builder::id)
+                    .tags(primaryPartitionKey()))
+                .addAttribute(type, a -> a.name("value")
+                    .getter(UnsupportedItem::value).setter(UnsupportedItem.Builder::value))
+                .build())
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + type);
+    }
+
+    @Test
+    @DisplayName("Custom provider before default selects CustomTypeConverter")
+    void build_whenRecordingCustomBeforeDefault_selectsCustomTypeConverter() {
+        CustomType input = new CustomType("x");
+        CustomTypeItem item = CustomTypeItem.builder().value(input).build();
+        EnhancedType<CustomType> type = EnhancedType.of(CustomType.class);
+        RecordingCustomProvider custom = new RecordingCustomProvider();
+
+        StaticImmutableTableSchema<CustomTypeItem, CustomTypeItem.Builder> schema =
+            StaticImmutableTableSchema.builder(CustomTypeItem.class, CustomTypeItem.Builder.class)
+                .newItemBuilder(CustomTypeItem.Builder::new, CustomTypeItem.Builder::build)
+                .attributeConverterProviders(custom, DefaultAttributeConverterProvider.create())
+                .addAttribute(type, a -> a.name("value")
+                    .getter(CustomTypeItem::value).setter(CustomTypeItem.Builder::value)
+                    .tags(primaryPartitionKey()))
+                .build();
+
+        Map<String, AttributeValue> map = schema.itemToMap(item, true);
+        CustomTypeItem read = schema.mapToItem(map);
+
+        assertThat(custom.requestedTypes()).hasSize(2);
+        assertThat(schema.converterForAttribute("value")).isInstanceOf(CustomTypeConverter.class);
+        assertThat(schema.converterForAttribute("value").attributeValueType()).isEqualTo(AttributeValueType.S);
+        assertThat(read.value()).isEqualTo(input);
+    }
+
+    @Test
+    @DisplayName("Null-returning provider falls back to the default string converter")
+    void build_whenReturningNullBeforeDefault_selectsStringAttributeConverter() {
+        EnhancedType<String> type = EnhancedType.of(String.class);
+        ReturningNullProvider custom = new ReturningNullProvider();
+
+        StaticImmutableTableSchema<StringItem, StringItem.Builder> schema =
+            StaticImmutableTableSchema.builder(StringItem.class, StringItem.Builder.class)
+                .newItemBuilder(StringItem.Builder::new, StringItem.Builder::build)
+                .attributeConverterProviders(custom, DefaultAttributeConverterProvider.create())
+                .addAttribute(type, a -> a.name("value")
+                    .getter(StringItem::value).setter(StringItem.Builder::value).tags(primaryPartitionKey()))
+                .build();
+
+        assertThat(custom.requestedTypes()).hasSize(1);
+        assertThat(schema.converterForAttribute("value")).isInstanceOf(StringAttributeConverter.class);
+        assertThat(schema.converterForAttribute("value").attributeValueType()).isEqualTo(AttributeValueType.S);
+    }
+
+    @Test
+    @DisplayName("Default provider before custom blocks later custom fallback")
+    void build_whenDefaultBeforeRecordingCustom_throwsAndDoesNotInvokeCustom() {
+        EnhancedType<CustomType> type = EnhancedType.of(CustomType.class);
+        RecordingCustomProvider custom = new RecordingCustomProvider();
+
+        assertThatThrownBy(() ->
+            StaticImmutableTableSchema.builder(CustomTypeItem.class, CustomTypeItem.Builder.class)
+                .newItemBuilder(CustomTypeItem.Builder::new, CustomTypeItem.Builder::build)
+                .attributeConverterProviders(DefaultAttributeConverterProvider.create(), custom)
+                .addAttribute(type, a -> a.name("value")
+                    .getter(CustomTypeItem::value).setter(CustomTypeItem.Builder::value)
+                    .tags(primaryPartitionKey()))
+                .build())
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + type);
+        assertThat(custom.requestedTypes()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Throwing provider exception is propagated without consulting the default")
+    void build_whenThrowingProviderBeforeDefault_propagatesProviderFailure() {
+        EnhancedType<CustomType> type = EnhancedType.of(CustomType.class);
+        RecordingDefaultProvider defaultProvider = new RecordingDefaultProvider();
+
+        assertThatThrownBy(() ->
+            StaticImmutableTableSchema.builder(CustomTypeItem.class, CustomTypeItem.Builder.class)
+                .newItemBuilder(CustomTypeItem.Builder::new, CustomTypeItem.Builder::build)
+                .attributeConverterProviders(new ThrowingProvider(), defaultProvider)
+                .addAttribute(type, a -> a.name("value")
+                    .getter(CustomTypeItem::value).setter(CustomTypeItem.Builder::value)
+                    .tags(primaryPartitionKey()))
+                .build())
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Attribute converter provider failed while looking up " + type);
+        assertThat(defaultProvider.requestedTypes()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Static immutable ObjectProvider before default selects ObjectStringConverter")
+    void build_whenObjectProviderBeforeDefault_selectsObjectStringConverter() {
+        ObjectItem item = ObjectItem.builder().value(new Object()).build();
+        EnhancedType<Object> type = EnhancedType.of(Object.class);
+        ObjectProvider provider = new ObjectProvider();
+
+        StaticImmutableTableSchema<ObjectItem, ObjectItem.Builder> schema =
+            StaticImmutableTableSchema.builder(ObjectItem.class, ObjectItem.Builder.class)
+                .newItemBuilder(ObjectItem.Builder::new, ObjectItem.Builder::build)
+                .attributeConverterProviders(provider, DefaultAttributeConverterProvider.create())
+                .addAttribute(type, a -> a.name("value")
+                    .getter(ObjectItem::value).setter(ObjectItem.Builder::value)
+                    .tags(primaryPartitionKey()))
+                .build();
+
+        Map<String, AttributeValue> map = schema.itemToMap(item, true);
+        ObjectItem read = schema.mapToItem(map);
+
+        int objectRequestCount = 0;
+        for (EnhancedType<?> requestedType : provider.requestedTypes()) {
+            if (EnhancedType.of(Object.class).equals(requestedType)) {
+                objectRequestCount++;
+            }
+        }
+        assertThat(objectRequestCount).isEqualTo(2);
+        assertThat(schema.converterForAttribute("value")).isInstanceOf(ObjectStringConverter.class);
+        assertThat(read.value()).isEqualTo("custom");
+    }
+
+    @Test
+    @DisplayName("Attribute-level ObjectStringConverter intercepts Object without consulting the provider")
+    void converterForAttribute_whenObjectStringConverter_skipsProviderAndBuilderReceivesConverterValue() {
+        ObjectItem item = ObjectItem.builder().value(new Object()).build();
+        EnhancedType<Object> type = EnhancedType.of(Object.class);
+        ObjectProvider provider = new ObjectProvider();
+
+        StaticImmutableTableSchema<ObjectItem, ObjectItem.Builder> schema =
+            StaticImmutableTableSchema.builder(ObjectItem.class, ObjectItem.Builder.class)
+                .newItemBuilder(ObjectItem.Builder::new, ObjectItem.Builder::build)
+                .attributeConverterProviders(provider, DefaultAttributeConverterProvider.create())
+                .addAttribute(type, a -> a.name("value")
+                    .getter(ObjectItem::value).setter(ObjectItem.Builder::value).tags(primaryPartitionKey())
+                    .attributeConverter(new ObjectStringConverter()))
+                .build();
+
+        Map<String, AttributeValue> map = schema.itemToMap(item, true);
+        ObjectItem read = schema.mapToItem(map);
+
+        assertThat(schema.converterForAttribute("value")).isInstanceOf(ObjectStringConverter.class);
+        assertThat(schema.converterForAttribute("value").attributeValueType()).isEqualTo(AttributeValueType.S);
+        assertThat(provider.requestedTypes()).doesNotContain(type);
+        assertThat(read.value()).isEqualTo("custom");
+    }
+
+    @Test
+    @DisplayName("Attribute-level UnsupportedStringConverter intercepts an unsupported class")
+    void converterForAttribute_whenUnsupportedStringConverter_rebuildsEqualValue() {
+        UnsupportedType input = new UnsupportedType();
+        UnsupportedItem item = UnsupportedItem.builder().value(input).build();
+        EnhancedType<UnsupportedType> type = EnhancedType.of(UnsupportedType.class);
+
+        StaticImmutableTableSchema<UnsupportedItem, UnsupportedItem.Builder> schema =
+            StaticImmutableTableSchema.builder(UnsupportedItem.class, UnsupportedItem.Builder.class)
+                .newItemBuilder(UnsupportedItem.Builder::new, UnsupportedItem.Builder::build)
+                .addAttribute(type, a -> a.name("value")
+                    .getter(UnsupportedItem::value).setter(UnsupportedItem.Builder::value)
+                    .tags(primaryPartitionKey())
+                    .attributeConverter(new UnsupportedStringConverter()))
+                .build();
+
+        Map<String, AttributeValue> map = schema.itemToMap(item, true);
+        UnsupportedItem read = schema.mapToItem(map);
+
+        assertThat(schema.converterForAttribute("value")).isInstanceOf(UnsupportedStringConverter.class);
+        assertThat(schema.converterForAttribute("value").attributeValueType()).isEqualTo(AttributeValueType.S);
+        assertThat(read.value()).isEqualTo(input);
+    }
+
+    @Test
+    @DisplayName("Attribute-level LinkedListConverter intercepts a captured LinkedList type")
+    void converterForAttribute_whenLinkedListConverter_builderReceivesLinkedList() {
+        LinkedList<String> input = new LinkedList<>(Arrays.asList("a", "b"));
+        LinkedListItem item = LinkedListItem.builder().id("id-1").value(input).build();
+        EnhancedType<LinkedList<String>> type = new EnhancedType<LinkedList<String>>() {
+        };
+        AtomicReference<Object> assigned = new AtomicReference<>();
+
+        StaticImmutableTableSchema<LinkedListItem, LinkedListItem.Builder> schema =
+            StaticImmutableTableSchema.builder(LinkedListItem.class, LinkedListItem.Builder.class)
+                .newItemBuilder(LinkedListItem.Builder::new, LinkedListItem.Builder::build)
+                .addAttribute(EnhancedType.of(String.class), a -> a.name("id")
+                    .getter(LinkedListItem::id).setter(LinkedListItem.Builder::id)
+                    .tags(primaryPartitionKey()))
+                .addAttribute(type, a -> a.name("value")
+                    .getter(LinkedListItem::value)
+                    .setter((builder, value) -> {
+                        assigned.set(value);
+                        builder.value(value);
+                    })
+                    .attributeConverter(new LinkedListConverter()))
+                .build();
+
+        Map<String, AttributeValue> map = schema.itemToMap(item, true);
+        schema.mapToItem(map);
+
+        assertThat(schema.converterForAttribute("value")).isInstanceOf(LinkedListConverter.class);
+        assertThat(schema.converterForAttribute("value").type()).isEqualTo(type);
+        assertThat(assigned.get()).isInstanceOf(LinkedList.class);
+    }
+
+    @Test
+    @DisplayName("Empty providers fail without an attribute converter")
+    void build_whenEmptyProvidersWithoutAttributeConverter_throwsNullPointerException() {
+        EnhancedType<String> type = EnhancedType.of(String.class);
+
+        assertThatThrownBy(() -> StaticImmutableTableSchema.builder(StringItem.class, StringItem.Builder.class)
+            .newItemBuilder(StringItem.Builder::new, StringItem.Builder::build)
+            .attributeConverterProviders(Collections.emptyList())
+            .addAttribute(type, a -> a.name("value")
+                .getter(StringItem::value).setter(StringItem.Builder::value).tags(primaryPartitionKey()))
+            .build())
+            .isInstanceOf(NullPointerException.class)
+            .satisfies(ex -> assertThat(ex.getMessage() == null || ex.getMessage().contains("null")).isTrue());
+    }
+
+    @Test
+    @DisplayName("Attribute-level CustomStringConverter survives empty providers")
+    void itemToMap_whenEmptyProvidersWithCustomStringConverter_writesCustomText() {
+        StringItem item = StringItem.builder().value("text").build();
+        EnhancedType<String> type = EnhancedType.of(String.class);
+
+        StaticImmutableTableSchema<StringItem, StringItem.Builder> schema =
+            StaticImmutableTableSchema.builder(StringItem.class, StringItem.Builder.class)
+                .newItemBuilder(StringItem.Builder::new, StringItem.Builder::build)
+                .attributeConverterProviders(Collections.emptyList())
+                .addAttribute(type, a -> a.name("value")
+                    .getter(StringItem::value).setter(StringItem.Builder::value).tags(primaryPartitionKey())
+                    .attributeConverter(new CustomStringConverter()))
+                .build();
+
+        Map<String, AttributeValue> map = schema.itemToMap(item, true);
+        StringItem read = schema.mapToItem(map);
+
+        assertThat(schema.converterForAttribute("value")).isInstanceOf(CustomStringConverter.class);
+        assertThat(schema.converterForAttribute("value").attributeValueType()).isEqualTo(AttributeValueType.S);
+        assertThat(map.get("value").s()).isEqualTo("custom:text");
+        assertThat(read.value()).isEqualTo("text");
+    }
+
+    @Test
+    @DisplayName("Unconverted captured LinkedList fails lookup before assignment")
+    void build_whenUnconvertedLinkedList_throwsConverterNotFound() {
+        EnhancedType<LinkedList<String>> type = new EnhancedType<LinkedList<String>>() {
+        };
+
+        assertThatThrownBy(() ->
+            StaticImmutableTableSchema.builder(LinkedListItem.class, LinkedListItem.Builder.class)
+                .newItemBuilder(LinkedListItem.Builder::new, LinkedListItem.Builder::build)
+                .addAttribute(EnhancedType.of(String.class), a -> a.name("id")
+                    .getter(LinkedListItem::id).setter(LinkedListItem.Builder::id)
+                    .tags(primaryPartitionKey()))
+                .addAttribute(type, a -> a.name("value")
+                    .getter(LinkedListItem::value).setter(LinkedListItem.Builder::value))
+                .build())
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + type);
+    }
+
+    @Test
+    @DisplayName("Custom member converter is not consulted for an enclosing list token")
+    void build_whenListOfUnsupportedWithMemberProvider_throwsConverterNotFoundForMemberType() {
+        EnhancedType<List<UnsupportedType>> type = EnhancedType.listOf(UnsupportedType.class);
+        UnsupportedMemberProvider custom = new UnsupportedMemberProvider();
+
+        assertThatThrownBy(() ->
+            StaticImmutableTableSchema.builder(UnsupportedListItem.class, UnsupportedListItem.Builder.class)
+                .newItemBuilder(UnsupportedListItem.Builder::new, UnsupportedListItem.Builder::build)
+                .attributeConverterProviders(custom, DefaultAttributeConverterProvider.create())
+                .addAttribute(type, a -> a.name("value")
+                    .getter(UnsupportedListItem::value).setter(UnsupportedListItem.Builder::value))
+                .build())
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + EnhancedType.of(UnsupportedType.class));
+        assertThat(custom.requestedTypes()).containsExactly(type);
+    }
+
+    @Test
+    @DisplayName("Collection of String selects SetAttributeConverter and rebuilds a LinkedHashSet")
+    void converterForAttribute_whenStringCollection_selectsSetConverterAndRebuildsLinkedHashSet() {
+        Collection<String> input = new LinkedHashSet<>();
+        input.add("a");
+        input.add("b");
+        CollectionItem item = CollectionItem.builder().id("id-1").value(input).build();
+        EnhancedType<Collection<String>> type = EnhancedType.collectionOf(String.class);
+
+        StaticImmutableTableSchema<CollectionItem, CollectionItem.Builder> schema =
+            StaticImmutableTableSchema.builder(CollectionItem.class, CollectionItem.Builder.class)
+                .newItemBuilder(CollectionItem.Builder::new, CollectionItem.Builder::build)
+                .addAttribute(EnhancedType.of(String.class), a -> a.name("id")
+                    .getter(CollectionItem::id).setter(CollectionItem.Builder::id)
+                    .tags(primaryPartitionKey()))
+                .addAttribute(type, a -> a.name("value")
+                    .getter(CollectionItem::value).setter(CollectionItem.Builder::value))
+                .build();
+
+        Map<String, AttributeValue> map = schema.itemToMap(item, true);
+        CollectionItem read = schema.mapToItem(map);
+
+        assertThat(schema.converterForAttribute("value")).isInstanceOf(SetAttributeConverter.class);
+        assertThat(schema.converterForAttribute("value").attributeValueType()).isEqualTo(AttributeValueType.SS);
+        assertThat(read.value()).isInstanceOf(LinkedHashSet.class)
+                                .containsExactly("a", "b");
+    }
+
+    @Test
+    @DisplayName("Set of String selects SetAttributeConverter and rebuilds a LinkedHashSet")
+    void converterForAttribute_whenStringSet_selectsSetConverterAndRebuildsLinkedHashSet() {
+        Set<String> input = new LinkedHashSet<>();
+        input.add("a");
+        input.add("b");
+        SetItem item = SetItem.builder().id("id-1").value(input).build();
+        EnhancedType<Set<String>> type = EnhancedType.setOf(String.class);
+
+        StaticImmutableTableSchema<SetItem, SetItem.Builder> schema =
+            StaticImmutableTableSchema.builder(SetItem.class, SetItem.Builder.class)
+                .newItemBuilder(SetItem.Builder::new, SetItem.Builder::build)
+                .addAttribute(EnhancedType.of(String.class), a -> a.name("id")
+                    .getter(SetItem::id).setter(SetItem.Builder::id).tags(primaryPartitionKey()))
+                .addAttribute(type, a -> a.name("value")
+                    .getter(SetItem::value).setter(SetItem.Builder::value))
+                .build();
+
+        Map<String, AttributeValue> map = schema.itemToMap(item, true);
+        SetItem read = schema.mapToItem(map);
+
+        assertThat(schema.converterForAttribute("value")).isInstanceOf(SetAttributeConverter.class);
+        assertThat(schema.converterForAttribute("value").attributeValueType()).isEqualTo(AttributeValueType.SS);
+        assertThat(read.value()).isInstanceOf(LinkedHashSet.class)
+                                .containsExactly("a", "b");
+    }
+
+    @Test
+    @DisplayName("Map of String to Integer selects MapAttributeConverter and rebuilds a LinkedHashMap")
+    void converterForAttribute_whenStringIntegerMap_selectsMapConverterAndRebuildsLinkedHashMap() {
+        Map<String, Integer> input = new LinkedHashMap<>();
+        input.put("a", 1);
+        input.put("b", 2);
+        MapItem item = MapItem.builder().id("id-1").value(input).build();
+        EnhancedType<Map<String, Integer>> type = EnhancedType.mapOf(String.class, Integer.class);
+
+        StaticImmutableTableSchema<MapItem, MapItem.Builder> schema =
+            StaticImmutableTableSchema.builder(MapItem.class, MapItem.Builder.class)
+                .newItemBuilder(MapItem.Builder::new, MapItem.Builder::build)
+                .addAttribute(EnhancedType.of(String.class), a -> a.name("id")
+                    .getter(MapItem::id).setter(MapItem.Builder::id).tags(primaryPartitionKey()))
+                .addAttribute(type, a -> a.name("value")
+                    .getter(MapItem::value).setter(MapItem.Builder::value))
+                .build();
+
+        Map<String, AttributeValue> map = schema.itemToMap(item, true);
+        MapItem read = schema.mapToItem(map);
+
+        assertThat(schema.converterForAttribute("value")).isInstanceOf(MapAttributeConverter.class);
+        assertThat(schema.converterForAttribute("value").attributeValueType()).isEqualTo(AttributeValueType.M);
+        assertThat(read.value()).isEqualTo(input).isInstanceOf(LinkedHashMap.class);
+    }
+
+    @Test
+    @DisplayName("Enum attribute selects EnumAttributeConverter and round-trips")
+    void converterForAttribute_whenEnumValue_selectsEnumConverterAndReadsEqualValue() {
+        EnumItem item = EnumItem.builder().id("id-1").value(TestEnum.OPEN).build();
+        EnhancedType<TestEnum> type = EnhancedType.of(TestEnum.class);
+
+        StaticImmutableTableSchema<EnumItem, EnumItem.Builder> schema =
+            StaticImmutableTableSchema.builder(EnumItem.class, EnumItem.Builder.class)
+                .newItemBuilder(EnumItem.Builder::new, EnumItem.Builder::build)
+                .addAttribute(EnhancedType.of(String.class), a -> a.name("id")
+                    .getter(EnumItem::id).setter(EnumItem.Builder::id).tags(primaryPartitionKey()))
+                .addAttribute(type, a -> a.name("value")
+                    .getter(EnumItem::value).setter(EnumItem.Builder::value))
+                .build();
+
+        Map<String, AttributeValue> map = schema.itemToMap(item, true);
+        EnumItem read = schema.mapToItem(map);
+
+        assertThat(schema.converterForAttribute("value")).isInstanceOf(EnumAttributeConverter.class);
+        assertThat(schema.converterForAttribute("value").attributeValueType()).isEqualTo(AttributeValueType.S);
+        assertThat(map.get("value").s()).isEqualTo("OPEN");
+        assertThat(read.value()).isEqualTo(TestEnum.OPEN);
+    }
+
+    @Test
+    @DisplayName("Unconverted captured HashSet fails lookup before assignment")
+    void build_whenUnconvertedHashSet_throwsConverterNotFound() {
+        EnhancedType<HashSet<String>> type = new EnhancedType<HashSet<String>>() {
+        };
+
+        assertThatThrownBy(() -> StaticImmutableTableSchema.builder(HashSetItem.class, HashSetItem.Builder.class)
+            .newItemBuilder(HashSetItem.Builder::new, HashSetItem.Builder::build)
+            .addAttribute(EnhancedType.of(String.class), a -> a.name("id")
+                .getter(HashSetItem::id).setter(HashSetItem.Builder::id).tags(primaryPartitionKey()))
+            .addAttribute(type, a -> a.name("value")
+                .getter(HashSetItem::value).setter(HashSetItem.Builder::value))
+            .build())
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + type);
+    }
+
+    @Test
+    @DisplayName("Unconverted captured HashMap fails lookup before assignment")
+    void build_whenUnconvertedHashMap_throwsConverterNotFound() {
+        EnhancedType<HashMap<String, Integer>> type = new EnhancedType<HashMap<String, Integer>>() {
+        };
+
+        assertThatThrownBy(() -> StaticImmutableTableSchema.builder(HashMapItem.class, HashMapItem.Builder.class)
+            .newItemBuilder(HashMapItem.Builder::new, HashMapItem.Builder::build)
+            .addAttribute(EnhancedType.of(String.class), a -> a.name("id")
+                .getter(HashMapItem::id).setter(HashMapItem.Builder::id).tags(primaryPartitionKey()))
+            .addAttribute(type, a -> a.name("value")
+                .getter(HashMapItem::value).setter(HashMapItem.Builder::value))
+            .build())
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + type);
+    }
+
+    private static TableSchema<DocumentType> documentSchema() {
+        return StaticTableSchema.builder(DocumentType.class)
+                                .newItemSupplier(DocumentType::new)
+                                .addAttribute(String.class, a -> a.name("name")
+                                                                  .getter(DocumentType::getName)
+                                                                  .setter(DocumentType::setName))
+                                .build();
+    }
+
+    private static StaticImmutableTableSchema<StringItem, StringItem.Builder> stringSchema() {
+        return StaticImmutableTableSchema.builder(StringItem.class, StringItem.Builder.class)
+            .newItemBuilder(StringItem.Builder::new, StringItem.Builder::build)
+            .addAttribute(EnhancedType.of(String.class), a -> a.name("id")
+                .getter(StringItem::id).setter(StringItem.Builder::id).tags(primaryPartitionKey()))
+            .addAttribute(EnhancedType.of(String.class), a -> a.name("value")
+                .getter(StringItem::value).setter(StringItem.Builder::value))
+            .build();
+    }
+
+    static final class InstantItem {
+        private final String id;
+        private final Instant value;
+
+        private InstantItem(Builder b) {
+            this.id = b.id;
+            this.value = b.value;
+        }
+
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        public String id() {
+            return id;
+        }
+
+        public Instant value() {
+            return value;
+        }
+
+        public static final class Builder {
+            private String id;
+            private Instant value;
+
+            public Builder() {
+            }
+
+            public Builder id(String id) {
+                this.id = id;
+                return this;
+            }
+
+            public Builder value(Instant value) {
+                this.value = value;
+                return this;
+            }
+
+            public InstantItem build() {
+                return new InstantItem(this);
+            }
+        }
+    }
+
+    static final class ListItem {
+        private final String id;
+        private final List<String> value;
+
+        private ListItem(Builder b) {
+            this.id = b.id;
+            this.value = b.value;
+        }
+
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        public String id() {
+            return id;
+        }
+
+        public List<String> value() {
+            return value;
+        }
+
+        public static final class Builder {
+            private String id;
+            private List<String> value;
+
+            public Builder() {
+            }
+
+            public Builder id(String id) {
+                this.id = id;
+                return this;
+            }
+
+            public Builder value(List<String> value) {
+                this.value = value;
+                return this;
+            }
+
+            public ListItem build() {
+                return new ListItem(this);
+            }
+        }
+    }
+
+    static final class DocumentItem {
+        private final String id;
+        private final DocumentType value;
+
+        private DocumentItem(Builder b) {
+            this.id = b.id;
+            this.value = b.value;
+        }
+
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        public String id() {
+            return id;
+        }
+
+        public DocumentType value() {
+            return value;
+        }
+
+        public static final class Builder {
+            private String id;
+            private DocumentType value;
+
+            public Builder() {
+            }
+
+            public Builder id(String id) {
+                this.id = id;
+                return this;
+            }
+
+            public Builder value(DocumentType value) {
+                this.value = value;
+                return this;
+            }
+
+            public DocumentItem build() {
+                return new DocumentItem(this);
+            }
+        }
+    }
+
+    static final class StringItem {
+        private final String id;
+        private final String value;
+
+        private StringItem(Builder b) {
+            this.id = b.id;
+            this.value = b.value;
+        }
+
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        public String id() {
+            return id;
+        }
+
+        public String value() {
+            return value;
+        }
+
+        public static final class Builder {
+            private String id;
+            private String value;
+
+            public Builder() {
+            }
+
+            public Builder id(String id) {
+                this.id = id;
+                return this;
+            }
+
+            public Builder value(String value) {
+                this.value = value;
+                return this;
+            }
+
+            public StringItem build() {
+                return new StringItem(this);
+            }
+        }
+    }
+
+    static final class ObjectItem {
+        private final String id;
+        private final Object value;
+
+        private ObjectItem(Builder b) {
+            this.id = b.id;
+            this.value = b.value;
+        }
+
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        public String id() {
+            return id;
+        }
+
+        public Object value() {
+            return value;
+        }
+
+        public static final class Builder {
+            private String id;
+            private Object value;
+
+            public Builder() {
+            }
+
+            public Builder id(String id) {
+                this.id = id;
+                return this;
+            }
+
+            public Builder value(Object value) {
+                this.value = value;
+                return this;
+            }
+
+            public ObjectItem build() {
+                return new ObjectItem(this);
+            }
+        }
+    }
+
+    static final class UnsupportedItem {
+        private final String id;
+        private final UnsupportedType value;
+
+        private UnsupportedItem(Builder b) {
+            this.id = b.id;
+            this.value = b.value;
+        }
+
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        public String id() {
+            return id;
+        }
+
+        public UnsupportedType value() {
+            return value;
+        }
+
+        public static final class Builder {
+            private String id;
+            private UnsupportedType value;
+
+            public Builder() {
+            }
+
+            public Builder id(String id) {
+                this.id = id;
+                return this;
+            }
+
+            public Builder value(UnsupportedType value) {
+                this.value = value;
+                return this;
+            }
+
+            public UnsupportedItem build() {
+                return new UnsupportedItem(this);
+            }
+        }
+    }
+
+    static final class CustomTypeItem {
+        private final CustomType value;
+
+        private CustomTypeItem(Builder b) {
+            this.value = b.value;
+        }
+
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        public CustomType value() {
+            return value;
+        }
+
+        public static final class Builder {
+            private CustomType value;
+
+            public Builder() {
+            }
+
+            public Builder value(CustomType value) {
+                this.value = value;
+                return this;
+            }
+
+            public CustomTypeItem build() {
+                return new CustomTypeItem(this);
+            }
+        }
+    }
+
+    static final class LinkedListItem {
+        private final String id;
+        private final LinkedList<String> value;
+
+        private LinkedListItem(Builder b) {
+            this.id = b.id;
+            this.value = b.value;
+        }
+
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        public String id() {
+            return id;
+        }
+
+        public LinkedList<String> value() {
+            return value;
+        }
+
+        public static final class Builder {
+            private String id;
+            private LinkedList<String> value;
+
+            public Builder() {
+            }
+
+            public Builder id(String id) {
+                this.id = id;
+                return this;
+            }
+
+            public Builder value(LinkedList<String> value) {
+                this.value = value;
+                return this;
+            }
+
+            public LinkedListItem build() {
+                return new LinkedListItem(this);
+            }
+        }
+    }
+
+    static final class UnsupportedListItem {
+        private final String id;
+        private final List<UnsupportedType> value;
+
+        private UnsupportedListItem(Builder b) {
+            this.id = b.id;
+            this.value = b.value;
+        }
+
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        public String id() {
+            return id;
+        }
+
+        public List<UnsupportedType> value() {
+            return value;
+        }
+
+        public static final class Builder {
+            private String id;
+            private List<UnsupportedType> value;
+
+            public Builder() {
+            }
+
+            public Builder id(String id) {
+                this.id = id;
+                return this;
+            }
+
+            public Builder value(List<UnsupportedType> value) {
+                this.value = value;
+                return this;
+            }
+
+            public UnsupportedListItem build() {
+                return new UnsupportedListItem(this);
+            }
+        }
+    }
+
+    static final class CollectionItem {
+        private final String id;
+        private final Collection<String> value;
+
+        private CollectionItem(Builder b) {
+            this.id = b.id;
+            this.value = b.value;
+        }
+
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        public String id() {
+            return id;
+        }
+
+        public Collection<String> value() {
+            return value;
+        }
+
+        public static final class Builder {
+            private String id;
+            private Collection<String> value;
+
+            public Builder() {
+            }
+
+            public Builder id(String id) {
+                this.id = id;
+                return this;
+            }
+
+            public Builder value(Collection<String> value) {
+                this.value = value;
+                return this;
+            }
+
+            public CollectionItem build() {
+                return new CollectionItem(this);
+            }
+        }
+    }
+
+    static final class SetItem {
+        private final String id;
+        private final Set<String> value;
+
+        private SetItem(Builder b) {
+            this.id = b.id;
+            this.value = b.value;
+        }
+
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        public String id() {
+            return id;
+        }
+
+        public Set<String> value() {
+            return value;
+        }
+
+        public static final class Builder {
+            private String id;
+            private Set<String> value;
+
+            public Builder() {
+            }
+
+            public Builder id(String id) {
+                this.id = id;
+                return this;
+            }
+
+            public Builder value(Set<String> value) {
+                this.value = value;
+                return this;
+            }
+
+            public SetItem build() {
+                return new SetItem(this);
+            }
+        }
+    }
+
+    static final class MapItem {
+        private final String id;
+        private final Map<String, Integer> value;
+
+        private MapItem(Builder b) {
+            this.id = b.id;
+            this.value = b.value;
+        }
+
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        public String id() {
+            return id;
+        }
+
+        public Map<String, Integer> value() {
+            return value;
+        }
+
+        public static final class Builder {
+            private String id;
+            private Map<String, Integer> value;
+
+            public Builder() {
+            }
+
+            public Builder id(String id) {
+                this.id = id;
+                return this;
+            }
+
+            public Builder value(Map<String, Integer> value) {
+                this.value = value;
+                return this;
+            }
+
+            public MapItem build() {
+                return new MapItem(this);
+            }
+        }
+    }
+
+    static final class EnumItem {
+        private final String id;
+        private final TestEnum value;
+
+        private EnumItem(Builder b) {
+            this.id = b.id;
+            this.value = b.value;
+        }
+
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        public String id() {
+            return id;
+        }
+
+        public TestEnum value() {
+            return value;
+        }
+
+        public static final class Builder {
+            private String id;
+            private TestEnum value;
+
+            public Builder() {
+            }
+
+            public Builder id(String id) {
+                this.id = id;
+                return this;
+            }
+
+            public Builder value(TestEnum value) {
+                this.value = value;
+                return this;
+            }
+
+            public EnumItem build() {
+                return new EnumItem(this);
+            }
+        }
+    }
+
+    static final class HashSetItem {
+        private final String id;
+        private final HashSet<String> value;
+
+        private HashSetItem(Builder b) {
+            this.id = b.id;
+            this.value = b.value;
+        }
+
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        public String id() {
+            return id;
+        }
+
+        public HashSet<String> value() {
+            return value;
+        }
+
+        public static final class Builder {
+            private String id;
+            private HashSet<String> value;
+
+            public Builder() {
+            }
+
+            public Builder id(String id) {
+                this.id = id;
+                return this;
+            }
+
+            public Builder value(HashSet<String> value) {
+                this.value = value;
+                return this;
+            }
+
+            public HashSetItem build() {
+                return new HashSetItem(this);
+            }
+        }
+    }
+
+    static final class HashMapItem {
+        private final String id;
+        private final HashMap<String, Integer> value;
+
+        private HashMapItem(Builder b) {
+            this.id = b.id;
+            this.value = b.value;
+        }
+
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        public String id() {
+            return id;
+        }
+
+        public HashMap<String, Integer> value() {
+            return value;
+        }
+
+        public static final class Builder {
+            private String id;
+            private HashMap<String, Integer> value;
+
+            public Builder() {
+            }
+
+            public Builder id(String id) {
+                this.id = id;
+                return this;
+            }
+
+            public Builder value(HashMap<String, Integer> value) {
+                this.value = value;
+                return this;
+            }
+
+            public HashMapItem build() {
+                return new HashMapItem(this);
+            }
+        }
+    }
+
+    enum TestEnum {
+        OPEN,
+        CLOSED
+    }
+
+    static final class CustomType {
+        private final String value;
+
+        CustomType(String value) {
+            this.value = value;
+        }
+
+        String value() {
+            return value;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof CustomType)) {
+                return false;
+            }
+            CustomType that = (CustomType) o;
+            return Objects.equals(value, that.value);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(value);
+        }
+    }
+
+    static final class UnsupportedType {
+        @Override
+        public boolean equals(Object o) {
+            return o instanceof UnsupportedType;
+        }
+
+        @Override
+        public int hashCode() {
+            return 1;
+        }
+    }
+
+    static final class DocumentType {
+        private String name;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+
+    public static final class RecordingCustomProvider implements AttributeConverterProvider {
+        private static final ThreadLocal<RecordingCustomProvider> CURRENT = new ThreadLocal<>();
+        private final List<EnhancedType<?>> requestedTypes = new ArrayList<>();
+
+        public RecordingCustomProvider() {
+            CURRENT.set(this);
+        }
+
+        public static RecordingCustomProvider current() {
+            return CURRENT.get();
+        }
+
+        public List<EnhancedType<?>> requestedTypes() {
+            return requestedTypes;
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> AttributeConverter<T> converterFor(EnhancedType<T> enhancedType) {
+            requestedTypes.add(enhancedType);
+            if (EnhancedType.of(CustomType.class).equals(enhancedType)) {
+                return (AttributeConverter<T>) new CustomTypeConverter();
+            }
+            return null;
+        }
+    }
+
+    public static final class ReturningNullProvider implements AttributeConverterProvider {
+        private static final ThreadLocal<ReturningNullProvider> CURRENT = new ThreadLocal<>();
+        private final List<EnhancedType<?>> requestedTypes = new ArrayList<>();
+
+        public ReturningNullProvider() {
+            CURRENT.set(this);
+        }
+
+        public static ReturningNullProvider current() {
+            return CURRENT.get();
+        }
+
+        public List<EnhancedType<?>> requestedTypes() {
+            return requestedTypes;
+        }
+
+        @Override
+        public <T> AttributeConverter<T> converterFor(EnhancedType<T> enhancedType) {
+            requestedTypes.add(enhancedType);
+            return null;
+        }
+    }
+
+    public static final class ThrowingProvider implements AttributeConverterProvider {
+        public ThrowingProvider() {
+        }
+
+        @Override
+        public <T> AttributeConverter<T> converterFor(EnhancedType<T> enhancedType) {
+            throw new IllegalArgumentException("Attribute converter provider failed while looking up " + enhancedType);
+        }
+    }
+
+    public static final class ObjectProvider implements AttributeConverterProvider {
+        private static final ThreadLocal<ObjectProvider> CURRENT = new ThreadLocal<>();
+        private final List<EnhancedType<?>> requestedTypes = new ArrayList<>();
+
+        public ObjectProvider() {
+            CURRENT.set(this);
+        }
+
+        public static ObjectProvider current() {
+            return CURRENT.get();
+        }
+
+        public List<EnhancedType<?>> requestedTypes() {
+            return requestedTypes;
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> AttributeConverter<T> converterFor(EnhancedType<T> enhancedType) {
+            requestedTypes.add(enhancedType);
+            if (EnhancedType.of(Object.class).equals(enhancedType)) {
+                return (AttributeConverter<T>) new ObjectStringConverter();
+            }
+            return null;
+        }
+    }
+
+    static final class RecordingDefaultProvider implements AttributeConverterProvider {
+        private final List<EnhancedType<?>> requestedTypes = new ArrayList<>();
+        private final AttributeConverterProvider delegate = DefaultAttributeConverterProvider.create();
+
+        List<EnhancedType<?>> requestedTypes() {
+            return requestedTypes;
+        }
+
+        @Override
+        public <T> AttributeConverter<T> converterFor(EnhancedType<T> enhancedType) {
+            requestedTypes.add(enhancedType);
+            return delegate.converterFor(enhancedType);
+        }
+    }
+
+    static final class UnsupportedMemberProvider implements AttributeConverterProvider {
+        private final List<EnhancedType<?>> requestedTypes = new ArrayList<>();
+
+        List<EnhancedType<?>> requestedTypes() {
+            return requestedTypes;
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> AttributeConverter<T> converterFor(EnhancedType<T> enhancedType) {
+            requestedTypes.add(enhancedType);
+            if (EnhancedType.of(UnsupportedType.class).equals(enhancedType)) {
+                return (AttributeConverter<T>) new UnsupportedStringConverter();
+            }
+            return null;
+        }
+    }
+
+    public static final class CustomTypeConverter implements AttributeConverter<CustomType> {
+        public CustomTypeConverter() {
+        }
+
+        @Override
+        public AttributeValue transformFrom(CustomType input) {
+            return AttributeValue.fromS("custom:" + input.value());
+        }
+
+        @Override
+        public CustomType transformTo(AttributeValue input) {
+            return new CustomType(input.s().substring("custom:".length()));
+        }
+
+        @Override
+        public EnhancedType<CustomType> type() {
+            return EnhancedType.of(CustomType.class);
+        }
+
+        @Override
+        public AttributeValueType attributeValueType() {
+            return AttributeValueType.S;
+        }
+    }
+
+    public static final class CustomStringConverter implements AttributeConverter<String> {
+        public CustomStringConverter() {
+        }
+
+        @Override
+        public AttributeValue transformFrom(String input) {
+            return AttributeValue.fromS("custom:" + input);
+        }
+
+        @Override
+        public String transformTo(AttributeValue input) {
+            String stored = input.s();
+            return stored.startsWith("custom:") ? stored.substring("custom:".length()) : stored;
+        }
+
+        @Override
+        public EnhancedType<String> type() {
+            return EnhancedType.of(String.class);
+        }
+
+        @Override
+        public AttributeValueType attributeValueType() {
+            return AttributeValueType.S;
+        }
+    }
+
+    public static final class ObjectStringConverter implements AttributeConverter<Object> {
+        public ObjectStringConverter() {
+        }
+
+        @Override
+        public AttributeValue transformFrom(Object input) {
+            return AttributeValue.fromS("custom");
+        }
+
+        @Override
+        public Object transformTo(AttributeValue input) {
+            return input.s();
+        }
+
+        @Override
+        public EnhancedType<Object> type() {
+            return EnhancedType.of(Object.class);
+        }
+
+        @Override
+        public AttributeValueType attributeValueType() {
+            return AttributeValueType.S;
+        }
+    }
+
+    public static final class UnsupportedStringConverter implements AttributeConverter<UnsupportedType> {
+        public UnsupportedStringConverter() {
+        }
+
+        @Override
+        public AttributeValue transformFrom(UnsupportedType input) {
+            return AttributeValue.fromS("custom");
+        }
+
+        @Override
+        public UnsupportedType transformTo(AttributeValue input) {
+            return new UnsupportedType();
+        }
+
+        @Override
+        public EnhancedType<UnsupportedType> type() {
+            return EnhancedType.of(UnsupportedType.class);
+        }
+
+        @Override
+        public AttributeValueType attributeValueType() {
+            return AttributeValueType.S;
+        }
+    }
+
+    public static final class LinkedListConverter implements AttributeConverter<LinkedList<String>> {
+        private static final EnhancedType<LinkedList<String>> TYPE = new EnhancedType<LinkedList<String>>() {
+        };
+
+        public LinkedListConverter() {
+        }
+
+        @Override
+        public AttributeValue transformFrom(LinkedList<String> input) {
+            List<AttributeValue> values = new ArrayList<>();
+            for (String member : input) {
+                values.add(AttributeValue.fromS(member));
+            }
+            return AttributeValue.fromL(values);
+        }
+
+        @Override
+        public LinkedList<String> transformTo(AttributeValue input) {
+            LinkedList<String> result = new LinkedList<>();
+            for (AttributeValue member : input.l()) {
+                result.add(member.s());
+            }
+            return result;
+        }
+
+        @Override
+        public EnhancedType<LinkedList<String>> type() {
+            return TYPE;
+        }
+
+        @Override
+        public AttributeValueType attributeValueType() {
+            return AttributeValueType.L;
+        }
+    }
+
+}

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/StaticSchemaConverterTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/StaticSchemaConverterTest.java
@@ -1,0 +1,1322 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static software.amazon.awssdk.enhanced.dynamodb.mapper.StaticAttributeTags.primaryPartitionKey;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.DocumentAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.ListAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.MapAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.SetAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.StringAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.UuidAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.StaticTableSchema;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+
+/**
+ * Tests converter selection and item conversion for static table schemas.
+ * <p>
+ * The tests cover scalar, enumeration, collection, map, and schema backed document attributes. They also verify null
+ * handling, configured provider precedence, attribute converters, empty provider lists, recursive member lookup, and
+ * unsupported attribute declarations during schema construction.
+ */
+public class StaticSchemaConverterTest {
+
+    @Test
+    @DisplayName("UUID attribute selects UuidAttributeConverter and round-trips the input")
+    void converterForAttribute_whenUuidValue_selectsUuidConverterAndReadsEqualValue() {
+        UUID input = UUID.fromString("123e4567-e89b-12d3-a456-426614174000");
+        UuidItem item = new UuidItem();
+        item.setId("id-1");
+        item.setValue(input);
+        EnhancedType<UUID> type = EnhancedType.of(UUID.class);
+
+        StaticTableSchema<UuidItem> schema = StaticTableSchema.builder(UuidItem.class)
+            .newItemSupplier(UuidItem::new)
+            .addAttribute(EnhancedType.of(String.class), a -> a.name("id")
+                .getter(UuidItem::getId).setter(UuidItem::setId).tags(primaryPartitionKey()))
+            .addAttribute(type, a -> a.name("value")
+                .getter(UuidItem::getValue).setter(UuidItem::setValue))
+            .build();
+
+        Map<String, AttributeValue> map = schema.itemToMap(item, true);
+        UuidItem read = schema.mapToItem(map);
+
+        assertThat(schema.converterForAttribute("value")).isInstanceOf(UuidAttributeConverter.class);
+        assertThat(schema.converterForAttribute("value").attributeValueType()).isEqualTo(AttributeValueType.S);
+        assertThat(read.getValue()).isEqualTo(input);
+    }
+
+    @Test
+    @DisplayName("Map of String to Integer selects MapAttributeConverter and reads a LinkedHashMap")
+    void converterForAttribute_whenStringIntegerMap_selectsMapConverterAndReadsLinkedHashMap() {
+        Map<String, Integer> input = new LinkedHashMap<>();
+        input.put("a", 1);
+        input.put("b", 2);
+        MapItem item = new MapItem();
+        item.setId("id-1");
+        item.setValue(input);
+        EnhancedType<Map<String, Integer>> type = EnhancedType.mapOf(String.class, Integer.class);
+
+        StaticTableSchema<MapItem> schema = StaticTableSchema.builder(MapItem.class)
+            .newItemSupplier(MapItem::new)
+            .addAttribute(EnhancedType.of(String.class), a -> a.name("id")
+                .getter(MapItem::getId).setter(MapItem::setId).tags(primaryPartitionKey()))
+            .addAttribute(type, a -> a.name("value")
+                .getter(MapItem::getValue).setter(MapItem::setValue))
+            .build();
+
+        Map<String, AttributeValue> map = schema.itemToMap(item, true);
+        MapItem read = schema.mapToItem(map);
+
+        assertThat(schema.converterForAttribute("value")).isInstanceOf(MapAttributeConverter.class);
+        assertThat(schema.converterForAttribute("value").attributeValueType()).isEqualTo(AttributeValueType.M);
+        assertThat(read.getValue()).isEqualTo(input).isInstanceOf(LinkedHashMap.class);
+    }
+
+    @Test
+    @DisplayName("Schema-bearing document attribute selects DocumentAttributeConverter and reconstructs")
+    void converterForAttribute_whenDocumentType_selectsDocumentConverterAndReconstructs() {
+        TableSchema<DocumentType> documentSchema = documentSchema();
+        DocumentType input = new DocumentType();
+        input.setName("doc");
+        DocumentItem item = new DocumentItem();
+        item.setId("id-1");
+        item.setValue(input);
+        EnhancedType<DocumentType> type = EnhancedType.documentOf(DocumentType.class, documentSchema);
+
+        StaticTableSchema<DocumentItem> schema = StaticTableSchema.builder(DocumentItem.class)
+            .newItemSupplier(DocumentItem::new)
+            .addAttribute(EnhancedType.of(String.class), a -> a.name("id")
+                .getter(DocumentItem::getId).setter(DocumentItem::setId).tags(primaryPartitionKey()))
+            .addAttribute(type, a -> a.name("value")
+                .getter(DocumentItem::getValue).setter(DocumentItem::setValue))
+            .build();
+
+        Map<String, AttributeValue> map = schema.itemToMap(item, true);
+        DocumentItem read = schema.mapToItem(map);
+
+        assertThat(schema.converterForAttribute("value")).isInstanceOf(DocumentAttributeConverter.class);
+        assertThat(schema.converterForAttribute("value").attributeValueType()).isEqualTo(AttributeValueType.M);
+        assertThat(map.get("value").m()).containsEntry("name", AttributeValue.fromS("doc"));
+        assertThat(read.getValue().getName()).isEqualTo("doc");
+    }
+
+    @Test
+    @DisplayName("Null string is stored as DynamoDB NULL when ignore-nulls is false")
+    void itemToMap_whenNullStringIgnoreNullsFalse_containsNulValue() {
+        StringItem item = new StringItem();
+        item.setId("id-1");
+        StaticTableSchema<StringItem> schema = stringSchema();
+
+        Map<String, AttributeValue> map = schema.itemToMap(item, false);
+
+        assertThat(map).containsEntry("value", AttributeValue.fromNul(true));
+    }
+
+    @Test
+    @DisplayName("Null string is omitted when ignore-nulls is true")
+    void itemToMap_whenNullStringIgnoreNullsTrue_omitsValue() {
+        StringItem item = new StringItem();
+        item.setId("id-1");
+        StaticTableSchema<StringItem> schema = stringSchema();
+
+        Map<String, AttributeValue> map = schema.itemToMap(item, true);
+
+        assertThat(map).doesNotContainKey("value");
+    }
+
+    @Test
+    @DisplayName("DynamoDB NULL is skipped on read and leaves the setter uncalled")
+    void mapToItem_whenNulValue_doesNotCallSetterAndLeavesValueNull() {
+        AtomicInteger setterCalls = new AtomicInteger();
+        StaticTableSchema<StringItem> schema = StaticTableSchema.builder(StringItem.class)
+            .newItemSupplier(StringItem::new)
+            .addAttribute(EnhancedType.of(String.class), a -> a.name("id")
+                .getter(StringItem::getId).setter(StringItem::setId).tags(primaryPartitionKey()))
+            .addAttribute(EnhancedType.of(String.class), a -> a.name("value")
+                .getter(StringItem::getValue)
+                .setter((item, value) -> {
+                    setterCalls.incrementAndGet();
+                    item.setValue(value);
+                }))
+            .build();
+        Map<String, AttributeValue> map = new LinkedHashMap<>();
+        map.put("id", AttributeValue.fromS("id-1"));
+        map.put("value", AttributeValue.fromNul(true));
+
+        StringItem read = schema.mapToItem(map);
+
+        assertThat(read).isNotNull();
+        assertThat(setterCalls.get()).isZero();
+        assertThat(read.getValue()).isNull();
+    }
+
+    @Test
+    @DisplayName("Unconverted Object attribute fails converter lookup")
+    void build_whenUnconvertedObject_throwsConverterNotFound() {
+        EnhancedType<Object> type = EnhancedType.of(Object.class);
+
+        assertThatThrownBy(() -> StaticTableSchema.builder(ObjectItem.class)
+            .newItemSupplier(ObjectItem::new)
+            .addAttribute(EnhancedType.of(String.class), a -> a.name("id")
+                .getter(ObjectItem::getId).setter(ObjectItem::setId).tags(primaryPartitionKey()))
+            .addAttribute(type, a -> a.name("value")
+                .getter(ObjectItem::getValue).setter(ObjectItem::setValue))
+            .build())
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + type);
+    }
+
+    @Test
+    @DisplayName("Unsupported attribute fails lookup with the enclosing type in the message")
+    void build_whenUnsupportedType_throwsConverterNotFound() {
+        EnhancedType<UnsupportedType> type = EnhancedType.of(UnsupportedType.class);
+
+        assertThatThrownBy(() -> StaticTableSchema.builder(UnsupportedItem.class)
+            .newItemSupplier(UnsupportedItem::new)
+            .addAttribute(EnhancedType.of(String.class), a -> a.name("id")
+                .getter(UnsupportedItem::getId).setter(UnsupportedItem::setId).tags(primaryPartitionKey()))
+            .addAttribute(type, a -> a.name("value")
+                .getter(UnsupportedItem::getValue).setter(UnsupportedItem::setValue))
+            .build())
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + type);
+    }
+
+    @Test
+    @DisplayName("Custom provider before default selects CustomTypeConverter")
+    void build_whenRecordingCustomBeforeDefault_selectsCustomTypeConverter() {
+        CustomType input = new CustomType("x");
+        CustomTypeItem item = new CustomTypeItem();
+        item.setValue(input);
+        EnhancedType<CustomType> type = EnhancedType.of(CustomType.class);
+        RecordingCustomProvider custom = new RecordingCustomProvider();
+
+        StaticTableSchema<CustomTypeItem> schema = StaticTableSchema.builder(CustomTypeItem.class)
+            .newItemSupplier(CustomTypeItem::new)
+            .attributeConverterProviders(custom, DefaultAttributeConverterProvider.create())
+            .addAttribute(type, a -> a.name("value")
+                .getter(CustomTypeItem::getValue).setter(CustomTypeItem::setValue).tags(primaryPartitionKey()))
+            .build();
+
+        Map<String, AttributeValue> map = schema.itemToMap(item, true);
+        CustomTypeItem read = schema.mapToItem(map);
+
+        assertThat(custom.requestedTypes()).hasSize(2);
+        assertThat(schema.converterForAttribute("value")).isInstanceOf(CustomTypeConverter.class);
+        assertThat(schema.converterForAttribute("value").attributeValueType()).isEqualTo(AttributeValueType.S);
+        assertThat(read.getValue()).isEqualTo(input);
+    }
+
+    @Test
+    @DisplayName("Null-returning provider falls back to the default string converter")
+    void build_whenReturningNullBeforeDefault_selectsStringAttributeConverter() {
+        EnhancedType<String> type = EnhancedType.of(String.class);
+        ReturningNullProvider custom = new ReturningNullProvider();
+
+        StaticTableSchema<StringItem> schema = StaticTableSchema.builder(StringItem.class)
+            .newItemSupplier(StringItem::new)
+            .attributeConverterProviders(custom, DefaultAttributeConverterProvider.create())
+            .addAttribute(type, a -> a.name("value")
+                .getter(StringItem::getValue).setter(StringItem::setValue).tags(primaryPartitionKey()))
+            .build();
+
+        assertThat(custom.requestedTypes()).hasSize(1);
+        assertThat(schema.converterForAttribute("value")).isInstanceOf(StringAttributeConverter.class);
+        assertThat(schema.converterForAttribute("value").attributeValueType()).isEqualTo(AttributeValueType.S);
+    }
+
+    @Test
+    @DisplayName("Default provider before custom blocks later custom fallback")
+    void build_whenDefaultBeforeRecordingCustom_throwsAndDoesNotInvokeCustom() {
+        EnhancedType<CustomType> type = EnhancedType.of(CustomType.class);
+        RecordingCustomProvider custom = new RecordingCustomProvider();
+
+        assertThatThrownBy(() -> StaticTableSchema.builder(CustomTypeItem.class)
+            .newItemSupplier(CustomTypeItem::new)
+            .attributeConverterProviders(DefaultAttributeConverterProvider.create(), custom)
+            .addAttribute(type, a -> a.name("value")
+                .getter(CustomTypeItem::getValue).setter(CustomTypeItem::setValue).tags(primaryPartitionKey()))
+            .build())
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + type);
+        assertThat(custom.requestedTypes()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Throwing provider exception is propagated without consulting the default")
+    void build_whenThrowingProviderBeforeDefault_propagatesProviderFailure() {
+        EnhancedType<CustomType> type = EnhancedType.of(CustomType.class);
+        RecordingDefaultProvider defaultProvider = new RecordingDefaultProvider();
+
+        assertThatThrownBy(() -> StaticTableSchema.builder(CustomTypeItem.class)
+            .newItemSupplier(CustomTypeItem::new)
+            .attributeConverterProviders(new ThrowingProvider(), defaultProvider)
+            .addAttribute(type, a -> a.name("value")
+                .getter(CustomTypeItem::getValue).setter(CustomTypeItem::setValue).tags(primaryPartitionKey()))
+            .build())
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Attribute converter provider failed while looking up " + type);
+        assertThat(defaultProvider.requestedTypes()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Static mutable ObjectProvider before default selects ObjectStringConverter")
+    void build_whenObjectProviderBeforeDefault_selectsObjectStringConverter() {
+        ObjectItem item = new ObjectItem();
+        item.setValue(new Object());
+        EnhancedType<Object> type = EnhancedType.of(Object.class);
+        ObjectProvider provider = new ObjectProvider();
+
+        StaticTableSchema<ObjectItem> schema = StaticTableSchema.builder(ObjectItem.class)
+            .newItemSupplier(ObjectItem::new)
+            .attributeConverterProviders(provider, DefaultAttributeConverterProvider.create())
+            .addAttribute(type, a -> a.name("value")
+                .getter(ObjectItem::getValue).setter(ObjectItem::setValue).tags(primaryPartitionKey()))
+            .build();
+
+        Map<String, AttributeValue> map = schema.itemToMap(item, true);
+        ObjectItem read = schema.mapToItem(map);
+
+        int objectRequestCount = 0;
+        for (EnhancedType<?> requestedType : provider.requestedTypes()) {
+            if (EnhancedType.of(Object.class).equals(requestedType)) {
+                objectRequestCount++;
+            }
+        }
+        assertThat(objectRequestCount).isEqualTo(2);
+        assertThat(schema.converterForAttribute("value")).isInstanceOf(ObjectStringConverter.class);
+        assertThat(read.getValue()).isEqualTo("custom");
+    }
+
+    @Test
+    @DisplayName("Custom provider intercepts a captured HashMap token before the default")
+    void build_whenHashMapProviderBeforeDefault_selectsHashMapConverter() {
+        HashMap<String, Integer> input = new HashMap<>();
+        input.put("a", 1);
+        HashMapItem item = new HashMapItem();
+        item.setId("id-1");
+        item.setValue(input);
+        EnhancedType<HashMap<String, Integer>> type = new EnhancedType<HashMap<String, Integer>>() {
+        };
+        ExactTypeProvider custom = new ExactTypeProvider(type, new HashMapConverter());
+        AtomicReference<Object> assigned = new AtomicReference<>();
+
+        StaticTableSchema<HashMapItem> schema = StaticTableSchema.builder(HashMapItem.class)
+            .newItemSupplier(HashMapItem::new)
+            .attributeConverterProviders(custom, DefaultAttributeConverterProvider.create())
+            .addAttribute(EnhancedType.of(String.class), a -> a.name("id")
+                .getter(HashMapItem::getId).setter(HashMapItem::setId).tags(primaryPartitionKey()))
+            .addAttribute(type, a -> a.name("value")
+                .getter(HashMapItem::getValue)
+                .setter((model, value) -> {
+                    assigned.set(value);
+                    model.setValue(value);
+                }))
+            .build();
+
+        Map<String, AttributeValue> map = schema.itemToMap(item, true);
+        schema.mapToItem(map);
+
+        assertThat(custom.requestCountFor(type)).isEqualTo(2);
+        assertThat(schema.converterForAttribute("value")).isInstanceOf(HashMapConverter.class);
+        assertThat(schema.converterForAttribute("value").attributeValueType()).isEqualTo(AttributeValueType.M);
+        assertThat(assigned.get()).isInstanceOf(HashMap.class);
+    }
+
+    @Test
+    @DisplayName("Attribute-level converter intercepts a schema-bearing Object token")
+    void build_whenDocumentObjectWithAttributeConverter_skipsProvider() {
+        ObjectItem item = new ObjectItem();
+        item.setId("id-1");
+        item.setValue(new Object());
+        TableSchema<Object> objectSchema =
+            StaticTableSchema.builder(Object.class).newItemSupplier(Object::new).build();
+        EnhancedType<Object> type = EnhancedType.documentOf(Object.class, objectSchema);
+        ReturningNullProvider provider = new ReturningNullProvider();
+        AtomicReference<Object> assigned = new AtomicReference<>();
+
+        StaticTableSchema<ObjectItem> schema = StaticTableSchema.builder(ObjectItem.class)
+            .newItemSupplier(ObjectItem::new)
+            .attributeConverterProviders(provider, DefaultAttributeConverterProvider.create())
+            .addAttribute(EnhancedType.of(String.class), a -> a.name("id")
+                .getter(ObjectItem::getId).setter(ObjectItem::setId).tags(primaryPartitionKey()))
+            .addAttribute(type, a -> a.name("value")
+                .getter(ObjectItem::getValue)
+                .setter((model, value) -> {
+                    assigned.set(value);
+                    model.setValue(value);
+                })
+                .attributeConverter(new ObjectStringConverter()))
+            .build();
+
+        Map<String, AttributeValue> map = schema.itemToMap(item, true);
+        schema.mapToItem(map);
+
+        assertThat(provider.requestedTypes()).doesNotContain(type);
+        assertThat(schema.converterForAttribute("value")).isInstanceOf(ObjectStringConverter.class);
+        assertThat(schema.converterForAttribute("value").attributeValueType()).isEqualTo(AttributeValueType.S);
+        assertThat(assigned.get()).isEqualTo("custom");
+    }
+
+    @Test
+    @DisplayName("Attribute-level ObjectStringConverter intercepts Object without consulting the provider")
+    void converterForAttribute_whenObjectStringConverter_skipsProviderAndReadsConverterValue() {
+        ObjectItem item = new ObjectItem();
+        item.setValue(new Object());
+        EnhancedType<Object> type = EnhancedType.of(Object.class);
+        ObjectProvider provider = new ObjectProvider();
+
+        StaticTableSchema<ObjectItem> schema = StaticTableSchema.builder(ObjectItem.class)
+            .newItemSupplier(ObjectItem::new)
+            .attributeConverterProviders(provider, DefaultAttributeConverterProvider.create())
+            .addAttribute(type, a -> a.name("value")
+                .getter(ObjectItem::getValue).setter(ObjectItem::setValue).tags(primaryPartitionKey())
+                .attributeConverter(new ObjectStringConverter()))
+            .build();
+
+        Map<String, AttributeValue> map = schema.itemToMap(item, true);
+        ObjectItem read = schema.mapToItem(map);
+
+        assertThat(schema.converterForAttribute("value")).isInstanceOf(ObjectStringConverter.class);
+        assertThat(schema.converterForAttribute("value").attributeValueType()).isEqualTo(AttributeValueType.S);
+        assertThat(provider.requestedTypes()).doesNotContain(type);
+        assertThat(read.getValue()).isEqualTo("custom");
+    }
+
+    @Test
+    @DisplayName("Attribute-level UnsupportedStringConverter intercepts an unsupported class")
+    void converterForAttribute_whenUnsupportedStringConverter_readsEqualValue() {
+        UnsupportedType input = new UnsupportedType();
+        UnsupportedItem item = new UnsupportedItem();
+        item.setValue(input);
+        EnhancedType<UnsupportedType> type = EnhancedType.of(UnsupportedType.class);
+
+        StaticTableSchema<UnsupportedItem> schema = StaticTableSchema.builder(UnsupportedItem.class)
+            .newItemSupplier(UnsupportedItem::new)
+            .addAttribute(type, a -> a.name("value")
+                .getter(UnsupportedItem::getValue).setter(UnsupportedItem::setValue)
+                .tags(primaryPartitionKey())
+                .attributeConverter(new UnsupportedStringConverter()))
+            .build();
+
+        Map<String, AttributeValue> map = schema.itemToMap(item, true);
+        UnsupportedItem read = schema.mapToItem(map);
+
+        assertThat(schema.converterForAttribute("value")).isInstanceOf(UnsupportedStringConverter.class);
+        assertThat(schema.converterForAttribute("value").attributeValueType()).isEqualTo(AttributeValueType.S);
+        assertThat(read.getValue()).isEqualTo(input);
+    }
+
+    @Test
+    @DisplayName("Attribute-level HashMapConverter intercepts a captured HashMap type")
+    void converterForAttribute_whenHashMapConverter_setterReceivesHashMap() {
+        HashMap<String, Integer> input = new HashMap<>();
+        input.put("a", 1);
+        HashMapItem item = new HashMapItem();
+        item.setId("id-1");
+        item.setValue(input);
+        EnhancedType<HashMap<String, Integer>> type = new EnhancedType<HashMap<String, Integer>>() {
+        };
+        AtomicReference<Object> assigned = new AtomicReference<>();
+
+        StaticTableSchema<HashMapItem> schema = StaticTableSchema.builder(HashMapItem.class)
+            .newItemSupplier(HashMapItem::new)
+            .addAttribute(EnhancedType.of(String.class), a -> a.name("id")
+                .getter(HashMapItem::getId).setter(HashMapItem::setId).tags(primaryPartitionKey()))
+            .addAttribute(type, a -> a.name("value")
+                .getter(HashMapItem::getValue)
+                .setter((model, value) -> {
+                    assigned.set(value);
+                    model.setValue(value);
+                })
+                .attributeConverter(new HashMapConverter()))
+            .build();
+
+        Map<String, AttributeValue> map = schema.itemToMap(item, true);
+        schema.mapToItem(map);
+
+        assertThat(schema.converterForAttribute("value")).isInstanceOf(HashMapConverter.class);
+        assertThat(schema.converterForAttribute("value").type()).isEqualTo(type);
+        assertThat(assigned.get()).isInstanceOf(HashMap.class);
+    }
+
+    @Test
+    @DisplayName("Empty providers fail without an attribute converter")
+    void build_whenEmptyProvidersWithoutAttributeConverter_throwsNullPointerException() {
+        EnhancedType<String> type = EnhancedType.of(String.class);
+
+        assertThatThrownBy(() -> StaticTableSchema.builder(StringItem.class)
+            .newItemSupplier(StringItem::new)
+            .attributeConverterProviders(Collections.emptyList())
+            .addAttribute(type, a -> a.name("value")
+                .getter(StringItem::getValue).setter(StringItem::setValue).tags(primaryPartitionKey()))
+            .build())
+            .isInstanceOf(NullPointerException.class)
+            .satisfies(ex -> assertThat(ex.getMessage() == null || ex.getMessage().contains("null")).isTrue());
+    }
+
+    @Test
+    @DisplayName("Attribute-level CustomStringConverter survives empty providers")
+    void itemToMap_whenEmptyProvidersWithCustomStringConverter_writesCustomText() {
+        StringItem item = new StringItem();
+        item.setValue("text");
+        EnhancedType<String> type = EnhancedType.of(String.class);
+
+        StaticTableSchema<StringItem> schema = StaticTableSchema.builder(StringItem.class)
+            .newItemSupplier(StringItem::new)
+            .attributeConverterProviders(Collections.emptyList())
+            .addAttribute(type, a -> a.name("value")
+                .getter(StringItem::getValue).setter(StringItem::setValue).tags(primaryPartitionKey())
+                .attributeConverter(new CustomStringConverter()))
+            .build();
+
+        Map<String, AttributeValue> map = schema.itemToMap(item, true);
+        StringItem read = schema.mapToItem(map);
+
+        assertThat(schema.converterForAttribute("value")).isInstanceOf(CustomStringConverter.class);
+        assertThat(schema.converterForAttribute("value").attributeValueType()).isEqualTo(AttributeValueType.S);
+        assertThat(map.get("value").s()).isEqualTo("custom:text");
+        assertThat(read.getValue()).isEqualTo("text");
+    }
+
+    @Test
+    @DisplayName("Unconverted captured HashMap fails lookup before assignment")
+    void build_whenUnconvertedHashMap_throwsConverterNotFound() {
+        EnhancedType<HashMap<String, Integer>> type = new EnhancedType<HashMap<String, Integer>>() {
+        };
+
+        assertThatThrownBy(() -> StaticTableSchema.builder(HashMapItem.class)
+            .newItemSupplier(HashMapItem::new)
+            .addAttribute(EnhancedType.of(String.class), a -> a.name("id")
+                .getter(HashMapItem::getId).setter(HashMapItem::setId).tags(primaryPartitionKey()))
+            .addAttribute(type, a -> a.name("value")
+                .getter(HashMapItem::getValue).setter(HashMapItem::setValue))
+            .build())
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + type);
+    }
+
+    @Test
+    @DisplayName("Custom member converter is not consulted for an enclosing map token")
+    void build_whenMapOfUnsupportedWithMemberProvider_throwsConverterNotFoundForMapType() {
+        EnhancedType<Map<String, UnsupportedType>> type =
+            EnhancedType.mapOf(String.class, UnsupportedType.class);
+        UnsupportedMemberProvider custom = new UnsupportedMemberProvider();
+
+        assertThatThrownBy(() -> StaticTableSchema.builder(UnsupportedMapItem.class)
+            .newItemSupplier(UnsupportedMapItem::new)
+            .attributeConverterProviders(custom, DefaultAttributeConverterProvider.create())
+            .addAttribute(type, a -> a.name("value")
+                .getter(UnsupportedMapItem::getValue).setter(UnsupportedMapItem::setValue))
+            .build())
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + EnhancedType.of(UnsupportedType.class));
+        assertThat(custom.requestedTypes()).containsExactly(type);
+    }
+
+    @Test
+    @DisplayName("Collection of String selects SetAttributeConverter and reads a LinkedHashSet")
+    void converterForAttribute_whenStringCollection_selectsSetConverterAndReadsLinkedHashSet() {
+        Collection<String> input = new LinkedHashSet<>();
+        input.add("a");
+        input.add("b");
+        CollectionItem item = new CollectionItem();
+        item.setId("id-1");
+        item.setValue(input);
+        EnhancedType<Collection<String>> type = EnhancedType.collectionOf(String.class);
+
+        StaticTableSchema<CollectionItem> schema = StaticTableSchema.builder(CollectionItem.class)
+            .newItemSupplier(CollectionItem::new)
+            .addAttribute(EnhancedType.of(String.class), a -> a.name("id")
+                .getter(CollectionItem::getId).setter(CollectionItem::setId).tags(primaryPartitionKey()))
+            .addAttribute(type, a -> a.name("value")
+                .getter(CollectionItem::getValue).setter(CollectionItem::setValue))
+            .build();
+
+        Map<String, AttributeValue> map = schema.itemToMap(item, true);
+        CollectionItem read = schema.mapToItem(map);
+
+        assertThat(schema.converterForAttribute("value")).isInstanceOf(SetAttributeConverter.class);
+        assertThat(schema.converterForAttribute("value").attributeValueType()).isEqualTo(AttributeValueType.SS);
+        assertThat(read.getValue()).isInstanceOf(LinkedHashSet.class)
+                                   .containsExactly("a", "b");
+    }
+
+    @Test
+    @DisplayName("List of String selects ListAttributeConverter and reads an ArrayList")
+    void converterForAttribute_whenStringList_selectsListConverterAndReadsArrayList() {
+        List<String> input = new ArrayList<>();
+        input.add("a");
+        input.add("b");
+        input.add("a");
+        ListItem item = new ListItem();
+        item.setId("id-1");
+        item.setValue(input);
+        EnhancedType<List<String>> type = EnhancedType.listOf(String.class);
+
+        StaticTableSchema<ListItem> schema = StaticTableSchema.builder(ListItem.class)
+            .newItemSupplier(ListItem::new)
+            .addAttribute(EnhancedType.of(String.class), a -> a.name("id")
+                .getter(ListItem::getId).setter(ListItem::setId).tags(primaryPartitionKey()))
+            .addAttribute(type, a -> a.name("value")
+                .getter(ListItem::getValue).setter(ListItem::setValue))
+            .build();
+
+        Map<String, AttributeValue> map = schema.itemToMap(item, true);
+        ListItem read = schema.mapToItem(map);
+
+        assertThat(schema.converterForAttribute("value")).isInstanceOf(ListAttributeConverter.class);
+        assertThat(schema.converterForAttribute("value").attributeValueType()).isEqualTo(AttributeValueType.L);
+        assertThat(read.getValue()).isInstanceOf(ArrayList.class)
+                                   .containsExactly("a", "b", "a");
+    }
+
+    @Test
+    @DisplayName("Set of String selects SetAttributeConverter and reads a LinkedHashSet")
+    void converterForAttribute_whenStringSet_selectsSetConverterAndReadsLinkedHashSet() {
+        Set<String> input = new LinkedHashSet<>();
+        input.add("a");
+        input.add("b");
+        SetItem item = new SetItem();
+        item.setId("id-1");
+        item.setValue(input);
+        EnhancedType<Set<String>> type = EnhancedType.setOf(String.class);
+
+        StaticTableSchema<SetItem> schema = StaticTableSchema.builder(SetItem.class)
+            .newItemSupplier(SetItem::new)
+            .addAttribute(EnhancedType.of(String.class), a -> a.name("id")
+                .getter(SetItem::getId).setter(SetItem::setId).tags(primaryPartitionKey()))
+            .addAttribute(type, a -> a.name("value")
+                .getter(SetItem::getValue).setter(SetItem::setValue))
+            .build();
+
+        Map<String, AttributeValue> map = schema.itemToMap(item, true);
+        SetItem read = schema.mapToItem(map);
+
+        assertThat(schema.converterForAttribute("value")).isInstanceOf(SetAttributeConverter.class);
+        assertThat(schema.converterForAttribute("value").attributeValueType()).isEqualTo(AttributeValueType.SS);
+        assertThat(read.getValue()).isInstanceOf(LinkedHashSet.class)
+                                   .containsExactly("a", "b");
+    }
+
+    @Test
+    @DisplayName("Enum attribute selects EnumAttributeConverter and round-trips")
+    void converterForAttribute_whenEnumValue_selectsEnumConverterAndReadsEqualValue() {
+        EnumItem item = new EnumItem();
+        item.setId("id-1");
+        item.setValue(TestEnum.OPEN);
+        EnhancedType<TestEnum> type = EnhancedType.of(TestEnum.class);
+
+        StaticTableSchema<EnumItem> schema = StaticTableSchema.builder(EnumItem.class)
+            .newItemSupplier(EnumItem::new)
+            .addAttribute(EnhancedType.of(String.class), a -> a.name("id")
+                .getter(EnumItem::getId).setter(EnumItem::setId).tags(primaryPartitionKey()))
+            .addAttribute(type, a -> a.name("value")
+                .getter(EnumItem::getValue).setter(EnumItem::setValue))
+            .build();
+
+        Map<String, AttributeValue> map = schema.itemToMap(item, true);
+        EnumItem read = schema.mapToItem(map);
+
+        assertThat(schema.converterForAttribute("value")).isInstanceOf(EnumAttributeConverter.class);
+        assertThat(schema.converterForAttribute("value").attributeValueType()).isEqualTo(AttributeValueType.S);
+        assertThat(map.get("value").s()).isEqualTo("OPEN");
+        assertThat(read.getValue()).isEqualTo(TestEnum.OPEN);
+    }
+
+    @Test
+    @DisplayName("Unconverted captured HashSet fails lookup before assignment")
+    void build_whenUnconvertedHashSet_throwsConverterNotFound() {
+        EnhancedType<HashSet<String>> type = new EnhancedType<HashSet<String>>() {
+        };
+
+        assertThatThrownBy(() -> StaticTableSchema.builder(HashSetItem.class)
+            .newItemSupplier(HashSetItem::new)
+            .addAttribute(EnhancedType.of(String.class), a -> a.name("id")
+                .getter(HashSetItem::getId).setter(HashSetItem::setId).tags(primaryPartitionKey()))
+            .addAttribute(type, a -> a.name("value")
+                .getter(HashSetItem::getValue).setter(HashSetItem::setValue))
+            .build())
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + type);
+    }
+
+    private static TableSchema<DocumentType> documentSchema() {
+        return StaticTableSchema.builder(DocumentType.class)
+                                .newItemSupplier(DocumentType::new)
+                                .addAttribute(String.class, a -> a.name("name")
+                                                                  .getter(DocumentType::getName)
+                                                                  .setter(DocumentType::setName))
+                                .build();
+    }
+
+    private static StaticTableSchema<StringItem> stringSchema() {
+        return StaticTableSchema.builder(StringItem.class)
+            .newItemSupplier(StringItem::new)
+            .addAttribute(EnhancedType.of(String.class), a -> a.name("id")
+                .getter(StringItem::getId).setter(StringItem::setId).tags(primaryPartitionKey()))
+            .addAttribute(EnhancedType.of(String.class), a -> a.name("value")
+                .getter(StringItem::getValue).setter(StringItem::setValue))
+            .build();
+    }
+
+    static final class UuidItem {
+        private String id;
+        private UUID value;
+
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        public UUID getValue() {
+            return value;
+        }
+
+        public void setValue(UUID value) {
+            this.value = value;
+        }
+    }
+
+    static final class MapItem {
+        private String id;
+        private Map<String, Integer> value;
+
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        public Map<String, Integer> getValue() {
+            return value;
+        }
+
+        public void setValue(Map<String, Integer> value) {
+            this.value = value;
+        }
+    }
+
+    static final class DocumentItem {
+        private String id;
+        private DocumentType value;
+
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        public DocumentType getValue() {
+            return value;
+        }
+
+        public void setValue(DocumentType value) {
+            this.value = value;
+        }
+    }
+
+    static final class StringItem {
+        private String id;
+        private String value;
+
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        public String getValue() {
+            return value;
+        }
+
+        public void setValue(String value) {
+            this.value = value;
+        }
+    }
+
+    static final class ObjectItem {
+        private String id;
+        private Object value;
+
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        public Object getValue() {
+            return value;
+        }
+
+        public void setValue(Object value) {
+            this.value = value;
+        }
+    }
+
+    static final class UnsupportedItem {
+        private String id;
+        private UnsupportedType value;
+
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        public UnsupportedType getValue() {
+            return value;
+        }
+
+        public void setValue(UnsupportedType value) {
+            this.value = value;
+        }
+    }
+
+    static final class CustomTypeItem {
+        private CustomType value;
+
+        public CustomType getValue() {
+            return value;
+        }
+
+        public void setValue(CustomType value) {
+            this.value = value;
+        }
+    }
+
+    static final class HashMapItem {
+        private String id;
+        private HashMap<String, Integer> value;
+
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        public HashMap<String, Integer> getValue() {
+            return value;
+        }
+
+        public void setValue(HashMap<String, Integer> value) {
+            this.value = value;
+        }
+    }
+
+    static final class UnsupportedMapItem {
+        private String id;
+        private Map<String, UnsupportedType> value;
+
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        public Map<String, UnsupportedType> getValue() {
+            return value;
+        }
+
+        public void setValue(Map<String, UnsupportedType> value) {
+            this.value = value;
+        }
+    }
+
+    static final class CollectionItem {
+        private String id;
+        private Collection<String> value;
+
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        public Collection<String> getValue() {
+            return value;
+        }
+
+        public void setValue(Collection<String> value) {
+            this.value = value;
+        }
+    }
+
+    static final class ListItem {
+        private String id;
+        private List<String> value;
+
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        public List<String> getValue() {
+            return value;
+        }
+
+        public void setValue(List<String> value) {
+            this.value = value;
+        }
+    }
+
+    static final class SetItem {
+        private String id;
+        private Set<String> value;
+
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        public Set<String> getValue() {
+            return value;
+        }
+
+        public void setValue(Set<String> value) {
+            this.value = value;
+        }
+    }
+
+    static final class EnumItem {
+        private String id;
+        private TestEnum value;
+
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        public TestEnum getValue() {
+            return value;
+        }
+
+        public void setValue(TestEnum value) {
+            this.value = value;
+        }
+    }
+
+    static final class HashSetItem {
+        private String id;
+        private HashSet<String> value;
+
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        public HashSet<String> getValue() {
+            return value;
+        }
+
+        public void setValue(HashSet<String> value) {
+            this.value = value;
+        }
+    }
+
+    enum TestEnum {
+        OPEN,
+        CLOSED
+    }
+
+    static final class CustomType {
+        private final String value;
+
+        CustomType(String value) {
+            this.value = value;
+        }
+
+        String value() {
+            return value;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof CustomType)) {
+                return false;
+            }
+            CustomType that = (CustomType) o;
+            return Objects.equals(value, that.value);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(value);
+        }
+    }
+
+    static final class UnsupportedType {
+        @Override
+        public boolean equals(Object o) {
+            return o instanceof UnsupportedType;
+        }
+
+        @Override
+        public int hashCode() {
+            return 1;
+        }
+    }
+
+    static final class DocumentType {
+        private String name;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+
+    public static final class RecordingCustomProvider implements AttributeConverterProvider {
+        private static final ThreadLocal<RecordingCustomProvider> CURRENT = new ThreadLocal<>();
+        private final List<EnhancedType<?>> requestedTypes = new ArrayList<>();
+
+        public RecordingCustomProvider() {
+            CURRENT.set(this);
+        }
+
+        public static RecordingCustomProvider current() {
+            return CURRENT.get();
+        }
+
+        public List<EnhancedType<?>> requestedTypes() {
+            return requestedTypes;
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> AttributeConverter<T> converterFor(EnhancedType<T> enhancedType) {
+            requestedTypes.add(enhancedType);
+            if (EnhancedType.of(CustomType.class).equals(enhancedType)) {
+                return (AttributeConverter<T>) new CustomTypeConverter();
+            }
+            return null;
+        }
+    }
+
+    public static final class ReturningNullProvider implements AttributeConverterProvider {
+        private static final ThreadLocal<ReturningNullProvider> CURRENT = new ThreadLocal<>();
+        private final List<EnhancedType<?>> requestedTypes = new ArrayList<>();
+
+        public ReturningNullProvider() {
+            CURRENT.set(this);
+        }
+
+        public static ReturningNullProvider current() {
+            return CURRENT.get();
+        }
+
+        public List<EnhancedType<?>> requestedTypes() {
+            return requestedTypes;
+        }
+
+        @Override
+        public <T> AttributeConverter<T> converterFor(EnhancedType<T> enhancedType) {
+            requestedTypes.add(enhancedType);
+            return null;
+        }
+    }
+
+    public static final class ThrowingProvider implements AttributeConverterProvider {
+        public ThrowingProvider() {
+        }
+
+        @Override
+        public <T> AttributeConverter<T> converterFor(EnhancedType<T> enhancedType) {
+            throw new IllegalArgumentException("Attribute converter provider failed while looking up " + enhancedType);
+        }
+    }
+
+    public static final class ObjectProvider implements AttributeConverterProvider {
+        private static final ThreadLocal<ObjectProvider> CURRENT = new ThreadLocal<>();
+        private final List<EnhancedType<?>> requestedTypes = new ArrayList<>();
+
+        public ObjectProvider() {
+            CURRENT.set(this);
+        }
+
+        public static ObjectProvider current() {
+            return CURRENT.get();
+        }
+
+        public List<EnhancedType<?>> requestedTypes() {
+            return requestedTypes;
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> AttributeConverter<T> converterFor(EnhancedType<T> enhancedType) {
+            requestedTypes.add(enhancedType);
+            if (EnhancedType.of(Object.class).equals(enhancedType)) {
+                return (AttributeConverter<T>) new ObjectStringConverter();
+            }
+            return null;
+        }
+    }
+
+    static final class ExactTypeProvider implements AttributeConverterProvider {
+        private final EnhancedType<?> target;
+        private final AttributeConverter<?> converter;
+        private final List<EnhancedType<?>> requestedTypes = new ArrayList<>();
+
+        ExactTypeProvider(EnhancedType<?> target, AttributeConverter<?> converter) {
+            this.target = target;
+            this.converter = converter;
+        }
+
+        int requestCountFor(EnhancedType<?> type) {
+            int count = 0;
+            for (EnhancedType<?> requestedType : requestedTypes) {
+                if (type.equals(requestedType)) {
+                    count++;
+                }
+            }
+            return count;
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> AttributeConverter<T> converterFor(EnhancedType<T> enhancedType) {
+            requestedTypes.add(enhancedType);
+            if (target.equals(enhancedType)) {
+                return (AttributeConverter<T>) converter;
+            }
+            return null;
+        }
+    }
+
+    static final class RecordingDefaultProvider implements AttributeConverterProvider {
+        private final List<EnhancedType<?>> requestedTypes = new ArrayList<>();
+        private final AttributeConverterProvider delegate = DefaultAttributeConverterProvider.create();
+
+        List<EnhancedType<?>> requestedTypes() {
+            return requestedTypes;
+        }
+
+        @Override
+        public <T> AttributeConverter<T> converterFor(EnhancedType<T> enhancedType) {
+            requestedTypes.add(enhancedType);
+            return delegate.converterFor(enhancedType);
+        }
+    }
+
+    static final class UnsupportedMemberProvider implements AttributeConverterProvider {
+        private final List<EnhancedType<?>> requestedTypes = new ArrayList<>();
+
+        List<EnhancedType<?>> requestedTypes() {
+            return requestedTypes;
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> AttributeConverter<T> converterFor(EnhancedType<T> enhancedType) {
+            requestedTypes.add(enhancedType);
+            if (EnhancedType.of(UnsupportedType.class).equals(enhancedType)) {
+                return (AttributeConverter<T>) new UnsupportedStringConverter();
+            }
+            return null;
+        }
+    }
+
+    public static final class CustomTypeConverter implements AttributeConverter<CustomType> {
+
+        @Override
+        public AttributeValue transformFrom(CustomType input) {
+            return AttributeValue.fromS("custom:" + input.value());
+        }
+
+        @Override
+        public CustomType transformTo(AttributeValue input) {
+            return new CustomType(input.s().substring("custom:".length()));
+        }
+
+        @Override
+        public EnhancedType<CustomType> type() {
+            return EnhancedType.of(CustomType.class);
+        }
+
+        @Override
+        public AttributeValueType attributeValueType() {
+            return AttributeValueType.S;
+        }
+    }
+
+    public static final class CustomStringConverter implements AttributeConverter<String> {
+
+        @Override
+        public AttributeValue transformFrom(String input) {
+            return AttributeValue.fromS("custom:" + input);
+        }
+
+        @Override
+        public String transformTo(AttributeValue input) {
+            String stored = input.s();
+            return stored.startsWith("custom:") ? stored.substring("custom:".length()) : stored;
+        }
+
+        @Override
+        public EnhancedType<String> type() {
+            return EnhancedType.of(String.class);
+        }
+
+        @Override
+        public AttributeValueType attributeValueType() {
+            return AttributeValueType.S;
+        }
+    }
+
+    public static final class ObjectStringConverter implements AttributeConverter<Object> {
+        public ObjectStringConverter() {
+        }
+
+        @Override
+        public AttributeValue transformFrom(Object input) {
+            return AttributeValue.fromS("custom");
+        }
+
+        @Override
+        public Object transformTo(AttributeValue input) {
+            return input.s();
+        }
+
+        @Override
+        public EnhancedType<Object> type() {
+            return EnhancedType.of(Object.class);
+        }
+
+        @Override
+        public AttributeValueType attributeValueType() {
+            return AttributeValueType.S;
+        }
+    }
+
+    public static final class UnsupportedStringConverter implements AttributeConverter<UnsupportedType> {
+
+        @Override
+        public AttributeValue transformFrom(UnsupportedType input) {
+            return AttributeValue.fromS("custom");
+        }
+
+        @Override
+        public UnsupportedType transformTo(AttributeValue input) {
+            return new UnsupportedType();
+        }
+
+        @Override
+        public EnhancedType<UnsupportedType> type() {
+            return EnhancedType.of(UnsupportedType.class);
+        }
+
+        @Override
+        public AttributeValueType attributeValueType() {
+            return AttributeValueType.S;
+        }
+    }
+
+    public static final class HashMapConverter implements AttributeConverter<HashMap<String, Integer>> {
+        private static final EnhancedType<HashMap<String, Integer>> TYPE =
+            new EnhancedType<HashMap<String, Integer>>() {
+            };
+
+        public HashMapConverter() {
+        }
+
+        @Override
+        public AttributeValue transformFrom(HashMap<String, Integer> input) {
+            Map<String, AttributeValue> values = new LinkedHashMap<>();
+            for (Map.Entry<String, Integer> entry : input.entrySet()) {
+                values.put(entry.getKey(), AttributeValue.fromN(Integer.toString(entry.getValue())));
+            }
+            return AttributeValue.fromM(values);
+        }
+
+        @Override
+        public HashMap<String, Integer> transformTo(AttributeValue input) {
+            HashMap<String, Integer> result = new HashMap<>();
+            for (Map.Entry<String, AttributeValue> entry : input.m().entrySet()) {
+                result.put(entry.getKey(), Integer.valueOf(entry.getValue().n()));
+            }
+            return result;
+        }
+
+        @Override
+        public EnhancedType<HashMap<String, Integer>> type() {
+            return TYPE;
+        }
+
+        @Override
+        public AttributeValueType attributeValueType() {
+            return AttributeValueType.M;
+        }
+    }
+
+}

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/functionaltests/DefaultAttributeConverterProviderOperationsTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/functionaltests/DefaultAttributeConverterProviderOperationsTest.java
@@ -1,0 +1,646 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.functionaltests;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static software.amazon.awssdk.enhanced.dynamodb.functionaltests.LocalDynamoDbAsyncTestBase.drainPublisher;
+import static software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.DefaultAttributeConverterProviderTestModels.ITEM_ID;
+import static software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.DefaultAttributeConverterProviderTestModels.assertReconstructedCollections;
+import static software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.DefaultAttributeConverterProviderTestModels.assertWrittenItem;
+import static software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.DefaultAttributeConverterProviderTestModels.completeItem;
+import static software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.DefaultAttributeConverterProviderTestModels.completeItemWithNullableNull;
+import static software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.DefaultAttributeConverterProviderTestModels.countersAttribute;
+import static software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.DefaultAttributeConverterProviderTestModels.eventsAttribute;
+import static software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.DefaultAttributeConverterProviderTestModels.eventsWithNullElementAttribute;
+import static software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.DefaultAttributeConverterProviderTestModels.labelsAttribute;
+import static software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.DefaultAttributeConverterProviderTestModels.oneCounter;
+import static software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.DefaultAttributeConverterProviderTestModels.oneLabel;
+import static software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.DefaultAttributeConverterProviderTestModels.populatedConverterRecord;
+import static software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.DefaultAttributeConverterProviderTestModels.typedCollectionsDocumentWithNull;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import software.amazon.awssdk.enhanced.dynamodb.AttributeValueType;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbAsyncTable;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedAsyncClient;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
+import software.amazon.awssdk.enhanced.dynamodb.Key;
+import software.amazon.awssdk.enhanced.dynamodb.TableMetadata;
+import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
+import software.amazon.awssdk.enhanced.dynamodb.document.EnhancedDocument;
+import software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.DefaultAttributeConverterProviderTestModels.ConverterRecord;
+import software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional;
+import software.amazon.awssdk.enhanced.dynamodb.model.ReadBatch;
+import software.amazon.awssdk.enhanced.dynamodb.model.WriteBatch;
+import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.DeleteTableRequest;
+
+/**
+ * Tests collection conversion during DynamoDB Enhanced Client table operations.
+ * <p>
+ * The tests exercise scans, queries, individual writes and reads, batch operations, and transactions with synchronous
+ * and asynchronous clients. They verify stored collection forms, reconstructed collection order, explicit and omitted
+ * null values, and conversion failures before or during an operation.
+ */
+public class DefaultAttributeConverterProviderOperationsTest extends LocalDynamoDbTestBase {
+
+    @BeforeAll
+    public static void startLocalDynamoDb() {
+        localDynamoDb().start();
+    }
+
+    @AfterAll
+    public static void stopLocalDynamoDbForJunit5() {
+        localDynamoDb().stop();
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @EnumSource(DynamoDbEnhancedClientType.class)
+    @DisplayName("Scan returns stored collection attributes in insertion order")
+    public void scan_whenTableContainsCollectionItem_reconstructsLinkedCollections(DynamoDbEnhancedClientType clientType) {
+        ConverterRecordOperations operations = openTable(clientType);
+        try {
+            operations.putItem(populatedConverterRecord());
+
+            List<ConverterRecord> items = operations.scanItems();
+
+            assertThat(items).hasSize(1);
+            assertReconstructedCollections(items.get(0));
+        } finally {
+            operations.deleteTable();
+        }
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @EnumSource(DynamoDbEnhancedClientType.class)
+    @DisplayName("Query returns stored collection attributes in insertion order")
+    public void query_whenTableContainsCollectionItem_reconstructsLinkedCollections(DynamoDbEnhancedClientType clientType) {
+        ConverterRecordOperations operations = openTable(clientType);
+        try {
+            operations.putItem(populatedConverterRecord());
+
+            List<ConverterRecord> items = operations.queryByPartition(ITEM_ID);
+
+            assertThat(items).hasSize(1);
+            assertReconstructedCollections(items.get(0));
+        } finally {
+            operations.deleteTable();
+        }
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @EnumSource(DynamoDbEnhancedClientType.class)
+    @DisplayName("Update persists collection attributes and returns them reconstructed")
+    public void updateItem_whenRecordHasCollections_writesAndReconstructsCollections(DynamoDbEnhancedClientType clientType) {
+        ConverterRecordOperations operations = openTable(clientType);
+        try {
+            ConverterRecord result = operations.updateItem(populatedConverterRecord());
+
+            assertWrittenItem(operations.storedItem());
+            assertReconstructedCollections(result);
+        } finally {
+            operations.deleteTable();
+        }
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @EnumSource(DynamoDbEnhancedClientType.class)
+    @DisplayName("Put persists the key and collection attribute forms")
+    public void putItem_whenRecordHasCollections_writesKeyAndCollectionAttributeForms(DynamoDbEnhancedClientType clientType) {
+        ConverterRecordOperations operations = openTable(clientType);
+        try {
+            operations.putItem(populatedConverterRecord());
+
+            assertWrittenItem(operations.storedItem());
+        } finally {
+            operations.deleteTable();
+        }
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @EnumSource(DynamoDbEnhancedClientType.class)
+    @DisplayName("Get returns stored collection attributes in insertion order")
+    public void putItemThenGetItem_whenTableContainsCompleteItem_reconstructsLinkedCollections(
+        DynamoDbEnhancedClientType clientType) {
+        ConverterRecordOperations operations = openTable(clientType);
+        try {
+            operations.putItem(populatedConverterRecord());
+
+            ConverterRecord result = operations.getItem(itemKey());
+
+            assertReconstructedCollections(result);
+        } finally {
+            operations.deleteTable();
+        }
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @EnumSource(DynamoDbEnhancedClientType.class)
+    @DisplayName("Delete returns the previous collection attributes and removes the item")
+    public void deleteItem_whenTableContainsCompleteItem_returnsOldCollections(DynamoDbEnhancedClientType clientType) {
+        ConverterRecordOperations operations = openTable(clientType);
+        try {
+            operations.putItem(populatedConverterRecord());
+
+            ConverterRecord result = operations.deleteItem(itemKey());
+
+            assertReconstructedCollections(result);
+            assertThat(operations.getItem(itemKey())).isNull();
+        } finally {
+            operations.deleteTable();
+        }
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @EnumSource(DynamoDbEnhancedClientType.class)
+    @DisplayName("Batch get returns stored collection attributes in insertion order")
+    public void batchGetItem_whenTableContainsCompleteItem_reconstructsLinkedCollections(DynamoDbEnhancedClientType clientType) {
+        ConverterRecordOperations operations = openTable(clientType);
+        try {
+            operations.putItem(populatedConverterRecord());
+
+            List<ConverterRecord> items = operations.batchGetItem(ITEM_ID);
+
+            assertThat(items).hasSize(1);
+            assertReconstructedCollections(items.get(0));
+        } finally {
+            operations.deleteTable();
+        }
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @EnumSource(DynamoDbEnhancedClientType.class)
+    @DisplayName("Batch write persists the key and collection attribute forms")
+    public void batchWriteItem_whenPutContainsCollections_writesKeyAndCollectionAttributeForms(
+        DynamoDbEnhancedClientType clientType) {
+        ConverterRecordOperations operations = openTable(clientType);
+        try {
+            operations.batchWriteItem(populatedConverterRecord());
+
+            assertWrittenItem(operations.storedItem());
+        } finally {
+            operations.deleteTable();
+        }
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @EnumSource(DynamoDbEnhancedClientType.class)
+    @DisplayName("Transact get returns stored collection attributes in insertion order")
+    public void transactGetItems_whenTableContainsCompleteItem_reconstructsLinkedCollections(
+        DynamoDbEnhancedClientType clientType) {
+        ConverterRecordOperations operations = openTable(clientType);
+        try {
+            operations.putItem(populatedConverterRecord());
+
+            List<ConverterRecord> items = operations.transactGetItems(ITEM_ID);
+
+            assertThat(items).hasSize(1);
+            assertReconstructedCollections(items.get(0));
+        } finally {
+            operations.deleteTable();
+        }
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @EnumSource(DynamoDbEnhancedClientType.class)
+    @DisplayName("Transact write persists the key and collection attribute forms")
+    public void transactWriteItems_whenPutContainsCollections_writesKeyAndCollectionAttributeForms(
+        DynamoDbEnhancedClientType clientType) {
+        ConverterRecordOperations operations = openTable(clientType);
+        try {
+            operations.transactWriteItems(populatedConverterRecord());
+
+            assertWrittenItem(operations.storedItem());
+        } finally {
+            operations.deleteTable();
+        }
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @EnumSource(DynamoDbEnhancedClientType.class)
+    @DisplayName("Get fails when a stored list attribute is a map")
+    public void getItem_whenStoredEventsAreAMap_throwsIllegalStateException(DynamoDbEnhancedClientType clientType) {
+        ConverterRecordOperations operations = openTable(clientType);
+        try {
+            Map<String, AttributeValue> item = new LinkedHashMap<>(completeItem());
+            item.put("events", AttributeValue.fromM(Collections.emptyMap()));
+            operations.putRawItem(item);
+
+            assertThatThrownBy(() -> operations.getItem(itemKey()))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute."
+                            + "ListAttributeConverter cannot convert an attribute of type M into the requested type "
+                            + "interface java.util.List");
+        } finally {
+            operations.deleteTable();
+        }
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @EnumSource(DynamoDbEnhancedClientType.class)
+    @DisplayName("Put omits a null map attribute and still writes the set and list")
+    public void putItem_whenCountersAreNull_omitsCountersAndWritesSetAndList(DynamoDbEnhancedClientType clientType) {
+        ConverterRecordOperations operations = openTable(clientType);
+        try {
+            ConverterRecord record = populatedConverterRecord();
+            record.setCounters(null);
+
+            operations.putItem(record);
+
+            Map<String, AttributeValue> item = operations.storedItem();
+            assertThat(item).doesNotContainKey("counters");
+            assertThat(item.get("labels")).isEqualTo(labelsAttribute());
+            assertThat(item.get("events")).isEqualTo(eventsAttribute());
+        } finally {
+            operations.deleteTable();
+        }
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @EnumSource(DynamoDbEnhancedClientType.class)
+    @DisplayName("Put stores a null list member and get returns that null")
+    public void putItemThenGetItem_whenListContainsNullElement_writesNullMemberAndReadsArrayListWithNull(
+        DynamoDbEnhancedClientType clientType) {
+        ConverterRecordOperations operations = openTable(clientType);
+        try {
+            ConverterRecord record = populatedConverterRecord();
+            ArrayList<String> events = new ArrayList<>();
+            events.add("a");
+            events.add(null);
+            events.add("b");
+            record.setEvents(events);
+
+            operations.putItem(record);
+
+            assertThat(operations.storedItem().get("events")).isEqualTo(eventsWithNullElementAttribute());
+
+            ConverterRecord result = operations.getItem(itemKey());
+
+            assertThat(result.getEvents()).isInstanceOf(ArrayList.class).containsExactly("a", null, "b");
+            assertThat(result.getCounters()).isInstanceOf(LinkedHashMap.class).isEqualTo(oneCounter());
+            assertThat(result.getLabels()).isEqualTo(oneLabel());
+        } finally {
+            operations.deleteTable();
+        }
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @EnumSource(DynamoDbEnhancedClientType.class)
+    @DisplayName("Put fails before the request when a map value is null")
+    public void putItem_whenMapValueIsNull_throwsNullPointerExceptionBeforeRequest(DynamoDbEnhancedClientType clientType) {
+        ConverterRecordOperations operations = openTable(clientType);
+        try {
+            ConverterRecord record = populatedConverterRecord();
+            LinkedHashMap<String, Integer> counters = new LinkedHashMap<>();
+            counters.put("missing", null);
+            record.setCounters(counters);
+
+            assertThatThrownBy(() -> operations.putItem(record))
+                .isInstanceOf(NullPointerException.class)
+                .satisfies(ex -> assertThat(ex.getMessage() == null || ex.getMessage().contains("null")).isTrue());
+            assertThat(operations.getItem(itemKey())).isNull();
+        } finally {
+            operations.deleteTable();
+        }
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @EnumSource(DynamoDbEnhancedClientType.class)
+    @DisplayName("Put of a document stores explicit null together with typed collections")
+    public void putItem_whenDocumentHasPutNull_writesNullAndTypedCollections(DynamoDbEnhancedClientType clientType) {
+        ConverterRecordOperations operations = openTable(clientType);
+        try {
+            operations.putDocument(typedCollectionsDocumentWithNull());
+
+            Map<String, AttributeValue> item = operations.storedItem();
+            assertThat(item.get("nullable")).isEqualTo(AttributeValue.fromNul(true));
+            assertThat(item.get("counters")).isEqualTo(countersAttribute());
+            assertThat(item.get("labels")).isEqualTo(labelsAttribute());
+            assertThat(item.get("events")).isEqualTo(eventsAttribute());
+        } finally {
+            operations.deleteTable();
+        }
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @EnumSource(DynamoDbEnhancedClientType.class)
+    @DisplayName("Get leaves a null property unset and reconstructs the collections")
+    public void getItem_whenNullableIsDynamoDbNull_skipsSetterAndReconstructsCollections(DynamoDbEnhancedClientType clientType) {
+        ConverterRecordOperations operations = openTable(clientType);
+        try {
+            operations.putRawItem(completeItemWithNullableNull());
+
+            ConverterRecord result = operations.getItem(itemKey());
+
+            assertThat(result.getNullable()).isNull();
+            assertReconstructedCollections(result);
+        } finally {
+            operations.deleteTable();
+        }
+    }
+
+    private ConverterRecordOperations openTable(DynamoDbEnhancedClientType clientType) {
+        ConverterRecordOperations operations = clientType == DynamoDbEnhancedClientType.SYNC
+                                               ? new SyncOperations()
+                                               : new AsyncOperations();
+        operations.createTable();
+        return operations;
+    }
+
+    private static Key itemKey() {
+        return Key.builder().partitionValue(ITEM_ID).build();
+    }
+
+    private static <T> T joinFuture(CompletableFuture<T> future) {
+        try {
+            return future.join();
+        } catch (CompletionException completionException) {
+            Throwable cause = completionException.getCause();
+            if (cause instanceof RuntimeException) {
+                throw (RuntimeException) cause;
+            }
+            if (cause instanceof Error) {
+                throw (Error) cause;
+            }
+            throw completionException;
+        }
+    }
+
+    private interface ConverterRecordOperations {
+        void createTable();
+
+        void deleteTable();
+
+        void putItem(ConverterRecord record);
+
+        ConverterRecord getItem(Key key);
+
+        ConverterRecord updateItem(ConverterRecord record);
+
+        ConverterRecord deleteItem(Key key);
+
+        List<ConverterRecord> scanItems();
+
+        List<ConverterRecord> queryByPartition(String partitionValue);
+
+        List<ConverterRecord> batchGetItem(String partitionValue);
+
+        void batchWriteItem(ConverterRecord record);
+
+        List<ConverterRecord> transactGetItems(String partitionValue);
+
+        void transactWriteItems(ConverterRecord record);
+
+        void putDocument(EnhancedDocument document);
+
+        void putRawItem(Map<String, AttributeValue> item);
+
+        Map<String, AttributeValue> storedItem();
+    }
+
+    private final class SyncOperations implements ConverterRecordOperations {
+        private final DynamoDbClient dynamoDbClient = localDynamoDb().createClient();
+        private final DynamoDbEnhancedClient enhancedClient =
+            DynamoDbEnhancedClient.builder().dynamoDbClient(dynamoDbClient).build();
+        private final String tableName = getConcreteTableName("table-name");
+        private final DynamoDbTable<ConverterRecord> table =
+            enhancedClient.table(tableName, TableSchema.fromBean(ConverterRecord.class));
+        private final DynamoDbTable<EnhancedDocument> documentTable =
+            enhancedClient.table(tableName,
+                                 TableSchema.documentSchemaBuilder()
+                                            .addIndexPartitionKey(TableMetadata.primaryIndexName(), "id",
+                                                                  AttributeValueType.S)
+                                            .build());
+
+        @Override
+        public void createTable() {
+            table.createTable(r -> r.provisionedThroughput(getDefaultProvisionedThroughput()));
+        }
+
+        @Override
+        public void deleteTable() {
+            dynamoDbClient.deleteTable(DeleteTableRequest.builder().tableName(tableName).build());
+        }
+
+        @Override
+        public void putItem(ConverterRecord record) {
+            table.putItem(record);
+        }
+
+        @Override
+        public ConverterRecord getItem(Key key) {
+            return table.getItem(key);
+        }
+
+        @Override
+        public ConverterRecord updateItem(ConverterRecord record) {
+            return table.updateItem(record);
+        }
+
+        @Override
+        public ConverterRecord deleteItem(Key key) {
+            return table.deleteItem(key);
+        }
+
+        @Override
+        public List<ConverterRecord> scanItems() {
+            List<ConverterRecord> items = new ArrayList<>();
+            for (ConverterRecord item : table.scan().items()) {
+                items.add(item);
+            }
+            return items;
+        }
+
+        @Override
+        public List<ConverterRecord> queryByPartition(String partitionValue) {
+            List<ConverterRecord> items = new ArrayList<>();
+            for (ConverterRecord item : table.query(QueryConditional.keyEqualTo(k -> k.partitionValue(partitionValue)))
+                                             .items()) {
+                items.add(item);
+            }
+            return items;
+        }
+
+        @Override
+        public List<ConverterRecord> batchGetItem(String partitionValue) {
+            List<ConverterRecord> items = new ArrayList<>();
+            for (ConverterRecord item : enhancedClient.batchGetItem(r -> r.readBatches(
+                ReadBatch.builder(ConverterRecord.class)
+                         .mappedTableResource(table)
+                         .addGetItem(i -> i.key(k -> k.partitionValue(partitionValue)))
+                         .build())).resultsForTable(table)) {
+                items.add(item);
+            }
+            return items;
+        }
+
+        @Override
+        public void batchWriteItem(ConverterRecord record) {
+            enhancedClient.batchWriteItem(r -> r.writeBatches(
+                WriteBatch.builder(ConverterRecord.class)
+                          .mappedTableResource(table)
+                          .addPutItem(record)
+                          .build()));
+        }
+
+        @Override
+        public List<ConverterRecord> transactGetItems(String partitionValue) {
+            return enhancedClient.transactGetItems(r -> r.addGetItem(table, Key.builder().partitionValue(partitionValue).build())).stream().map(document -> document.getItem(table)).collect(Collectors.toList());
+        }
+
+        @Override
+        public void transactWriteItems(ConverterRecord record) {
+            enhancedClient.transactWriteItems(r -> r.addPutItem(table, record));
+        }
+
+        @Override
+        public void putDocument(EnhancedDocument document) {
+            documentTable.putItem(document);
+        }
+
+        @Override
+        public void putRawItem(Map<String, AttributeValue> item) {
+            dynamoDbClient.putItem(r -> r.tableName(tableName).item(item));
+        }
+
+        @Override
+        public Map<String, AttributeValue> storedItem() {
+            return dynamoDbClient.getItem(r -> r.tableName(tableName)
+                                          .key(Collections.singletonMap("id", AttributeValue.fromS(ITEM_ID)))
+                                          .consistentRead(true))
+                           .item();
+        }
+    }
+
+    private final class AsyncOperations implements ConverterRecordOperations {
+        private final DynamoDbAsyncClient dynamoDbAsyncClient = localDynamoDb().createAsyncClient();
+        private final DynamoDbEnhancedAsyncClient enhancedClient =
+            DynamoDbEnhancedAsyncClient.builder().dynamoDbClient(dynamoDbAsyncClient).build();
+        private final String tableName = getConcreteTableName("table-name");
+        private final DynamoDbAsyncTable<ConverterRecord> table =
+            enhancedClient.table(tableName, TableSchema.fromBean(ConverterRecord.class));
+        private final DynamoDbAsyncTable<EnhancedDocument> documentTable =
+            enhancedClient.table(tableName,
+                                 TableSchema.documentSchemaBuilder()
+                                            .addIndexPartitionKey(TableMetadata.primaryIndexName(), "id",
+                                                                  AttributeValueType.S)
+                                            .build());
+
+        @Override
+        public void createTable() {
+            joinFuture(table.createTable(r -> r.provisionedThroughput(getDefaultProvisionedThroughput())));
+        }
+
+        @Override
+        public void deleteTable() {
+            joinFuture(dynamoDbAsyncClient.deleteTable(DeleteTableRequest.builder().tableName(tableName).build()));
+        }
+
+        @Override
+        public void putItem(ConverterRecord record) {
+            joinFuture(table.putItem(record));
+        }
+
+        @Override
+        public ConverterRecord getItem(Key key) {
+            return joinFuture(table.getItem(key));
+        }
+
+        @Override
+        public ConverterRecord updateItem(ConverterRecord record) {
+            return joinFuture(table.updateItem(record));
+        }
+
+        @Override
+        public ConverterRecord deleteItem(Key key) {
+            return joinFuture(table.deleteItem(key));
+        }
+
+        @Override
+        public List<ConverterRecord> scanItems() {
+            return drainPublisher(table.scan().items(), 1);
+        }
+
+        @Override
+        public List<ConverterRecord> queryByPartition(String partitionValue) {
+            return drainPublisher(
+                table.query(QueryConditional.keyEqualTo(k -> k.partitionValue(partitionValue))).items(), 1);
+        }
+
+        @Override
+        public List<ConverterRecord> batchGetItem(String partitionValue) {
+            return drainPublisher(enhancedClient.batchGetItem(r -> r.readBatches(
+                ReadBatch.builder(ConverterRecord.class)
+                         .mappedTableResource(table)
+                         .addGetItem(i -> i.key(k -> k.partitionValue(partitionValue)))
+                         .build())).resultsForTable(table), 1);
+        }
+
+        @Override
+        public void batchWriteItem(ConverterRecord record) {
+            joinFuture(enhancedClient.batchWriteItem(r -> r.writeBatches(
+                WriteBatch.builder(ConverterRecord.class)
+                          .mappedTableResource(table)
+                          .addPutItem(record)
+                          .build())));
+        }
+
+        @Override
+        public List<ConverterRecord> transactGetItems(String partitionValue) {
+            return joinFuture(enhancedClient.transactGetItems(
+                r -> r.addGetItem(table, Key.builder().partitionValue(partitionValue).build()))).stream().map(document -> document.getItem(table)).collect(Collectors.toList());
+        }
+
+        @Override
+        public void transactWriteItems(ConverterRecord record) {
+            joinFuture(enhancedClient.transactWriteItems(r -> r.addPutItem(table, record)));
+        }
+
+        @Override
+        public void putDocument(EnhancedDocument document) {
+            joinFuture(documentTable.putItem(document));
+        }
+
+        @Override
+        public void putRawItem(Map<String, AttributeValue> item) {
+            joinFuture(dynamoDbAsyncClient.putItem(r -> r.tableName(tableName).item(item)));
+        }
+
+        @Override
+        public Map<String, AttributeValue> storedItem() {
+            return dynamoDbAsyncClient.getItem(r -> r.tableName(tableName)
+                                          .key(Collections.singletonMap("id", AttributeValue.fromS(ITEM_ID)))
+                                          .consistentRead(true))
+                           .join()
+                           .item();
+        }
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/functionaltests/DefaultAttributeConverterProviderSchemaTypesTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/functionaltests/DefaultAttributeConverterProviderSchemaTypesTest.java
@@ -1,0 +1,648 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.functionaltests;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.DefaultAttributeConverterProviderTestModels.assertReconstructedCollections;
+import static software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.DefaultAttributeConverterProviderTestModels.assertWrittenItem;
+import static software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.DefaultAttributeConverterProviderTestModels.DETAILS_NOTE;
+import static software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.DefaultAttributeConverterProviderTestModels.DIRECT_VALUE;
+import static software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.DefaultAttributeConverterProviderTestModels.ITEM_ID;
+import static software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.DefaultAttributeConverterProviderTestModels.allBranchesDocument;
+import static software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.DefaultAttributeConverterProviderTestModels.allBranchesStaticImmutableSchema;
+import static software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.DefaultAttributeConverterProviderTestModels.allBranchesStaticSchema;
+import static software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.DefaultAttributeConverterProviderTestModels.completeItem;
+import static software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.DefaultAttributeConverterProviderTestModels.countersAttribute;
+import static software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.DefaultAttributeConverterProviderTestModels.detailsSchema;
+import static software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.DefaultAttributeConverterProviderTestModels.eventsAttribute;
+import static software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.DefaultAttributeConverterProviderTestModels.labelsAttribute;
+import static software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.DefaultAttributeConverterProviderTestModels.oneCounter;
+import static software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.DefaultAttributeConverterProviderTestModels.oneEvent;
+import static software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.DefaultAttributeConverterProviderTestModels.oneLabel;
+import static software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.DefaultAttributeConverterProviderTestModels.populatedAllBranchesBean;
+import static software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.DefaultAttributeConverterProviderTestModels.populatedAllBranchesImmutable;
+import static software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.DefaultAttributeConverterProviderTestModels.populatedAllBranchesStaticImmutable;
+import static software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.DefaultAttributeConverterProviderTestModels.populatedAllBranchesStaticRecord;
+import static software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.DefaultAttributeConverterProviderTestModels.populatedConverterImmutable;
+import static software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.DefaultAttributeConverterProviderTestModels.populatedConverterRecord;
+import static software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.DefaultAttributeConverterProviderTestModels.populatedDefaultProviderBean;
+import static software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.DefaultAttributeConverterProviderTestModels.populatedDefaultProviderImmutable;
+import static software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.DefaultAttributeConverterProviderTestModels.populatedStaticImmutableRecord;
+import static software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.DefaultAttributeConverterProviderTestModels.populatedStaticRecord;
+import static software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.DefaultAttributeConverterProviderTestModels.staticImmutableRecordSchema;
+import static software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.DefaultAttributeConverterProviderTestModels.staticRecordSchema;
+import static software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.DefaultAttributeConverterProviderTestModels.typedCollectionsDocument;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import software.amazon.awssdk.enhanced.dynamodb.AttributeValueType;
+import software.amazon.awssdk.enhanced.dynamodb.DefaultAttributeConverterProvider;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbAsyncTable;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedAsyncClient;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
+import software.amazon.awssdk.enhanced.dynamodb.EnhancedType;
+import software.amazon.awssdk.enhanced.dynamodb.IndexMetadata;
+import software.amazon.awssdk.enhanced.dynamodb.Key;
+import software.amazon.awssdk.enhanced.dynamodb.TableMetadata;
+import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
+import software.amazon.awssdk.enhanced.dynamodb.document.EnhancedDocument;
+import software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.DefaultAttributeConverterProviderTestModels.AllBranchesBean;
+import software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.DefaultAttributeConverterProviderTestModels.AllBranchesDetails;
+import software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.DefaultAttributeConverterProviderTestModels.AllBranchesImmutable;
+import software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.DefaultAttributeConverterProviderTestModels.BeanWithArrayList;
+import software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.DefaultAttributeConverterProviderTestModels.BeanWithHashMap;
+import software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.DefaultAttributeConverterProviderTestModels.BeanWithHashSet;
+import software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.DefaultAttributeConverterProviderTestModels.BeanWithObject;
+import software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.DefaultAttributeConverterProviderTestModels.BeanWithUnsupported;
+import software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.DefaultAttributeConverterProviderTestModels.AllBranchesStaticImmutable;
+import software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.DefaultAttributeConverterProviderTestModels.AllBranchesStaticRecord;
+import software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.DefaultAttributeConverterProviderTestModels.ConverterImmutable;
+import software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.DefaultAttributeConverterProviderTestModels.ConverterRecord;
+import software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.DefaultAttributeConverterProviderTestModels.DefaultProviderBean;
+import software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.DefaultAttributeConverterProviderTestModels.DefaultProviderImmutable;
+import software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.DefaultAttributeConverterProviderTestModels.FlattenedChildBean;
+import software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.DefaultAttributeConverterProviderTestModels.OuterFlattenedBean;
+import software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.DefaultAttributeConverterProviderTestModels.SingleGsiPartitionBean;
+import software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.DefaultAttributeConverterProviderTestModels.SingleGsiSortBean;
+import software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.DefaultAttributeConverterProviderTestModels.StaticImmutableRecord;
+import software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.DefaultAttributeConverterProviderTestModels.StaticRecord;
+import software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.DefaultAttributeConverterProviderTestModels.TestEnum;
+import software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.DefaultAttributeConverterProviderTestModels.UnsupportedType;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.ListAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.MapAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.internal.converter.attribute.SetAttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.Order;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.BeanTableSchema;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.StaticImmutableTableSchema;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.StaticTableSchema;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbFlatten;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbImmutable;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbSecondaryPartitionKey;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbSecondarySortKey;
+import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.DeleteTableRequest;
+
+/**
+ * Schema factories for bean, immutable, static mutable, static immutable, and document types.
+ * <p>
+ * In-memory factory cases run once. They cover successful conversion, construction failures, omitted
+ * providers, flatten, and default GSI key order.
+ * Table put and get cases run for each {@link DynamoDbEnhancedClientType}.
+ */
+public class DefaultAttributeConverterProviderSchemaTypesTest extends LocalDynamoDbTestBase {
+
+    @BeforeAll
+    public static void startLocalDynamoDb() {
+        localDynamoDb().start();
+    }
+
+    @AfterAll
+    public static void stopLocalDynamoDbForJunit5() {
+        localDynamoDb().stop();
+    }
+
+    @BeforeEach
+    public void clearBeanSchemaCache() throws Exception {
+        Method clear = BeanTableSchema.class.getDeclaredMethod("clearSchemaCache");
+        clear.setAccessible(true);
+        clear.invoke(null);
+    }
+
+    @Test
+    @DisplayName("Bean schema converts supported collections to DynamoDB and back")
+    public void itemToMapThenMapToItem_whenFromBeanConverterRecordIsPopulated_roundTripsSupportedCollections() {
+        TableSchema<ConverterRecord> schema = TableSchema.fromBean(ConverterRecord.class);
+        ConverterRecord item = populatedConverterRecord();
+
+        Map<String, AttributeValue> map = schema.itemToMap(item, true);
+        ConverterRecord read = schema.mapToItem(map);
+
+        assertWrittenCollections(map);
+        assertReconstructedCollections(read);
+    }
+
+    @Test
+    @DisplayName("Immutable schema converts supported collections to DynamoDB and back")
+    public void itemToMapThenMapToItem_whenFromImmutableClassIsPopulated_roundTripsSupportedCollections() {
+        TableSchema<ConverterImmutable> schema = TableSchema.fromImmutableClass(ConverterImmutable.class);
+        ConverterImmutable item = populatedConverterImmutable();
+
+        Map<String, AttributeValue> map = schema.itemToMap(item, true);
+        ConverterImmutable read = schema.mapToItem(map);
+
+        assertWrittenCollections(map);
+        assertThat(read.counters()).isInstanceOf(LinkedHashMap.class).isEqualTo(oneCounter());
+        assertThat(read.labels()).isInstanceOf(LinkedHashSet.class).isEqualTo(oneLabel());
+        assertThat(read.events()).isInstanceOf(ArrayList.class).isEqualTo(oneEvent());
+    }
+
+    @Test
+    @DisplayName("Document schema converts typed collections to DynamoDB and back")
+    public void itemToMapThenMapToItem_whenDocumentHasTypedCollections_roundTripsSupportedCollections() {
+        TableSchema<EnhancedDocument> schema = TableSchema.documentSchemaBuilder().build();
+        EnhancedDocument document = typedCollectionsDocument();
+
+        Map<String, AttributeValue> map = schema.itemToMap(document, false);
+        EnhancedDocument read = schema.mapToItem(map);
+
+        assertWrittenCollections(map);
+        assertThat(read.get("counters", EnhancedType.mapOf(String.class, Integer.class)))
+            .isInstanceOf(LinkedHashMap.class)
+            .isEqualTo(oneCounter());
+        assertThat(read.get("labels", EnhancedType.setOf(String.class)))
+            .isInstanceOf(LinkedHashSet.class)
+            .isEqualTo(oneLabel());
+        assertThat(read.get("events", EnhancedType.listOf(String.class)))
+            .isInstanceOf(ArrayList.class)
+            .isEqualTo(oneEvent());
+    }
+
+    @Test
+    @DisplayName("Static schema converts supported collections to DynamoDB and back")
+    public void itemToMapThenMapToItem_whenStaticTableSchemaRecordIsPopulated_roundTripsSupportedCollections() {
+        StaticTableSchema<StaticRecord> schema = staticRecordSchema();
+        StaticRecord item = populatedStaticRecord();
+
+        Map<String, AttributeValue> map = schema.itemToMap(item, true);
+        StaticRecord read = schema.mapToItem(map);
+
+        assertWrittenCollections(map);
+        assertThat(read.getCounters()).isInstanceOf(LinkedHashMap.class).isEqualTo(oneCounter());
+        assertThat(read.getLabels()).isInstanceOf(LinkedHashSet.class).isEqualTo(oneLabel());
+        assertThat(read.getEvents()).isInstanceOf(ArrayList.class).isEqualTo(oneEvent());
+    }
+
+    @Test
+    @DisplayName("Bean schema uses the default provider when converters are omitted")
+    public void itemToMapThenMapToItem_whenFromBeanConverterProvidersOmitted_roundTripsSupportedCollections() {
+        DynamoDbBean annotation = DefaultProviderBean.class.getAnnotation(DynamoDbBean.class);
+        TableSchema<DefaultProviderBean> schema = TableSchema.fromBean(DefaultProviderBean.class);
+        DefaultProviderBean item = populatedDefaultProviderBean();
+
+        Map<String, AttributeValue> map = schema.itemToMap(item, true);
+        DefaultProviderBean read = schema.mapToItem(map);
+
+        assertThat(annotation.converterProviders()).containsExactly(DefaultAttributeConverterProvider.class);
+        assertWrittenCollections(map);
+        assertThat(read.getCounters()).isInstanceOf(LinkedHashMap.class).isEqualTo(oneCounter());
+        assertThat(read.getLabels()).isInstanceOf(LinkedHashSet.class).isEqualTo(oneLabel());
+        assertThat(read.getEvents()).isInstanceOf(ArrayList.class).isEqualTo(oneEvent());
+    }
+
+    @Test
+    @DisplayName("Immutable schema uses the default provider when converters are omitted")
+    public void itemToMapThenMapToItem_whenFromImmutableConverterProvidersOmitted_roundTripsSupportedCollections() {
+        DynamoDbImmutable annotation = DefaultProviderImmutable.class.getAnnotation(DynamoDbImmutable.class);
+        TableSchema<DefaultProviderImmutable> schema =
+            TableSchema.fromImmutableClass(DefaultProviderImmutable.class);
+        DefaultProviderImmutable item = populatedDefaultProviderImmutable();
+
+        Map<String, AttributeValue> map = schema.itemToMap(item, true);
+        DefaultProviderImmutable read = schema.mapToItem(map);
+
+        assertThat(annotation.converterProviders()).containsExactly(DefaultAttributeConverterProvider.class);
+        assertWrittenCollections(map);
+        assertThat(read.counters()).isInstanceOf(LinkedHashMap.class).isEqualTo(oneCounter());
+        assertThat(read.labels()).isInstanceOf(LinkedHashSet.class).isEqualTo(oneLabel());
+        assertThat(read.events()).isInstanceOf(ArrayList.class).isEqualTo(oneEvent());
+    }
+
+    @Test
+    @DisplayName("Flattened child collections convert without an explicit flatten bean class")
+    public void itemToMapThenMapToItem_whenFlattenOmitsBeanClass_roundTripsFlattenedChildCollections() throws Exception {
+        DynamoDbFlatten flatten = OuterFlattenedBean.class.getMethod("getChild").getAnnotation(DynamoDbFlatten.class);
+        FlattenedChildBean child = new FlattenedChildBean();
+        child.setCounters(oneCounter());
+        child.setLabels(oneLabel());
+        child.setEvents(oneEvent());
+        OuterFlattenedBean item = new OuterFlattenedBean();
+        item.setId(ITEM_ID);
+        item.setChild(child);
+        TableSchema<OuterFlattenedBean> schema = TableSchema.fromBean(OuterFlattenedBean.class);
+
+        Map<String, AttributeValue> map = schema.itemToMap(item, true);
+        OuterFlattenedBean read = schema.mapToItem(map);
+
+        assertThat(flatten.dynamoDbBeanClass()).isEqualTo(Object.class);
+        assertWrittenCollections(map);
+        assertThat(read.getChild().getCounters()).isInstanceOf(LinkedHashMap.class).isEqualTo(oneCounter());
+        assertThat(read.getChild().getLabels()).isInstanceOf(LinkedHashSet.class).isEqualTo(oneLabel());
+        assertThat(read.getChild().getEvents()).isInstanceOf(ArrayList.class).isEqualTo(oneEvent());
+    }
+
+    @Test
+    @DisplayName("Secondary partition key without order is an unspecified string key")
+    public void fromBean_whenSecondaryPartitionKeyOmitsOrder_usesUnspecifiedStringKey() throws Exception {
+        DynamoDbSecondaryPartitionKey annotation =
+            SingleGsiPartitionBean.class.getMethod("getGsiKey")
+                                        .getAnnotation(DynamoDbSecondaryPartitionKey.class);
+        TableSchema<SingleGsiPartitionBean> schema = TableSchema.fromBean(SingleGsiPartitionBean.class);
+        IndexMetadata gsi = index(schema, "gsi");
+
+        assertThat(annotation.order()).isEqualTo(Order.UNSPECIFIED);
+        assertThat(gsi.partitionKeys()).hasSize(1);
+        assertThat(gsi.partitionKeys().get(0).attributeValueType()).isEqualTo(AttributeValueType.S);
+        assertThat(gsi.partitionKeys().get(0).order()).isEqualTo(Order.UNSPECIFIED);
+    }
+
+    @Test
+    @DisplayName("Secondary sort key without order is an unspecified integer key")
+    public void fromBean_whenSecondarySortKeyOmitsOrder_usesUnspecifiedIntegerKey() throws Exception {
+        DynamoDbSecondarySortKey annotation =
+            SingleGsiSortBean.class.getMethod("getGsiSort").getAnnotation(DynamoDbSecondarySortKey.class);
+        TableSchema<SingleGsiSortBean> schema = TableSchema.fromBean(SingleGsiSortBean.class);
+        IndexMetadata gsi = index(schema, "gsi");
+
+        assertThat(annotation.order()).isEqualTo(Order.UNSPECIFIED);
+        assertThat(gsi.sortKeys()).hasSize(1);
+        assertThat(gsi.sortKeys().get(0).attributeValueType()).isEqualTo(AttributeValueType.N);
+        assertThat(gsi.sortKeys().get(0).order()).isEqualTo(Order.UNSPECIFIED);
+    }
+
+    @Test
+    @DisplayName("Static schema generates collection converters when providers are omitted")
+    public void itemToMapThenMapToItem_whenStaticTableSchemaProvidersOmitted_roundTripsGeneratedCollectionConverters() {
+        StaticTableSchema<StaticRecord> schema = staticRecordSchema();
+        StaticRecord item = populatedStaticRecord();
+
+        Map<String, AttributeValue> map = schema.itemToMap(item, true);
+        StaticRecord read = schema.mapToItem(map);
+
+        assertThat(schema.converterForAttribute("counters")).isInstanceOf(MapAttributeConverter.class);
+        assertThat(schema.converterForAttribute("labels")).isInstanceOf(SetAttributeConverter.class);
+        assertThat(schema.converterForAttribute("events")).isInstanceOf(ListAttributeConverter.class);
+        assertWrittenCollections(map);
+        assertThat(read.getCounters()).isInstanceOf(LinkedHashMap.class).isEqualTo(oneCounter());
+        assertThat(read.getLabels()).isInstanceOf(LinkedHashSet.class).isEqualTo(oneLabel());
+        assertThat(read.getEvents()).isInstanceOf(ArrayList.class).isEqualTo(oneEvent());
+    }
+
+    @Test
+    @DisplayName("Static immutable schema generates collection converters when providers are omitted")
+    public void itemToMapThenMapToItem_whenStaticImmutableProvidersOmitted_roundTripsGeneratedCollectionConverters() {
+        StaticImmutableTableSchema<StaticImmutableRecord, StaticImmutableRecord.Builder> schema =
+            staticImmutableRecordSchema();
+        StaticImmutableRecord item = populatedStaticImmutableRecord();
+
+        Map<String, AttributeValue> map = schema.itemToMap(item, true);
+        StaticImmutableRecord read = schema.mapToItem(map);
+
+        assertThat(schema.converterForAttribute("counters")).isInstanceOf(MapAttributeConverter.class);
+        assertThat(schema.converterForAttribute("labels")).isInstanceOf(SetAttributeConverter.class);
+        assertThat(schema.converterForAttribute("events")).isInstanceOf(ListAttributeConverter.class);
+        assertWrittenCollections(map);
+        assertThat(read.counters()).isInstanceOf(LinkedHashMap.class).isEqualTo(oneCounter());
+        assertThat(read.labels()).isInstanceOf(LinkedHashSet.class).isEqualTo(oneLabel());
+        assertThat(read.events()).isInstanceOf(ArrayList.class).isEqualTo(oneEvent());
+    }
+
+    @Test
+    @DisplayName("Document schema reads generated collection classes when providers are omitted")
+    public void documentSchemaBuilder_whenAttributeConverterProvidersOmitted_readsGeneratedCollectionClasses() {
+        TableSchema<EnhancedDocument> schema = TableSchema.documentSchemaBuilder().build();
+        Map<String, AttributeValue> attributeMap = completeItem();
+
+        EnhancedDocument read = schema.mapToItem(attributeMap);
+
+        assertThat(read.get("counters", EnhancedType.mapOf(String.class, Integer.class)))
+            .isInstanceOf(LinkedHashMap.class)
+            .isEqualTo(oneCounter());
+        assertThat(read.get("labels", EnhancedType.setOf(String.class)))
+            .isInstanceOf(LinkedHashSet.class)
+            .isEqualTo(oneLabel());
+        assertThat(read.get("events", EnhancedType.listOf(String.class)))
+            .isInstanceOf(ArrayList.class)
+            .isEqualTo(oneEvent());
+    }
+
+    @Test
+    @DisplayName("Rejects a bean schema when its Object attribute has no converter")
+    public void fromBean_whenBeanDeclaresObject_throwsConverterNotFound() {
+        assertThatThrownBy(() -> TableSchema.fromBean(BeanWithObject.class))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + EnhancedType.of(Object.class));
+    }
+
+    @Test
+    @DisplayName("Rejects a bean schema that declares an unsupported attribute type")
+    public void fromBean_whenBeanDeclaresUnsupportedType_throwsIllegalStateException() {
+        assertThatThrownBy(() -> TableSchema.fromBean(BeanWithUnsupported.class))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + EnhancedType.of(UnsupportedType.class));
+    }
+
+    @Test
+    @DisplayName("Rejects a bean schema that declares an ArrayList attribute")
+    public void fromBean_whenBeanDeclaresArrayList_throwsIllegalStateException() {
+        EnhancedType<ArrayList<String>> type = new EnhancedType<ArrayList<String>>() { };
+        assertThatThrownBy(() -> TableSchema.fromBean(BeanWithArrayList.class))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + type);
+    }
+
+    @Test
+    @DisplayName("Rejects a bean schema that declares a HashSet attribute")
+    public void fromBean_whenBeanDeclaresHashSet_throwsIllegalStateException() {
+        EnhancedType<HashSet<String>> type = new EnhancedType<HashSet<String>>() { };
+        assertThatThrownBy(() -> TableSchema.fromBean(BeanWithHashSet.class))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + type);
+    }
+
+    @Test
+    @DisplayName("Rejects a bean schema that declares a HashMap attribute")
+    public void fromBean_whenBeanDeclaresHashMap_throwsIllegalStateException() {
+        EnhancedType<HashMap<String, Integer>> type = new EnhancedType<HashMap<String, Integer>>() { };
+        assertThatThrownBy(() -> TableSchema.fromBean(BeanWithHashMap.class))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + type);
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @EnumSource(DynamoDbEnhancedClientType.class)
+    @DisplayName("Bean table put and get convert every default lookup type")
+    public void putItemThenGetItem_whenBeanSchemaHasAllLookupTypes_roundTripsConvertedValues(
+        DynamoDbEnhancedClientType clientType) {
+        SchemaTableClient client = openTable(clientType);
+        try {
+            TableSchema<AllBranchesBean> schema = TableSchema.fromBean(AllBranchesBean.class);
+
+            client.putItem(schema, populatedAllBranchesBean());
+            AllBranchesBean result = client.getItem(schema, itemKey());
+
+            assertAllBranchesItem(client.storedItem());
+            assertThat(result.getDirect()).isEqualTo(DIRECT_VALUE);
+            assertThat(result.getStatus()).isEqualTo(TestEnum.OPEN);
+            assertThat(result.getDetails().getNote()).isEqualTo(DETAILS_NOTE);
+            assertThat(result.getCounters()).isInstanceOf(LinkedHashMap.class).isEqualTo(oneCounter());
+            assertThat(result.getLabels()).isInstanceOf(LinkedHashSet.class).isEqualTo(oneLabel());
+            assertThat(result.getEvents()).isInstanceOf(ArrayList.class).isEqualTo(oneEvent());
+        } finally {
+            client.deleteTable();
+        }
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @EnumSource(DynamoDbEnhancedClientType.class)
+    @DisplayName("Immutable table put and get convert every default lookup type")
+    public void putItemThenGetItem_whenImmutableSchemaHasAllLookupTypes_roundTripsConvertedValues(
+        DynamoDbEnhancedClientType clientType) {
+        SchemaTableClient client = openTable(clientType);
+        try {
+            TableSchema<AllBranchesImmutable> schema = TableSchema.fromImmutableClass(AllBranchesImmutable.class);
+
+            client.putItem(schema, populatedAllBranchesImmutable());
+            AllBranchesImmutable result = client.getItem(schema, itemKey());
+
+            assertAllBranchesItem(client.storedItem());
+            assertAllBranchesImmutable(result);
+        } finally {
+            client.deleteTable();
+        }
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @EnumSource(DynamoDbEnhancedClientType.class)
+    @DisplayName("Static table put and get convert every default lookup type")
+    public void putItemThenGetItem_whenStaticSchemaHasAllLookupTypes_roundTripsConvertedValues(
+        DynamoDbEnhancedClientType clientType) {
+        SchemaTableClient client = openTable(clientType);
+        try {
+            TableSchema<AllBranchesStaticRecord> schema = allBranchesStaticSchema();
+
+            client.putItem(schema, populatedAllBranchesStaticRecord());
+            AllBranchesStaticRecord result = client.getItem(schema, itemKey());
+
+            assertAllBranchesItem(client.storedItem());
+            assertThat(result.getDirect()).isEqualTo(DIRECT_VALUE);
+            assertThat(result.getStatus()).isEqualTo(TestEnum.OPEN);
+            assertThat(result.getDetails().getNote()).isEqualTo(DETAILS_NOTE);
+            assertThat(result.getCounters()).isInstanceOf(LinkedHashMap.class).isEqualTo(oneCounter());
+            assertThat(result.getLabels()).isInstanceOf(LinkedHashSet.class).isEqualTo(oneLabel());
+            assertThat(result.getEvents()).isInstanceOf(ArrayList.class).isEqualTo(oneEvent());
+        } finally {
+            client.deleteTable();
+        }
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @EnumSource(DynamoDbEnhancedClientType.class)
+    @DisplayName("Static immutable table put and get convert every default lookup type")
+    public void putItemThenGetItem_whenStaticImmutableSchemaHasAllLookupTypes_roundTripsConvertedValues(
+        DynamoDbEnhancedClientType clientType) {
+        SchemaTableClient client = openTable(clientType);
+        try {
+            TableSchema<AllBranchesStaticImmutable> schema = allBranchesStaticImmutableSchema();
+
+            client.putItem(schema, populatedAllBranchesStaticImmutable());
+            AllBranchesStaticImmutable result = client.getItem(schema, itemKey());
+
+            assertAllBranchesItem(client.storedItem());
+            assertThat(result.direct()).isEqualTo(DIRECT_VALUE);
+            assertThat(result.status()).isEqualTo(TestEnum.OPEN);
+            assertThat(result.details().getNote()).isEqualTo(DETAILS_NOTE);
+            assertThat(result.counters()).isInstanceOf(LinkedHashMap.class).isEqualTo(oneCounter());
+            assertThat(result.labels()).isInstanceOf(LinkedHashSet.class).isEqualTo(oneLabel());
+            assertThat(result.events()).isInstanceOf(ArrayList.class).isEqualTo(oneEvent());
+        } finally {
+            client.deleteTable();
+        }
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @EnumSource(DynamoDbEnhancedClientType.class)
+    @DisplayName("Document table put and get convert every default lookup type")
+    public void putItemThenGetItem_whenDocumentSchemaHasAllLookupTypes_roundTripsConvertedValues(
+        DynamoDbEnhancedClientType clientType) {
+        SchemaTableClient client = openTable(clientType);
+        try {
+            TableSchema<AllBranchesDetails> details = detailsSchema();
+            TableSchema<EnhancedDocument> schema =
+                TableSchema.documentSchemaBuilder()
+                           .addIndexPartitionKey(TableMetadata.primaryIndexName(), "id", AttributeValueType.S)
+                           .build();
+
+            client.putItem(schema, allBranchesDocument(details));
+            EnhancedDocument result = client.getItem(schema, itemKey());
+
+            assertAllBranchesItem(client.storedItem());
+            assertThat(result.get("direct", EnhancedType.of(String.class))).isEqualTo(DIRECT_VALUE);
+            assertThat(result.get("status", EnhancedType.of(TestEnum.class))).isEqualTo(TestEnum.OPEN);
+            assertThat(result.get("details", EnhancedType.documentOf(AllBranchesDetails.class, details)).getNote())
+                .isEqualTo(DETAILS_NOTE);
+            assertThat(result.get("counters", EnhancedType.mapOf(String.class, Integer.class)))
+                .isInstanceOf(LinkedHashMap.class)
+                .isEqualTo(oneCounter());
+            assertThat(result.get("labels", EnhancedType.setOf(String.class)))
+                .isInstanceOf(LinkedHashSet.class)
+                .isEqualTo(oneLabel());
+            assertThat(result.get("events", EnhancedType.listOf(String.class)))
+                .isInstanceOf(ArrayList.class)
+                .isEqualTo(oneEvent());
+        } finally {
+            client.deleteTable();
+        }
+    }
+
+    private SchemaTableClient openTable(DynamoDbEnhancedClientType clientType) {
+        SchemaTableClient client = clientType == DynamoDbEnhancedClientType.SYNC
+                                   ? new SyncSchemaTableClient()
+                                   : new AsyncSchemaTableClient();
+        client.createTable();
+        return client;
+    }
+
+    private static Key itemKey() {
+        return Key.builder().partitionValue(ITEM_ID).build();
+    }
+
+    private static void assertWrittenCollections(Map<String, AttributeValue> map) {
+        assertThat(map.get("counters")).isEqualTo(countersAttribute());
+        assertThat(map.get("labels")).isEqualTo(labelsAttribute());
+        assertThat(map.get("events")).isEqualTo(eventsAttribute());
+    }
+
+    private static void assertAllBranchesItem(Map<String, AttributeValue> item) {
+        assertWrittenItem(item);
+        assertThat(item.get("direct").s()).isEqualTo(DIRECT_VALUE);
+        assertThat(item.get("status").s()).isEqualTo(TestEnum.OPEN.toString());
+        assertThat(item.get("details").m().get("note").s()).isEqualTo(DETAILS_NOTE);
+    }
+
+    private static void assertAllBranchesImmutable(AllBranchesImmutable result) {
+        assertThat(result.id()).isEqualTo(ITEM_ID);
+        assertThat(result.direct()).isEqualTo(DIRECT_VALUE);
+        assertThat(result.status()).isEqualTo(TestEnum.OPEN);
+        assertThat(result.details().getNote()).isEqualTo(DETAILS_NOTE);
+        assertThat(result.counters()).isInstanceOf(LinkedHashMap.class).isEqualTo(oneCounter());
+        assertThat(result.labels()).isInstanceOf(LinkedHashSet.class).isEqualTo(oneLabel());
+        assertThat(result.events()).isInstanceOf(ArrayList.class).isEqualTo(oneEvent());
+    }
+
+    private static IndexMetadata index(TableSchema<?> schema, String indexName) {
+        for (IndexMetadata index : schema.tableMetadata().indices()) {
+            if (indexName.equals(index.name())) {
+                return index;
+            }
+        }
+        throw new AssertionError("Missing index " + indexName);
+    }
+
+    private interface SchemaTableClient {
+        void createTable();
+
+        void deleteTable();
+
+        <T> void putItem(TableSchema<T> schema, T item);
+
+        <T> T getItem(TableSchema<T> schema, Key key);
+
+        Map<String, AttributeValue> storedItem();
+    }
+
+    private final class SyncSchemaTableClient implements SchemaTableClient {
+        private final DynamoDbClient dynamoDbClient = localDynamoDb().createClient();
+        private final DynamoDbEnhancedClient enhancedClient =
+            DynamoDbEnhancedClient.builder().dynamoDbClient(dynamoDbClient).build();
+        private final String tableName = getConcreteTableName("table-name");
+        private final DynamoDbTable<ConverterRecord> table =
+            enhancedClient.table(tableName, TableSchema.fromBean(ConverterRecord.class));
+
+        @Override
+        public void createTable() {
+            table.createTable(r -> r.provisionedThroughput(getDefaultProvisionedThroughput()));
+        }
+
+        @Override
+        public void deleteTable() {
+            dynamoDbClient.deleteTable(DeleteTableRequest.builder().tableName(tableName).build());
+        }
+
+        @Override
+        public <T> void putItem(TableSchema<T> schema, T item) {
+            enhancedClient.table(tableName, schema).putItem(item);
+        }
+
+        @Override
+        public <T> T getItem(TableSchema<T> schema, Key key) {
+            return enhancedClient.table(tableName, schema).getItem(key);
+        }
+
+        @Override
+        public Map<String, AttributeValue> storedItem() {
+            return dynamoDbClient.getItem(r -> r.tableName(tableName)
+                                          .key(Collections.singletonMap("id", AttributeValue.fromS(ITEM_ID)))
+                                          .consistentRead(true))
+                           .item();
+        }
+    }
+
+    private final class AsyncSchemaTableClient implements SchemaTableClient {
+        private final DynamoDbAsyncClient dynamoDbAsyncClient = localDynamoDb().createAsyncClient();
+        private final DynamoDbEnhancedAsyncClient enhancedClient =
+            DynamoDbEnhancedAsyncClient.builder().dynamoDbClient(dynamoDbAsyncClient).build();
+        private final String tableName = getConcreteTableName("table-name");
+        private final DynamoDbAsyncTable<ConverterRecord> table =
+            enhancedClient.table(tableName, TableSchema.fromBean(ConverterRecord.class));
+
+        @Override
+        public void createTable() {
+            table.createTable(r -> r.provisionedThroughput(getDefaultProvisionedThroughput())).join();
+        }
+
+        @Override
+        public void deleteTable() {
+            dynamoDbAsyncClient.deleteTable(DeleteTableRequest.builder().tableName(tableName).build()).join();
+        }
+
+        @Override
+        public <T> void putItem(TableSchema<T> schema, T item) {
+            enhancedClient.table(tableName, schema).putItem(item).join();
+        }
+
+        @Override
+        public <T> T getItem(TableSchema<T> schema, Key key) {
+            return enhancedClient.table(tableName, schema).getItem(key).join();
+        }
+
+        @Override
+        public Map<String, AttributeValue> storedItem() {
+            return dynamoDbAsyncClient.getItem(r -> r.tableName(tableName)
+                                          .key(Collections.singletonMap("id", AttributeValue.fromS(ITEM_ID)))
+                                          .consistentRead(true))
+                           .join()
+                           .item();
+        }
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/functionaltests/DefaultAttributeConverterProviderTableSetupTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/functionaltests/DefaultAttributeConverterProviderTableSetupTest.java
@@ -1,0 +1,386 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.functionaltests;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.DefaultAttributeConverterProviderTestModels.staticImmutableRecordSchema;
+import static software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.DefaultAttributeConverterProviderTestModels.staticRecordSchema;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import software.amazon.awssdk.enhanced.dynamodb.AttributeValueType;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbAsyncTable;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedAsyncClient;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
+import software.amazon.awssdk.enhanced.dynamodb.EnhancedType;
+import software.amazon.awssdk.enhanced.dynamodb.TableMetadata;
+import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
+import software.amazon.awssdk.enhanced.dynamodb.document.EnhancedDocument;
+import software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.DefaultAttributeConverterProviderTestModels.BeanWithArrayList;
+import software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.DefaultAttributeConverterProviderTestModels.BeanWithHashMap;
+import software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.DefaultAttributeConverterProviderTestModels.BeanWithHashSet;
+import software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.DefaultAttributeConverterProviderTestModels.BeanWithObject;
+import software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.DefaultAttributeConverterProviderTestModels.BeanWithUnsupported;
+import software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.DefaultAttributeConverterProviderTestModels.ConverterImmutable;
+import software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.DefaultAttributeConverterProviderTestModels.ConverterRecord;
+import software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.DefaultAttributeConverterProviderTestModels.DefaultProviderBean;
+import software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.DefaultAttributeConverterProviderTestModels.SingleGsiSortBean;
+import software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.DefaultAttributeConverterProviderTestModels.UnsupportedType;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.BeanTableSchema;
+import software.amazon.awssdk.enhanced.dynamodb.model.EnhancedGlobalSecondaryIndex;
+import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.DeleteTableRequest;
+import software.amazon.awssdk.services.dynamodb.model.GlobalSecondaryIndexDescription;
+import software.amazon.awssdk.services.dynamodb.model.ProjectionType;
+
+/**
+ * Enhanced Client table bind and createTable for DefaultAttributeConverterProvider schemas.
+ * <p>
+ * Each case runs for {@link DynamoDbEnhancedClientType#SYNC} and {@link DynamoDbEnhancedClientType#ASYNC}.
+ * The class covers successful bind and create for all five schema kinds, bind failures for
+ * unconvertible attributes, omitted-provider bind, and GSI metadata on create.
+ */
+public class DefaultAttributeConverterProviderTableSetupTest extends LocalDynamoDbTestBase {
+
+    @BeforeAll
+    public static void startLocalDynamoDb() {
+        localDynamoDb().start();
+    }
+
+    @AfterAll
+    public static void stopLocalDynamoDbForJunit5() {
+        localDynamoDb().stop();
+    }
+
+    @BeforeEach
+    public void clearBeanSchemaCache() throws Exception {
+        Method clear = BeanTableSchema.class.getDeclaredMethod("clearSchemaCache");
+        clear.setAccessible(true);
+        clear.invoke(null);
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @EnumSource(DynamoDbEnhancedClientType.class)
+    @DisplayName("Creates a table from a convertible bean schema")
+    public void tableThenCreateTable_whenBeanSchemaIsConvertible_createsTable(DynamoDbEnhancedClientType clientType) {
+        SetupClient client = openClient(clientType, "bean");
+        try {
+            client.createTable(TableSchema.fromBean(ConverterRecord.class));
+
+            assertThat(client.tableExists()).isTrue();
+        } finally {
+            client.deleteTable();
+        }
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @EnumSource(DynamoDbEnhancedClientType.class)
+    @DisplayName("Creates a table from a convertible immutable schema")
+    public void tableThenCreateTable_whenImmutableSchemaIsConvertible_createsTable(DynamoDbEnhancedClientType clientType) {
+        SetupClient client = openClient(clientType, "immutable");
+        try {
+            client.createTable(TableSchema.fromImmutableClass(ConverterImmutable.class));
+
+            assertThat(client.tableExists()).isTrue();
+        } finally {
+            client.deleteTable();
+        }
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @EnumSource(DynamoDbEnhancedClientType.class)
+    @DisplayName("Creates a table from a convertible static schema")
+    public void tableThenCreateTable_whenStaticSchemaIsConvertible_createsTable(DynamoDbEnhancedClientType clientType) {
+        SetupClient client = openClient(clientType, "static");
+        try {
+            client.createTable(staticRecordSchema());
+
+            assertThat(client.tableExists()).isTrue();
+        } finally {
+            client.deleteTable();
+        }
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @EnumSource(DynamoDbEnhancedClientType.class)
+    @DisplayName("Creates a table from a convertible static immutable schema")
+    public void tableThenCreateTable_whenStaticImmutableSchemaIsConvertible_createsTable(DynamoDbEnhancedClientType clientType) {
+        SetupClient client = openClient(clientType, "static-imm");
+        try {
+            client.createTable(staticImmutableRecordSchema());
+
+            assertThat(client.tableExists()).isTrue();
+        } finally {
+            client.deleteTable();
+        }
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @EnumSource(DynamoDbEnhancedClientType.class)
+    @DisplayName("Creates a table from a convertible document schema")
+    public void tableThenCreateTable_whenDocumentSchemaIsConvertible_createsTable(DynamoDbEnhancedClientType clientType) {
+        SetupClient client = openClient(clientType, "document");
+        try {
+            client.createTable(documentSchema());
+
+            assertThat(client.tableExists()).isTrue();
+        } finally {
+            client.deleteTable();
+        }
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @EnumSource(DynamoDbEnhancedClientType.class)
+    @DisplayName("Creates a table when the bean omits converter providers")
+    public void tableThenCreateTable_whenConverterProvidersAreOmitted_createsTable(DynamoDbEnhancedClientType clientType) {
+        SetupClient client = openClient(clientType, "omitted");
+        try {
+            client.createTable(TableSchema.fromBean(DefaultProviderBean.class));
+
+            assertThat(client.tableExists()).isTrue();
+        } finally {
+            client.deleteTable();
+        }
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @EnumSource(DynamoDbEnhancedClientType.class)
+    @DisplayName("Creates a GSI with an unspecified integer sort key")
+    public void tableThenCreateTable_whenBeanDeclaresGsi_createsIndexWithUnspecifiedIntegerSort(
+        DynamoDbEnhancedClientType clientType) {
+        SetupClient client = openClient(clientType, "gsi");
+        try {
+            TableSchema<SingleGsiSortBean> schema = TableSchema.fromBean(SingleGsiSortBean.class);
+
+            client.createTableWithGsi(schema, "gsi");
+
+            assertThat(schema.tableMetadata().indexPartitionKey("gsi")).isEqualTo("gsiKey");
+            assertThat(schema.tableMetadata().indexSortKey("gsi")).contains("gsiSort");
+            assertThat(client.globalSecondaryIndexNames()).contains("gsi");
+        } finally {
+            client.deleteTable();
+        }
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @EnumSource(DynamoDbEnhancedClientType.class)
+    @DisplayName("Rejects table setup when a bean Object attribute has no converter")
+    public void table_whenBeanDeclaresObject_throwsConverterNotFoundBeforeSetupCompletes(
+        DynamoDbEnhancedClientType clientType) {
+        assertThatThrownBy(() -> table(clientType, "unused-table", TableSchema.fromBean(BeanWithObject.class)))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + EnhancedType.of(Object.class));
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @EnumSource(DynamoDbEnhancedClientType.class)
+    @DisplayName("Rejects table setup when a bean attribute has no converter")
+    public void table_whenBeanDeclaresUnsupportedType_throwsIllegalStateException(DynamoDbEnhancedClientType clientType) {
+        assertThatThrownBy(() -> table(clientType, "unused-table", TableSchema.fromBean(BeanWithUnsupported.class)))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + EnhancedType.of(UnsupportedType.class));
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @EnumSource(DynamoDbEnhancedClientType.class)
+    @DisplayName("Rejects table setup when a bean attribute is ArrayList")
+    public void table_whenBeanDeclaresArrayList_throwsIllegalStateException(DynamoDbEnhancedClientType clientType) {
+        EnhancedType<ArrayList<String>> type = new EnhancedType<ArrayList<String>>() { };
+        assertThatThrownBy(() -> table(clientType, "unused-table", TableSchema.fromBean(BeanWithArrayList.class)))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + type);
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @EnumSource(DynamoDbEnhancedClientType.class)
+    @DisplayName("Rejects table setup when a bean attribute is HashSet")
+    public void table_whenBeanDeclaresHashSet_throwsIllegalStateException(DynamoDbEnhancedClientType clientType) {
+        EnhancedType<HashSet<String>> type = new EnhancedType<HashSet<String>>() { };
+        assertThatThrownBy(() -> table(clientType, "unused-table", TableSchema.fromBean(BeanWithHashSet.class)))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + type);
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @EnumSource(DynamoDbEnhancedClientType.class)
+    @DisplayName("Rejects table setup when a bean attribute is HashMap")
+    public void table_whenBeanDeclaresHashMap_throwsIllegalStateException(DynamoDbEnhancedClientType clientType) {
+        EnhancedType<HashMap<String, Integer>> type = new EnhancedType<HashMap<String, Integer>>() { };
+        assertThatThrownBy(() -> table(clientType, "unused-table", TableSchema.fromBean(BeanWithHashMap.class)))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Converter not found for " + type);
+    }
+
+    private SetupClient openClient(DynamoDbEnhancedClientType clientType, String tableNameSuffix) {
+        return clientType == DynamoDbEnhancedClientType.SYNC
+               ? new SyncSetupClient(tableNameSuffix)
+               : new AsyncSetupClient(tableNameSuffix);
+    }
+
+    private void table(DynamoDbEnhancedClientType clientType, String tableName, TableSchema<?> schema) {
+        if (clientType == DynamoDbEnhancedClientType.SYNC) {
+            DynamoDbEnhancedClient.builder()
+                                  .dynamoDbClient(localDynamoDb().createClient())
+                                  .build()
+                                  .table(tableName, schema);
+            return;
+        }
+        DynamoDbEnhancedAsyncClient.builder()
+                                   .dynamoDbClient(localDynamoDb().createAsyncClient())
+                                   .build()
+                                   .table(tableName, schema);
+    }
+
+    private static TableSchema<EnhancedDocument> documentSchema() {
+        return TableSchema.documentSchemaBuilder()
+                          .addIndexPartitionKey(TableMetadata.primaryIndexName(), "id", AttributeValueType.S)
+                          .build();
+    }
+
+    private interface SetupClient {
+        <T> void createTable(TableSchema<T> schema);
+
+        <T> void createTableWithGsi(TableSchema<T> schema, String indexName);
+
+        boolean tableExists();
+
+        List<String> globalSecondaryIndexNames();
+
+        void deleteTable();
+    }
+
+    private final class SyncSetupClient implements SetupClient {
+        private final DynamoDbClient dynamoDbClient = localDynamoDb().createClient();
+        private final DynamoDbEnhancedClient enhancedClient =
+            DynamoDbEnhancedClient.builder().dynamoDbClient(dynamoDbClient).build();
+        private final String tableName;
+
+        SyncSetupClient(String tableNameSuffix) {
+            this.tableName = getConcreteTableName(tableNameSuffix);
+        }
+
+        @Override
+        public <T> void createTable(TableSchema<T> schema) {
+            DynamoDbTable<T> table = enhancedClient.table(tableName, schema);
+            table.createTable(r -> r.provisionedThroughput(getDefaultProvisionedThroughput()));
+        }
+
+        @Override
+        public <T> void createTableWithGsi(TableSchema<T> schema, String indexName) {
+            DynamoDbTable<T> table = enhancedClient.table(tableName, schema);
+            table.createTable(r -> r.provisionedThroughput(getDefaultProvisionedThroughput())
+                                    .globalSecondaryIndices(EnhancedGlobalSecondaryIndex.builder()
+                                                                                        .indexName(indexName)
+                                                                                        .projection(p -> p.projectionType(
+                                                                                            ProjectionType.KEYS_ONLY))
+                                                                                        .provisionedThroughput(
+                                                                                            getDefaultProvisionedThroughput())
+                                                                                        .build()));
+        }
+
+        @Override
+        public boolean tableExists() {
+            return tableName.equals(dynamoDbClient.describeTable(r -> r.tableName(tableName)).table().tableName());
+        }
+
+        @Override
+        public List<String> globalSecondaryIndexNames() {
+            List<GlobalSecondaryIndexDescription> indexes =
+                dynamoDbClient.describeTable(r -> r.tableName(tableName)).table().globalSecondaryIndexes();
+            if (indexes == null) {
+                return Collections.emptyList();
+            }
+            List<String> names = new ArrayList<>();
+            for (GlobalSecondaryIndexDescription index : indexes) {
+                names.add(index.indexName());
+            }
+            return names;
+        }
+
+        @Override
+        public void deleteTable() {
+            dynamoDbClient.deleteTable(DeleteTableRequest.builder().tableName(tableName).build());
+        }
+    }
+
+    private final class AsyncSetupClient implements SetupClient {
+        private final DynamoDbAsyncClient dynamoDbAsyncClient = localDynamoDb().createAsyncClient();
+        private final DynamoDbEnhancedAsyncClient enhancedClient =
+            DynamoDbEnhancedAsyncClient.builder().dynamoDbClient(dynamoDbAsyncClient).build();
+        private final String tableName;
+
+        AsyncSetupClient(String tableNameSuffix) {
+            this.tableName = getConcreteTableName(tableNameSuffix);
+        }
+
+        @Override
+        public <T> void createTable(TableSchema<T> schema) {
+            DynamoDbAsyncTable<T> table = enhancedClient.table(tableName, schema);
+            table.createTable(r -> r.provisionedThroughput(getDefaultProvisionedThroughput())).join();
+        }
+
+        @Override
+        public <T> void createTableWithGsi(TableSchema<T> schema, String indexName) {
+            DynamoDbAsyncTable<T> table = enhancedClient.table(tableName, schema);
+            table.createTable(r -> r.provisionedThroughput(getDefaultProvisionedThroughput())
+                                    .globalSecondaryIndices(EnhancedGlobalSecondaryIndex.builder()
+                                                                                        .indexName(indexName)
+                                                                                        .projection(p -> p.projectionType(
+                                                                                            ProjectionType.KEYS_ONLY))
+                                                                                        .provisionedThroughput(
+                                                                                            getDefaultProvisionedThroughput())
+                                                                                        .build()))
+                 .join();
+        }
+
+        @Override
+        public boolean tableExists() {
+            return tableName.equals(dynamoDbAsyncClient.describeTable(r -> r.tableName(tableName)).join().table().tableName());
+        }
+
+        @Override
+        public List<String> globalSecondaryIndexNames() {
+            List<GlobalSecondaryIndexDescription> indexes =
+                dynamoDbAsyncClient.describeTable(r -> r.tableName(tableName)).join().table().globalSecondaryIndexes();
+            if (indexes == null) {
+                return Collections.emptyList();
+            }
+            List<String> names = new ArrayList<>();
+            for (GlobalSecondaryIndexDescription index : indexes) {
+                names.add(index.indexName());
+            }
+            return names;
+        }
+
+        @Override
+        public void deleteTable() {
+            dynamoDbAsyncClient.deleteTable(DeleteTableRequest.builder().tableName(tableName).build()).join();
+        }
+    }
+}

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/functionaltests/DynamoDbEnhancedClientType.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/functionaltests/DynamoDbEnhancedClientType.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.functionaltests;
+
+/**
+ * Identifies the DynamoDB Enhanced Client mode used by parameterized table operation tests. The values distinguish
+ * operations performed through synchronous clients from operations performed through asynchronous clients.
+ */
+public enum DynamoDbEnhancedClientType {
+    SYNC,
+    ASYNC
+}

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/functionaltests/models/DefaultAttributeConverterProviderTestModels.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/functionaltests/models/DefaultAttributeConverterProviderTestModels.java
@@ -1,0 +1,1339 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.enhanced.dynamodb.functionaltests.models;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static software.amazon.awssdk.enhanced.dynamodb.mapper.StaticAttributeTags.primaryPartitionKey;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import software.amazon.awssdk.enhanced.dynamodb.EnhancedType;
+import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
+import software.amazon.awssdk.enhanced.dynamodb.document.EnhancedDocument;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.StaticImmutableTableSchema;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.StaticTableSchema;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbFlatten;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbImmutable;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbSecondaryPartitionKey;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbSecondarySortKey;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+
+/**
+ * Shared models, collection fixtures, and DynamoDB attribute maps for DefaultAttributeConverterProvider table tests.
+ */
+public final class DefaultAttributeConverterProviderTestModels {
+
+    public static final String TABLE_NAME = "TABLE_NAME";
+    public static final String ITEM_ID = "id-1";
+    public static final String COUNTER_KEY = "count";
+    public static final Integer COUNTER_VALUE = 1;
+    public static final String LABEL_VALUE = "red";
+    public static final String EVENT_VALUE = "created";
+    public static final String DIRECT_VALUE = "plain";
+    public static final String DETAILS_NOTE = "note-1";
+
+    private DefaultAttributeConverterProviderTestModels() {
+    }
+
+    public static LinkedHashMap<String, Integer> oneCounter() {
+        LinkedHashMap<String, Integer> counters = new LinkedHashMap<>();
+        counters.put(COUNTER_KEY, COUNTER_VALUE);
+        return counters;
+    }
+
+    public static LinkedHashSet<String> oneLabel() {
+        LinkedHashSet<String> labels = new LinkedHashSet<>();
+        labels.add(LABEL_VALUE);
+        return labels;
+    }
+
+    public static ArrayList<String> oneEvent() {
+        ArrayList<String> events = new ArrayList<>();
+        events.add(EVENT_VALUE);
+        return events;
+    }
+
+    public static AttributeValue idAttribute() {
+        return AttributeValue.builder().s(ITEM_ID).build();
+    }
+
+    public static AttributeValue countersAttribute() {
+        return AttributeValue.builder()
+                             .m(Collections.singletonMap(COUNTER_KEY,
+                                                         AttributeValue.builder().n("1").build()))
+                             .build();
+    }
+
+    public static AttributeValue labelsAttribute() {
+        return AttributeValue.builder().ss(LABEL_VALUE).build();
+    }
+
+    public static AttributeValue eventsAttribute() {
+        return AttributeValue.builder()
+                             .l(AttributeValue.builder().s(EVENT_VALUE).build())
+                             .build();
+    }
+
+    public static AttributeValue eventsWithNullElementAttribute() {
+        List<AttributeValue> members = new ArrayList<>();
+        members.add(AttributeValue.builder().s("a").build());
+        members.add(AttributeValue.fromNul(true));
+        members.add(AttributeValue.builder().s("b").build());
+        return AttributeValue.builder().l(members).build();
+    }
+
+    public static Map<String, AttributeValue> completeItem() {
+        Map<String, AttributeValue> item = new LinkedHashMap<>();
+        item.put("id", idAttribute());
+        item.put("counters", countersAttribute());
+        item.put("labels", labelsAttribute());
+        item.put("events", eventsAttribute());
+        return item;
+    }
+
+    public static Map<String, AttributeValue> completeItemWithNullableNull() {
+        Map<String, AttributeValue> item = new LinkedHashMap<>(completeItem());
+        item.put("nullable", AttributeValue.fromNul(true));
+        return item;
+    }
+
+    public static ConverterRecord populatedConverterRecord() {
+        ConverterRecord record = new ConverterRecord();
+        record.setId(ITEM_ID);
+        record.setCounters(oneCounter());
+        record.setLabels(oneLabel());
+        record.setEvents(oneEvent());
+        return record;
+    }
+
+    public static void assertWrittenItem(Map<String, AttributeValue> item) {
+        assertThat(item.get("id").s()).isEqualTo(ITEM_ID);
+        assertThat(item.get("counters")).isEqualTo(countersAttribute());
+        assertThat(item.get("labels")).isEqualTo(labelsAttribute());
+        assertThat(item.get("events")).isEqualTo(eventsAttribute());
+    }
+
+    public static void assertReconstructedCollections(ConverterRecord record) {
+        assertThat(record.getId()).isEqualTo(ITEM_ID);
+        assertThat(record.getCounters()).isInstanceOf(LinkedHashMap.class).isEqualTo(oneCounter());
+        assertThat(record.getLabels()).isInstanceOf(LinkedHashSet.class).isEqualTo(oneLabel());
+        assertThat(record.getEvents()).isInstanceOf(ArrayList.class).isEqualTo(oneEvent());
+    }
+
+    public static ConverterImmutable populatedConverterImmutable() {
+        return ConverterImmutable.builder()
+                                 .id(ITEM_ID)
+                                 .counters(oneCounter())
+                                 .labels(oneLabel())
+                                 .events(oneEvent())
+                                 .build();
+    }
+
+    public static StaticRecord populatedStaticRecord() {
+        StaticRecord record = new StaticRecord();
+        record.setId(ITEM_ID);
+        record.setCounters(oneCounter());
+        record.setLabels(oneLabel());
+        record.setEvents(oneEvent());
+        return record;
+    }
+
+    public static StaticImmutableRecord populatedStaticImmutableRecord() {
+        return StaticImmutableRecord.builder()
+                                    .id(ITEM_ID)
+                                    .counters(oneCounter())
+                                    .labels(oneLabel())
+                                    .events(oneEvent())
+                                    .build();
+    }
+
+    public static DefaultProviderBean populatedDefaultProviderBean() {
+        DefaultProviderBean bean = new DefaultProviderBean();
+        bean.setId(ITEM_ID);
+        bean.setCounters(oneCounter());
+        bean.setLabels(oneLabel());
+        bean.setEvents(oneEvent());
+        return bean;
+    }
+
+    public static DefaultProviderImmutable populatedDefaultProviderImmutable() {
+        return DefaultProviderImmutable.builder()
+                                       .id(ITEM_ID)
+                                       .counters(oneCounter())
+                                       .labels(oneLabel())
+                                       .events(oneEvent())
+                                       .build();
+    }
+
+    public static AllBranchesDetails populatedDetails() {
+        AllBranchesDetails details = new AllBranchesDetails();
+        details.setNote(DETAILS_NOTE);
+        return details;
+    }
+
+    public static TableSchema<AllBranchesDetails> detailsSchema() {
+        return TableSchema.fromBean(AllBranchesDetails.class);
+    }
+
+    public static AllBranchesBean populatedAllBranchesBean() {
+        AllBranchesBean bean = new AllBranchesBean();
+        bean.setId(ITEM_ID);
+        bean.setDirect(DIRECT_VALUE);
+        bean.setCounters(oneCounter());
+        bean.setLabels(oneLabel());
+        bean.setEvents(oneEvent());
+        bean.setStatus(TestEnum.OPEN);
+        bean.setDetails(populatedDetails());
+        return bean;
+    }
+
+    public static AllBranchesImmutable populatedAllBranchesImmutable() {
+        return AllBranchesImmutable.builder()
+                                   .id(ITEM_ID)
+                                   .direct(DIRECT_VALUE)
+                                   .counters(oneCounter())
+                                   .labels(oneLabel())
+                                   .events(oneEvent())
+                                   .status(TestEnum.OPEN)
+                                   .details(populatedDetails())
+                                   .build();
+    }
+
+    public static AllBranchesStaticRecord populatedAllBranchesStaticRecord() {
+        AllBranchesStaticRecord record = new AllBranchesStaticRecord();
+        record.setId(ITEM_ID);
+        record.setDirect(DIRECT_VALUE);
+        record.setCounters(oneCounter());
+        record.setLabels(oneLabel());
+        record.setEvents(oneEvent());
+        record.setStatus(TestEnum.OPEN);
+        record.setDetails(populatedDetails());
+        return record;
+    }
+
+    public static AllBranchesStaticImmutable populatedAllBranchesStaticImmutable() {
+        return AllBranchesStaticImmutable.builder()
+                                         .id(ITEM_ID)
+                                         .direct(DIRECT_VALUE)
+                                         .counters(oneCounter())
+                                         .labels(oneLabel())
+                                         .events(oneEvent())
+                                         .status(TestEnum.OPEN)
+                                         .details(populatedDetails())
+                                         .build();
+    }
+
+    public static Map<String, AttributeValue> allBranchesItem() {
+        Map<String, AttributeValue> details = new LinkedHashMap<>();
+        details.put("note", AttributeValue.builder().s(DETAILS_NOTE).build());
+        Map<String, AttributeValue> item = new LinkedHashMap<>(completeItem());
+        item.put("direct", AttributeValue.builder().s(DIRECT_VALUE).build());
+        item.put("status", AttributeValue.builder().s(TestEnum.OPEN.toString()).build());
+        item.put("details", AttributeValue.builder().m(details).build());
+        return item;
+    }
+
+    public static EnhancedDocument typedCollectionsDocument() {
+        return EnhancedDocument.builder()
+                               .putString("id", ITEM_ID)
+                               .putMap("counters", oneCounter(),
+                                       EnhancedType.of(String.class), EnhancedType.of(Integer.class))
+                               .put("labels", oneLabel(), EnhancedType.setOf(String.class))
+                               .putList("events", oneEvent(), EnhancedType.of(String.class))
+                               .build();
+    }
+
+    public static EnhancedDocument typedCollectionsDocumentWithNull() {
+        return typedCollectionsDocument().toBuilder()
+                                         .putNull("nullable")
+                                         .build();
+    }
+
+    public static EnhancedDocument allBranchesDocument(TableSchema<AllBranchesDetails> schema) {
+        return EnhancedDocument.builder()
+                               .putString("id", ITEM_ID)
+                               .putString("direct", DIRECT_VALUE)
+                               .putMap("counters", oneCounter(),
+                                       EnhancedType.of(String.class), EnhancedType.of(Integer.class))
+                               .put("labels", oneLabel(), EnhancedType.setOf(String.class))
+                               .putList("events", oneEvent(), EnhancedType.of(String.class))
+                               .put("status", TestEnum.OPEN, TestEnum.class)
+                               .put("details", populatedDetails(),
+                                    EnhancedType.documentOf(AllBranchesDetails.class, schema))
+                               .build();
+    }
+
+    public static StaticTableSchema<StaticRecord> staticRecordSchema() {
+        return StaticTableSchema.builder(StaticRecord.class)
+                                .newItemSupplier(StaticRecord::new)
+                                .addAttribute(String.class, a -> a.name("id")
+                                                                  .getter(StaticRecord::getId)
+                                                                  .setter(StaticRecord::setId)
+                                                                  .tags(primaryPartitionKey()))
+                                .addAttribute(EnhancedType.mapOf(String.class, Integer.class),
+                                              a -> a.name("counters")
+                                                    .getter(StaticRecord::getCounters)
+                                                    .setter(StaticRecord::setCounters))
+                                .addAttribute(EnhancedType.setOf(String.class),
+                                              a -> a.name("labels")
+                                                    .getter(StaticRecord::getLabels)
+                                                    .setter(StaticRecord::setLabels))
+                                .addAttribute(EnhancedType.listOf(String.class),
+                                              a -> a.name("events")
+                                                    .getter(StaticRecord::getEvents)
+                                                    .setter(StaticRecord::setEvents))
+                                .build();
+    }
+
+    public static StaticImmutableTableSchema<StaticImmutableRecord, StaticImmutableRecord.Builder>
+        staticImmutableRecordSchema() {
+        return StaticImmutableTableSchema.builder(StaticImmutableRecord.class, StaticImmutableRecord.Builder.class)
+                                         .newItemBuilder(StaticImmutableRecord::builder,
+                                                         StaticImmutableRecord.Builder::build)
+                                         .addAttribute(String.class, a -> a.name("id")
+                                                                           .getter(StaticImmutableRecord::id)
+                                                                           .setter(StaticImmutableRecord.Builder::id)
+                                                                           .tags(primaryPartitionKey()))
+                                         .addAttribute(EnhancedType.mapOf(String.class, Integer.class),
+                                                       a -> a.name("counters")
+                                                             .getter(StaticImmutableRecord::counters)
+                                                             .setter(StaticImmutableRecord.Builder::counters))
+                                         .addAttribute(EnhancedType.setOf(String.class),
+                                                       a -> a.name("labels")
+                                                             .getter(StaticImmutableRecord::labels)
+                                                             .setter(StaticImmutableRecord.Builder::labels))
+                                         .addAttribute(EnhancedType.listOf(String.class),
+                                                       a -> a.name("events")
+                                                             .getter(StaticImmutableRecord::events)
+                                                             .setter(StaticImmutableRecord.Builder::events))
+                                         .build();
+    }
+
+    public static StaticTableSchema<AllBranchesStaticRecord> allBranchesStaticSchema() {
+        TableSchema<AllBranchesDetails> details = detailsSchema();
+        return StaticTableSchema.builder(AllBranchesStaticRecord.class)
+                                .newItemSupplier(AllBranchesStaticRecord::new)
+                                .addAttribute(EnhancedType.of(String.class),
+                                              a -> a.name("id")
+                                                    .getter(AllBranchesStaticRecord::getId)
+                                                    .setter(AllBranchesStaticRecord::setId)
+                                                    .tags(primaryPartitionKey()))
+                                .addAttribute(EnhancedType.of(String.class),
+                                              a -> a.name("direct")
+                                                    .getter(AllBranchesStaticRecord::getDirect)
+                                                    .setter(AllBranchesStaticRecord::setDirect))
+                                .addAttribute(EnhancedType.mapOf(String.class, Integer.class),
+                                              a -> a.name("counters")
+                                                    .getter(AllBranchesStaticRecord::getCounters)
+                                                    .setter(AllBranchesStaticRecord::setCounters))
+                                .addAttribute(EnhancedType.setOf(String.class),
+                                              a -> a.name("labels")
+                                                    .getter(AllBranchesStaticRecord::getLabels)
+                                                    .setter(AllBranchesStaticRecord::setLabels))
+                                .addAttribute(EnhancedType.listOf(String.class),
+                                              a -> a.name("events")
+                                                    .getter(AllBranchesStaticRecord::getEvents)
+                                                    .setter(AllBranchesStaticRecord::setEvents))
+                                .addAttribute(EnhancedType.of(TestEnum.class),
+                                              a -> a.name("status")
+                                                    .getter(AllBranchesStaticRecord::getStatus)
+                                                    .setter(AllBranchesStaticRecord::setStatus))
+                                .addAttribute(EnhancedType.documentOf(AllBranchesDetails.class, details),
+                                              a -> a.name("details")
+                                                    .getter(AllBranchesStaticRecord::getDetails)
+                                                    .setter(AllBranchesStaticRecord::setDetails))
+                                .build();
+    }
+
+    public static StaticImmutableTableSchema<AllBranchesStaticImmutable, AllBranchesStaticImmutable.Builder>
+        allBranchesStaticImmutableSchema() {
+        TableSchema<AllBranchesDetails> details = detailsSchema();
+        return StaticImmutableTableSchema.builder(AllBranchesStaticImmutable.class,
+                                                  AllBranchesStaticImmutable.Builder.class)
+                                         .newItemBuilder(AllBranchesStaticImmutable::builder,
+                                                         AllBranchesStaticImmutable.Builder::build)
+                                         .addAttribute(EnhancedType.of(String.class),
+                                                       a -> a.name("id")
+                                                             .getter(AllBranchesStaticImmutable::id)
+                                                             .setter(AllBranchesStaticImmutable.Builder::id)
+                                                             .tags(primaryPartitionKey()))
+                                         .addAttribute(EnhancedType.of(String.class),
+                                                       a -> a.name("direct")
+                                                             .getter(AllBranchesStaticImmutable::direct)
+                                                             .setter(AllBranchesStaticImmutable.Builder::direct))
+                                         .addAttribute(EnhancedType.mapOf(String.class, Integer.class),
+                                                       a -> a.name("counters")
+                                                             .getter(AllBranchesStaticImmutable::counters)
+                                                             .setter(AllBranchesStaticImmutable.Builder::counters))
+                                         .addAttribute(EnhancedType.setOf(String.class),
+                                                       a -> a.name("labels")
+                                                             .getter(AllBranchesStaticImmutable::labels)
+                                                             .setter(AllBranchesStaticImmutable.Builder::labels))
+                                         .addAttribute(EnhancedType.listOf(String.class),
+                                                       a -> a.name("events")
+                                                             .getter(AllBranchesStaticImmutable::events)
+                                                             .setter(AllBranchesStaticImmutable.Builder::events))
+                                         .addAttribute(EnhancedType.of(TestEnum.class),
+                                                       a -> a.name("status")
+                                                             .getter(AllBranchesStaticImmutable::status)
+                                                             .setter(AllBranchesStaticImmutable.Builder::status))
+                                         .addAttribute(EnhancedType.documentOf(AllBranchesDetails.class, details),
+                                                       a -> a.name("details")
+                                                             .getter(AllBranchesStaticImmutable::details)
+                                                             .setter(AllBranchesStaticImmutable.Builder::details))
+                                         .build();
+    }
+
+    public enum TestEnum {
+        OPEN,
+        CLOSED
+    }
+
+    public static class UnsupportedType {
+    }
+
+    @DynamoDbBean
+    public static class ConverterRecord {
+        private String id;
+        private Map<String, Integer> counters;
+        private Set<String> labels;
+        private List<String> events;
+        private String nullable;
+
+        @DynamoDbPartitionKey
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        public Map<String, Integer> getCounters() {
+            return counters;
+        }
+
+        public void setCounters(Map<String, Integer> counters) {
+            this.counters = counters;
+        }
+
+        public Set<String> getLabels() {
+            return labels;
+        }
+
+        public void setLabels(Set<String> labels) {
+            this.labels = labels;
+        }
+
+        public List<String> getEvents() {
+            return events;
+        }
+
+        public void setEvents(List<String> events) {
+            this.events = events;
+        }
+
+        public String getNullable() {
+            return nullable;
+        }
+
+        public void setNullable(String nullable) {
+            this.nullable = nullable;
+        }
+    }
+
+    @DynamoDbImmutable(builder = ConverterImmutable.Builder.class)
+    public static final class ConverterImmutable {
+        private final String id;
+        private final Map<String, Integer> counters;
+        private final Set<String> labels;
+        private final List<String> events;
+
+        private ConverterImmutable(Builder builder) {
+            this.id = builder.id;
+            this.counters = builder.counters;
+            this.labels = builder.labels;
+            this.events = builder.events;
+        }
+
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        @DynamoDbPartitionKey
+        public String id() {
+            return id;
+        }
+
+        public Map<String, Integer> counters() {
+            return counters;
+        }
+
+        public Set<String> labels() {
+            return labels;
+        }
+
+        public List<String> events() {
+            return events;
+        }
+
+        public static final class Builder {
+            private String id;
+            private Map<String, Integer> counters;
+            private Set<String> labels;
+            private List<String> events;
+
+            private Builder() {
+            }
+
+            public Builder id(String id) {
+                this.id = id;
+                return this;
+            }
+
+            public Builder counters(Map<String, Integer> counters) {
+                this.counters = counters;
+                return this;
+            }
+
+            public Builder labels(Set<String> labels) {
+                this.labels = labels;
+                return this;
+            }
+
+            public Builder events(List<String> events) {
+                this.events = events;
+                return this;
+            }
+
+            public ConverterImmutable build() {
+                return new ConverterImmutable(this);
+            }
+        }
+    }
+
+    public static class StaticRecord {
+        private String id;
+        private Map<String, Integer> counters;
+        private Set<String> labels;
+        private List<String> events;
+
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        public Map<String, Integer> getCounters() {
+            return counters;
+        }
+
+        public void setCounters(Map<String, Integer> counters) {
+            this.counters = counters;
+        }
+
+        public Set<String> getLabels() {
+            return labels;
+        }
+
+        public void setLabels(Set<String> labels) {
+            this.labels = labels;
+        }
+
+        public List<String> getEvents() {
+            return events;
+        }
+
+        public void setEvents(List<String> events) {
+            this.events = events;
+        }
+    }
+
+    public static final class StaticImmutableRecord {
+        private final String id;
+        private final Map<String, Integer> counters;
+        private final Set<String> labels;
+        private final List<String> events;
+
+        private StaticImmutableRecord(Builder builder) {
+            this.id = builder.id;
+            this.counters = builder.counters;
+            this.labels = builder.labels;
+            this.events = builder.events;
+        }
+
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        public String id() {
+            return id;
+        }
+
+        public Map<String, Integer> counters() {
+            return counters;
+        }
+
+        public Set<String> labels() {
+            return labels;
+        }
+
+        public List<String> events() {
+            return events;
+        }
+
+        public static final class Builder {
+            private String id;
+            private Map<String, Integer> counters;
+            private Set<String> labels;
+            private List<String> events;
+
+            private Builder() {
+            }
+
+            public Builder id(String id) {
+                this.id = id;
+                return this;
+            }
+
+            public Builder counters(Map<String, Integer> counters) {
+                this.counters = counters;
+                return this;
+            }
+
+            public Builder labels(Set<String> labels) {
+                this.labels = labels;
+                return this;
+            }
+
+            public Builder events(List<String> events) {
+                this.events = events;
+                return this;
+            }
+
+            public StaticImmutableRecord build() {
+                return new StaticImmutableRecord(this);
+            }
+        }
+    }
+
+    @DynamoDbBean
+    public static class DefaultProviderBean {
+        private String id;
+        private Map<String, Integer> counters;
+        private Set<String> labels;
+        private List<String> events;
+
+        @DynamoDbPartitionKey
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        public Map<String, Integer> getCounters() {
+            return counters;
+        }
+
+        public void setCounters(Map<String, Integer> counters) {
+            this.counters = counters;
+        }
+
+        public Set<String> getLabels() {
+            return labels;
+        }
+
+        public void setLabels(Set<String> labels) {
+            this.labels = labels;
+        }
+
+        public List<String> getEvents() {
+            return events;
+        }
+
+        public void setEvents(List<String> events) {
+            this.events = events;
+        }
+    }
+
+    @DynamoDbImmutable(builder = DefaultProviderImmutable.Builder.class)
+    public static final class DefaultProviderImmutable {
+        private final String id;
+        private final Map<String, Integer> counters;
+        private final Set<String> labels;
+        private final List<String> events;
+
+        private DefaultProviderImmutable(Builder builder) {
+            this.id = builder.id;
+            this.counters = builder.counters;
+            this.labels = builder.labels;
+            this.events = builder.events;
+        }
+
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        @DynamoDbPartitionKey
+        public String id() {
+            return id;
+        }
+
+        public Map<String, Integer> counters() {
+            return counters;
+        }
+
+        public Set<String> labels() {
+            return labels;
+        }
+
+        public List<String> events() {
+            return events;
+        }
+
+        public static final class Builder {
+            private String id;
+            private Map<String, Integer> counters;
+            private Set<String> labels;
+            private List<String> events;
+
+            private Builder() {
+            }
+
+            public Builder id(String id) {
+                this.id = id;
+                return this;
+            }
+
+            public Builder counters(Map<String, Integer> counters) {
+                this.counters = counters;
+                return this;
+            }
+
+            public Builder labels(Set<String> labels) {
+                this.labels = labels;
+                return this;
+            }
+
+            public Builder events(List<String> events) {
+                this.events = events;
+                return this;
+            }
+
+            public DefaultProviderImmutable build() {
+                return new DefaultProviderImmutable(this);
+            }
+        }
+    }
+
+    @DynamoDbBean
+    public static class FlattenedChildBean {
+        private Map<String, Integer> counters;
+        private Set<String> labels;
+        private List<String> events;
+
+        public Map<String, Integer> getCounters() {
+            return counters;
+        }
+
+        public void setCounters(Map<String, Integer> counters) {
+            this.counters = counters;
+        }
+
+        public Set<String> getLabels() {
+            return labels;
+        }
+
+        public void setLabels(Set<String> labels) {
+            this.labels = labels;
+        }
+
+        public List<String> getEvents() {
+            return events;
+        }
+
+        public void setEvents(List<String> events) {
+            this.events = events;
+        }
+    }
+
+    @DynamoDbBean
+    public static class OuterFlattenedBean {
+        private String id;
+        private FlattenedChildBean child;
+
+        @DynamoDbPartitionKey
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        @DynamoDbFlatten
+        public FlattenedChildBean getChild() {
+            return child;
+        }
+
+        public void setChild(FlattenedChildBean child) {
+            this.child = child;
+        }
+    }
+
+    @DynamoDbBean
+    public static class SingleGsiPartitionBean {
+        private String id;
+        private String gsiKey;
+
+        @DynamoDbPartitionKey
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        @DynamoDbSecondaryPartitionKey(indexNames = "gsi")
+        public String getGsiKey() {
+            return gsiKey;
+        }
+
+        public void setGsiKey(String gsiKey) {
+            this.gsiKey = gsiKey;
+        }
+    }
+
+    @DynamoDbBean
+    public static class SingleGsiSortBean {
+        private String id;
+        private String gsiKey;
+        private Integer gsiSort;
+
+        @DynamoDbPartitionKey
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        @DynamoDbSecondaryPartitionKey(indexNames = "gsi")
+        public String getGsiKey() {
+            return gsiKey;
+        }
+
+        public void setGsiKey(String gsiKey) {
+            this.gsiKey = gsiKey;
+        }
+
+        @DynamoDbSecondarySortKey(indexNames = "gsi")
+        public Integer getGsiSort() {
+            return gsiSort;
+        }
+
+        public void setGsiSort(Integer gsiSort) {
+            this.gsiSort = gsiSort;
+        }
+    }
+
+    @DynamoDbBean
+    public static class AllBranchesDetails {
+        private String note;
+
+        public String getNote() {
+            return note;
+        }
+
+        public void setNote(String note) {
+            this.note = note;
+        }
+    }
+
+    @DynamoDbBean
+    public static class AllBranchesBean {
+        private String id;
+        private String direct;
+        private Map<String, Integer> counters;
+        private Set<String> labels;
+        private List<String> events;
+        private TestEnum status;
+        private AllBranchesDetails details;
+
+        @DynamoDbPartitionKey
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        public String getDirect() {
+            return direct;
+        }
+
+        public void setDirect(String direct) {
+            this.direct = direct;
+        }
+
+        public Map<String, Integer> getCounters() {
+            return counters;
+        }
+
+        public void setCounters(Map<String, Integer> counters) {
+            this.counters = counters;
+        }
+
+        public Set<String> getLabels() {
+            return labels;
+        }
+
+        public void setLabels(Set<String> labels) {
+            this.labels = labels;
+        }
+
+        public List<String> getEvents() {
+            return events;
+        }
+
+        public void setEvents(List<String> events) {
+            this.events = events;
+        }
+
+        public TestEnum getStatus() {
+            return status;
+        }
+
+        public void setStatus(TestEnum status) {
+            this.status = status;
+        }
+
+        public AllBranchesDetails getDetails() {
+            return details;
+        }
+
+        public void setDetails(AllBranchesDetails details) {
+            this.details = details;
+        }
+    }
+
+    @DynamoDbImmutable(builder = AllBranchesImmutable.Builder.class)
+    public static final class AllBranchesImmutable {
+        private final String id;
+        private final String direct;
+        private final Map<String, Integer> counters;
+        private final Set<String> labels;
+        private final List<String> events;
+        private final TestEnum status;
+        private final AllBranchesDetails details;
+
+        private AllBranchesImmutable(Builder builder) {
+            this.id = builder.id;
+            this.direct = builder.direct;
+            this.counters = builder.counters;
+            this.labels = builder.labels;
+            this.events = builder.events;
+            this.status = builder.status;
+            this.details = builder.details;
+        }
+
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        @DynamoDbPartitionKey
+        public String id() {
+            return id;
+        }
+
+        public String direct() {
+            return direct;
+        }
+
+        public Map<String, Integer> counters() {
+            return counters;
+        }
+
+        public Set<String> labels() {
+            return labels;
+        }
+
+        public List<String> events() {
+            return events;
+        }
+
+        public TestEnum status() {
+            return status;
+        }
+
+        public AllBranchesDetails details() {
+            return details;
+        }
+
+        public static final class Builder {
+            private String id;
+            private String direct;
+            private Map<String, Integer> counters;
+            private Set<String> labels;
+            private List<String> events;
+            private TestEnum status;
+            private AllBranchesDetails details;
+
+            private Builder() {
+            }
+
+            public Builder id(String id) {
+                this.id = id;
+                return this;
+            }
+
+            public Builder direct(String direct) {
+                this.direct = direct;
+                return this;
+            }
+
+            public Builder counters(Map<String, Integer> counters) {
+                this.counters = counters;
+                return this;
+            }
+
+            public Builder labels(Set<String> labels) {
+                this.labels = labels;
+                return this;
+            }
+
+            public Builder events(List<String> events) {
+                this.events = events;
+                return this;
+            }
+
+            public Builder status(TestEnum status) {
+                this.status = status;
+                return this;
+            }
+
+            public Builder details(AllBranchesDetails details) {
+                this.details = details;
+                return this;
+            }
+
+            public AllBranchesImmutable build() {
+                return new AllBranchesImmutable(this);
+            }
+        }
+    }
+
+    public static class AllBranchesStaticRecord {
+        private String id;
+        private String direct;
+        private Map<String, Integer> counters;
+        private Set<String> labels;
+        private List<String> events;
+        private TestEnum status;
+        private AllBranchesDetails details;
+
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        public String getDirect() {
+            return direct;
+        }
+
+        public void setDirect(String direct) {
+            this.direct = direct;
+        }
+
+        public Map<String, Integer> getCounters() {
+            return counters;
+        }
+
+        public void setCounters(Map<String, Integer> counters) {
+            this.counters = counters;
+        }
+
+        public Set<String> getLabels() {
+            return labels;
+        }
+
+        public void setLabels(Set<String> labels) {
+            this.labels = labels;
+        }
+
+        public List<String> getEvents() {
+            return events;
+        }
+
+        public void setEvents(List<String> events) {
+            this.events = events;
+        }
+
+        public TestEnum getStatus() {
+            return status;
+        }
+
+        public void setStatus(TestEnum status) {
+            this.status = status;
+        }
+
+        public AllBranchesDetails getDetails() {
+            return details;
+        }
+
+        public void setDetails(AllBranchesDetails details) {
+            this.details = details;
+        }
+    }
+
+    public static final class AllBranchesStaticImmutable {
+        private final String id;
+        private final String direct;
+        private final Map<String, Integer> counters;
+        private final Set<String> labels;
+        private final List<String> events;
+        private final TestEnum status;
+        private final AllBranchesDetails details;
+
+        private AllBranchesStaticImmutable(Builder builder) {
+            this.id = builder.id;
+            this.direct = builder.direct;
+            this.counters = builder.counters;
+            this.labels = builder.labels;
+            this.events = builder.events;
+            this.status = builder.status;
+            this.details = builder.details;
+        }
+
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        public String id() {
+            return id;
+        }
+
+        public String direct() {
+            return direct;
+        }
+
+        public Map<String, Integer> counters() {
+            return counters;
+        }
+
+        public Set<String> labels() {
+            return labels;
+        }
+
+        public List<String> events() {
+            return events;
+        }
+
+        public TestEnum status() {
+            return status;
+        }
+
+        public AllBranchesDetails details() {
+            return details;
+        }
+
+        public static final class Builder {
+            private String id;
+            private String direct;
+            private Map<String, Integer> counters;
+            private Set<String> labels;
+            private List<String> events;
+            private TestEnum status;
+            private AllBranchesDetails details;
+
+            private Builder() {
+            }
+
+            public Builder id(String id) {
+                this.id = id;
+                return this;
+            }
+
+            public Builder direct(String direct) {
+                this.direct = direct;
+                return this;
+            }
+
+            public Builder counters(Map<String, Integer> counters) {
+                this.counters = counters;
+                return this;
+            }
+
+            public Builder labels(Set<String> labels) {
+                this.labels = labels;
+                return this;
+            }
+
+            public Builder events(List<String> events) {
+                this.events = events;
+                return this;
+            }
+
+            public Builder status(TestEnum status) {
+                this.status = status;
+                return this;
+            }
+
+            public Builder details(AllBranchesDetails details) {
+                this.details = details;
+                return this;
+            }
+
+            public AllBranchesStaticImmutable build() {
+                return new AllBranchesStaticImmutable(this);
+            }
+        }
+    }
+
+    @DynamoDbBean
+    public static class BeanWithObject {
+        private String id;
+        private Object payload;
+
+        @DynamoDbPartitionKey
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        public Object getPayload() {
+            return payload;
+        }
+
+        public void setPayload(Object payload) {
+            this.payload = payload;
+        }
+    }
+
+    @DynamoDbBean
+    public static class BeanWithUnsupported {
+        private String id;
+        private UnsupportedType payload;
+
+        @DynamoDbPartitionKey
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        public UnsupportedType getPayload() {
+            return payload;
+        }
+
+        public void setPayload(UnsupportedType payload) {
+            this.payload = payload;
+        }
+    }
+
+    @DynamoDbBean
+    public static class BeanWithArrayList {
+        private String id;
+        private ArrayList<String> values;
+
+        @DynamoDbPartitionKey
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        public ArrayList<String> getValues() {
+            return values;
+        }
+
+        public void setValues(ArrayList<String> values) {
+            this.values = values;
+        }
+    }
+
+    @DynamoDbBean
+    public static class BeanWithHashSet {
+        private String id;
+        private HashSet<String> values;
+
+        @DynamoDbPartitionKey
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        public HashSet<String> getValues() {
+            return values;
+        }
+
+        public void setValues(HashSet<String> values) {
+            this.values = values;
+        }
+    }
+
+    @DynamoDbBean
+    public static class BeanWithHashMap {
+        private String id;
+        private HashMap<String, Integer> values;
+
+        @DynamoDbPartitionKey
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        public HashMap<String, Integer> getValues() {
+            return values;
+        }
+
+        public void setValues(HashMap<String, Integer> values) {
+            this.values = values;
+        }
+    }
+}


### PR DESCRIPTION
## Motivation and Context
 
The DynamoDB Enhanced Client requires generic type information to create collection converters. Raw `Map`, `Set`, and `List` declarations do not provide that information. Earlier converter resolution could access a missing type parameter and throw an `IndexOutOfBoundsException`.
 
Plain `Object` requires separate handling. Because `Object` is a supertype of the collection interfaces, it could enter collection routing even though it is not a collection and the default provider has no `Object` converter.
 
Nested collection failures also did not always identify the actual missing type. For example, `Map<String, Object>` requires a converter for `Object`, so the error should identify `Object` rather than the enclosing map.
 
## Changes
 
This change improves validation and diagnostics while preserving existing collection-routing behavior.
 
- `DefaultAttributeConverterProvider` excludes plain `Object` from collection routing.
- Raw `Map`, `Set`, and `List` declarations are validated before their type parameters are accessed.
- Nested list members, set members, and map values are resolved through the public converter lookup. A missing converter now identifies the missing nested type.
- `DefaultEnhancedDocument` applies the same `Object` guard and raw-type validation to its direct list and map conversion paths.
- The configured converter-provider chain remains available for `Object` and other custom types. Applications can provide an `AttributeConverter<Object>` when they define the required serialization behavior.
 
## Behavior and Compatibility
 
The existing collection-routing precedence remains map, then set, then list. This preserves the existing behavior of `Collection<T>` and `Iterable<T>`, which resolve through the set converter.
 
| Declaration | Result |
|---|---|
| `Map<String, Integer>`, `Set<String>`, and `List<String>` | Supported when the required converters are available. |
| `Collection<String>` and `Iterable<String>` | Supported with existing set-converter behavior. |
| `SequencedCollection<String>` | Supported through the existing hierarchy on Java 21 and later. |
| Raw `Map`, `Set`, and `List` | Rejected with an `IllegalStateException` stating that type parameters are required. |
| Plain `Object` with only default converters | Rejected because no default `Object` converter exists. |
| `Map<String, Object>`, `Set<Object>`, and `List<Object>` with only default converters | Rejected with `Converter not found for EnhancedType(java.lang.Object)`. |
| Nested unsupported member or map value | Rejected with an error for the missing nested type. |
| Plain or nested `Object` with a custom converter | Supported when the configured provider chain returns an `AttributeConverter<Object>`. |
| `HashMap`, `HashSet`, `ArrayList`, and other concrete collection declarations | Remain unsupported by the default provider. |
 
No public APIs, annotations, schemas, dependencies, or DynamoDB wire representations are changed.
 
## Testing
 
The updated tests cover converter lookup, caching, conversion, and registration. They cover parameterized and raw `Map`, `Set`, `List`, `Collection`, and `Iterable` declarations, concrete collection implementations, plain `Object`, custom `Object` converters, and nested missing member types.
 
Bean, immutable, document, static, static immutable, nested, and flattened schema paths are covered. Existing sync and async CRUD, scan, query, batch, transaction, null handling, and extension tests continue to exercise the Enhanced Client.
 
### Test Coverage on modified classes
 
<img width="768" height="339" alt="image" src="https://github.com/user-attachments/assets/ebc32521-65b9-4af4-8bdd-6d8b29a3af64" />

 
### Test coverage checklist
 
| Scenario | Covered | Comments |
|---|:---:|---|
| **1. Different TableSchema Creation Methods** | [x] | |
| a. `TableSchema.fromBean(Customer.class)` | [x] | |
| b. `TableSchema.fromImmutableClass(Customer.class)` | [x] | |
| c. `TableSchema.documentSchemaBuilder().build()` | [x] | |
| d. `StaticTableSchema.builder(Customer.class)` | [x] | |
| **2. Nesting of Different TableSchema Types** | [x] | |
| a. Bean with nested bean as non-null | [x] | |
| b. Bean with nested immutable as non-null | [x] | |
| c. Immutable with nested bean as non-null | [x] | |
| d. Bean with nested bean as null | [x] | |
| e. Bean with nested immutable as null | [x] | |
| f. Immutable with nested bean as null | [x] | |
| **3. CRUD Operations** | [x] | Sync, async, functional, and integration coverage exists. |
| a. `scan()` | [x] | |
| b. `query()` | [x] | |
| c. `updateItem()` | [x] | |
| d. `putItem()` | [x] | |
| e. `getItem()` | [x] | |
| f. `deleteItem()` | [x] | |
| g. `batchGetItem()` | [x] | |
| h. `batchWriteItem()` | [x] | |
| i. `transactGetItems()` | [x] | |
| j. `transactWriteItems()` | [x] | |
| **4. Data Types and Null Handling** | [x] | |
| a. Top-level null attributes | [x] | |
| b. Collections with null elements | [x] | |
| c. Maps with null values | [x] | |
| d. Conversion between null Java values and `AttributeValue` | [x] | |
| e. Serialization and deserialization cycle with null values | [x] | |
| **5. AsyncTable and SyncTable** | [x] | |
| a. `DynamoDbAsyncTable` | [x] | |
| b. `DynamoDbTable` | [x] | |
| **6. New or Modification in Extensions** | [x] | Existing extension coverage remains applicable. This change does not modify extensions. |
| a. All TableSchema methods with extensions | [ ] | No extension implementation changes. |
| b. Default values in annotations | [ ] | Not changed by this PR. |
| c. Annotation and builder combination through extensions | [ ] | No new coverage added for this combination. |
| **7. New or Modification in Converters** | [x] | Core focus of this PR. |
| a. All TableSchema creation methods | [x] | |
| b. Default values in annotations | [ ] | Converter routing does not modify annotation default-value behavior. |
| c. Scenarios from sections 1 to 5 | [x] | |
| **8. Shared Client Cross Table Behavior** | [ ] | No shared client configuration changes. |
| a. Supported and unsupported or custom schema tables on one client | [ ] | No mixed schema client scenario added. |
| b. Extension-enabled shared client | [ ] | No shared client extension scenario added. |
| c. Cache isolation | [x] | `DefaultAttributeConverterProviderCacheTest` covers converter caching. |
| d. Async shared-client scenarios | [ ] | No async shared client scenario added. |
| **9. Extension Interaction Matrix** | [ ] | No extension implementation changes. |
| a. Default and custom extension-chain ordering | [x] | Existing `ChainExtensionTest` coverage. |
| b. Auto timestamp and versioning on the same item | [ ] | This change does not modify extension interaction behavior. |
| c. Auto UUID and update behavior interaction | [ ] | This change does not modify auto UUID or update behavior. |
| d. Extensions with condition expressions | [ ] | This change does not affect condition expression processing. |
| e. Extensions in batch and transaction flows | [ ] | This change does not modify extension execution in batch or transaction requests. |
| **10. Nested and Flattened Cross Operation Invariants** | [x] | Existing nested and flattened coverage remains applicable. |
| a. Flattened attributes across chained operations | [ ] | No cross operation validation changes. |
| b. Flattened maps with mixed scalar, map, and list payloads | [ ] | No flattened payload conversion changes. |
| c. Nested projection and filter combinations | [ ] | This change does not alter projection or filter expression behavior. |
| d. Nested structures with partition, sort, or index tags | [x] | Existing `FlattenWithTagsTest` coverage. |
| e. Sync and async parity for nested and flattened invariants | [ ] | No sync or async table behavior changes. |
| **11. Mixed Schema Multi Table Request** | [ ] | No multi table request changes. |
| a. Mixed-schema `batchGet` | [ ] | No `batchGet` request changes. |
| b. Mixed-schema `batchWrite` | [ ] | No `batchWrite` request changes. |
| c. Mixed-schema `transactGet` | [ ] | No `transactGet` request changes. |
| d. Mixed-schema `transactWrite` | [ ] | No `transactWrite` request changes. |
| e. Partial success and failure diagnostics | [ ] | No request diagnostic or partial-result handling changes. |
 
## Types of changes
 
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
 
## Checklist
 
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document.
- [x] Local run of `mvn install` succeeds.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the Javadoc documentation.
- [ ] I have updated the Javadoc documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have added a changelog entry.
- [ ] My change is to implement a 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md).
 
## License
 
- [x] I confirm that this pull request can be released under the Apache 2 license.