### PR TITLE
[Default Read/Write Timeout 5/N] Rename rollout gate to AWS_ENABLE_DEFAULT_SOCKET_TIMEOUT_2026

### DIFF
--- a/codegen/src/main/java/software/amazon/awssdk/codegen/model/config/customization/CustomizationConfig.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/model/config/customization/CustomizationConfig.java
@@ -233,7 +233,7 @@ public class CustomizationConfig {
     /**
      * Whether the client will apply a default read/write timeout by default.
      */
-    private Boolean defaultEnableReadTimeout2026;
+    private Boolean defaultEnableSocketTimeout2026;
 
     /**
      * Whether to generate an abstract decorator class that delegates to the async service client
@@ -742,12 +742,12 @@ public class CustomizationConfig {
         this.defaultNewRetries2026 = defaultNewRetries2026;
     }
 
-    public Boolean getDefaultEnableReadTimeout2026() {
-        return defaultEnableReadTimeout2026;
+    public Boolean getDefaultEnableSocketTimeout2026() {
+        return defaultEnableSocketTimeout2026;
     }
 
-    public void setDefaultEnableReadTimeout2026(Boolean defaultEnableReadTimeout2026) {
-        this.defaultEnableReadTimeout2026 = defaultEnableReadTimeout2026;
+    public void setDefaultEnableSocketTimeout2026(Boolean defaultEnableSocketTimeout2026) {
+        this.defaultEnableSocketTimeout2026 = defaultEnableSocketTimeout2026;
     }
 
     public ServiceConfig getServiceConfig() {

--- a/codegen/src/main/java/software/amazon/awssdk/codegen/poet/builder/BaseClientBuilderClass.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/poet/builder/BaseClientBuilderClass.java
@@ -332,7 +332,7 @@ public class BaseClientBuilderClass implements ClassSpec {
         String userAgent = model.getCustomizationConfig().getUserAgent();
         RetryMode defaultRetryMode = model.getCustomizationConfig().getDefaultRetryMode();
         Boolean defaultNewRetries2026 = model.getCustomizationConfig().getDefaultNewRetries2026();
-        Boolean defaultEnableReadTimeout2026 = model.getCustomizationConfig().getDefaultEnableReadTimeout2026();
+        Boolean defaultEnableSocketTimeout2026 = model.getCustomizationConfig().getDefaultEnableSocketTimeout2026();
 
         // If none of the options are customized, then we do not need to bother overriding the method
         if (!hasInternalDefaults()) {
@@ -357,9 +357,9 @@ public class BaseClientBuilderClass implements ClassSpec {
             builder.addCode("c.option($T.DEFAULT_NEW_RETRIES_2026, $L);\n",
                             SdkClientOption.class, defaultNewRetries2026);
         }
-        if (defaultEnableReadTimeout2026 != null) {
-            builder.addCode("c.option($T.DEFAULT_ENABLE_READ_TIMEOUT_2026, $L);\n",
-                            SdkClientOption.class, defaultEnableReadTimeout2026);
+        if (defaultEnableSocketTimeout2026 != null) {
+            builder.addCode("c.option($T.DEFAULT_ENABLE_SOCKET_TIMEOUT_2026, $L);\n",
+                            SdkClientOption.class, defaultEnableSocketTimeout2026);
         }
         builder.addCode("});\n");
         return Optional.of(builder.build());
@@ -370,7 +370,7 @@ public class BaseClientBuilderClass implements ClassSpec {
         return customizationConfig.getUserAgent() != null
                || customizationConfig.getDefaultRetryMode() != null
                || customizationConfig.getDefaultNewRetries2026() != null
-               || customizationConfig.getDefaultEnableReadTimeout2026() != null;
+               || customizationConfig.getDefaultEnableSocketTimeout2026() != null;
     }
 
     private MethodSpec finalizeServiceConfigurationMethod() {

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-client-builder-internal-defaults-class.java
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/builder/test-client-builder-internal-defaults-class.java
@@ -77,7 +77,7 @@ abstract class DefaultJsonBaseClientBuilder<B extends JsonBaseClientBuilder<B, C
             c.option(SdkClientOption.INTERNAL_USER_AGENT, "md/foobar");
             c.option(SdkClientOption.DEFAULT_RETRY_MODE, RetryMode.STANDARD);
             c.option(SdkClientOption.DEFAULT_NEW_RETRIES_2026, true);
-            c.option(SdkClientOption.DEFAULT_ENABLE_READ_TIMEOUT_2026, true);
+            c.option(SdkClientOption.DEFAULT_ENABLE_SOCKET_TIMEOUT_2026, true);
         });
     }
 

--- a/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/internalconfig/customization.config
+++ b/codegen/src/test/resources/software/amazon/awssdk/codegen/poet/client/c2j/internalconfig/customization.config
@@ -5,5 +5,5 @@
     "userAgent": "md/foobar",
     "defaultRetryMode": "STANDARD",
     "defaultNewRetries2026": "true",
-    "defaultEnableReadTimeout2026": "true"
+    "defaultEnableSocketTimeout2026": "true"
 }

--- a/core/aws-core/src/main/java/software/amazon/awssdk/awscore/client/builder/AwsDefaultClientBuilder.java
+++ b/core/aws-core/src/main/java/software/amazon/awssdk/awscore/client/builder/AwsDefaultClientBuilder.java
@@ -51,7 +51,7 @@ import software.amazon.awssdk.core.client.builder.SdkDefaultClientBuilder;
 import software.amazon.awssdk.core.client.config.SdkAdvancedClientOption;
 import software.amazon.awssdk.core.client.config.SdkClientConfiguration;
 import software.amazon.awssdk.core.client.config.SdkClientOption;
-import software.amazon.awssdk.core.http.EnableDefaultReadTimeout2026Resolver;
+import software.amazon.awssdk.core.http.EnableDefaultSocketTimeout2026Resolver;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
 import software.amazon.awssdk.core.internal.SdkInternalTestAdvancedClientOption;
 import software.amazon.awssdk.core.internal.retry.SdkDefaultRetryStrategy;
@@ -263,10 +263,10 @@ public abstract class AwsDefaultClientBuilder<BuilderT extends AwsClientBuilder<
     }
 
     /**
-     * Applies the {@code AWS_ENABLE_DEFAULT_READ_TIMEOUT_2026} rollout gate to the codegen-baked
+     * Applies the {@code AWS_ENABLE_DEFAULT_SOCKET_TIMEOUT_2026} rollout gate to the codegen-baked
      * {@link SdkHttpConfigurationOption#SDK_INTERNAL_FALLBACK_READ_WRITE_TIMEOUT} contributed by {@link #serviceHttpConfig()}.
-     * The gate resolves from the {@code AWS_ENABLE_DEFAULT_READ_TIMEOUT_2026} environment variable/system property, else the
-     * codegen-baked {@link SdkClientOption#DEFAULT_ENABLE_READ_TIMEOUT_2026} default, else off.
+     * The gate resolves from the {@code AWS_ENABLE_DEFAULT_SOCKET_TIMEOUT_2026} environment variable/system property, else the
+     * codegen-baked {@link SdkClientOption#DEFAULT_ENABLE_SOCKET_TIMEOUT_2026} default, else off.
      *
      * <p>When the gate is on, an unlisted service (nothing baked) gets the flat 5-minute default and a baked tier is kept as-is
      * ({@link Duration#ZERO} for fully-exempt, 15 minutes for partial). When the gate is off, a baked positive tier (partial)
@@ -275,8 +275,8 @@ public abstract class AwsDefaultClientBuilder<BuilderT extends AwsClientBuilder<
      * not truthy, so the HTTP client's option-absent path applies nothing either way.
      */
     private AttributeMap applyDefaultReadWriteTimeout(LazyValueSource config, AttributeMap serviceHttpConfig) {
-        boolean gateEnabled = new EnableDefaultReadTimeout2026Resolver()
-            .defaultEnableReadTimeout2026(config.get(SdkClientOption.DEFAULT_ENABLE_READ_TIMEOUT_2026))
+        boolean gateEnabled = new EnableDefaultSocketTimeout2026Resolver()
+            .defaultEnableSocketTimeout2026(config.get(SdkClientOption.DEFAULT_ENABLE_SOCKET_TIMEOUT_2026))
             .resolve();
 
         Duration bakedTier = serviceHttpConfig.get(SdkHttpConfigurationOption.SDK_INTERNAL_FALLBACK_READ_WRITE_TIMEOUT);

--- a/core/aws-core/src/test/java/software/amazon/awssdk/awscore/client/builder/AwsDefaultClientBuilderReadWriteTimeoutTest.java
+++ b/core/aws-core/src/test/java/software/amazon/awssdk/awscore/client/builder/AwsDefaultClientBuilderReadWriteTimeoutTest.java
@@ -47,14 +47,14 @@ import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.utils.AttributeMap;
 
 /**
- * Verifies the {@code AWS_ENABLE_DEFAULT_READ_TIMEOUT_2026} rollout gate applied in
+ * Verifies the {@code AWS_ENABLE_DEFAULT_SOCKET_TIMEOUT_2026} rollout gate applied in
  * {@link AwsDefaultClientBuilder#resolveHttpClientConfig} to the codegen-baked
  * {@link SdkHttpConfigurationOption#SDK_INTERNAL_FALLBACK_READ_WRITE_TIMEOUT}.
  */
 @ExtendWith(MockitoExtension.class)
 class AwsDefaultClientBuilderReadWriteTimeoutTest {
 
-    private static final String GATE_PROPERTY = SdkSystemSetting.AWS_ENABLE_DEFAULT_READ_TIMEOUT_2026.property();
+    private static final String GATE_PROPERTY = SdkSystemSetting.AWS_ENABLE_DEFAULT_SOCKET_TIMEOUT_2026.property();
     private static final Duration PARTIAL_TIER = Duration.ofMinutes(15);
     private static final Duration FLAT_DEFAULT = Duration.ofMinutes(5);
 
@@ -168,7 +168,7 @@ class AwsDefaultClientBuilderReadWriteTimeoutTest {
             if (!codegenGateDefault) {
                 return config;
             }
-            return config.merge(c -> c.option(SdkClientOption.DEFAULT_ENABLE_READ_TIMEOUT_2026, true));
+            return config.merge(c -> c.option(SdkClientOption.DEFAULT_ENABLE_SOCKET_TIMEOUT_2026, true));
         }
 
         @Override

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/SdkSystemSetting.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/SdkSystemSetting.java
@@ -286,7 +286,7 @@ public enum SdkSystemSetting implements SystemSetting {
      * <p>This setting is not intended to be used by end users. It gates an interim rollout and is subject to removal in a
      * future release.
      */
-    AWS_ENABLE_DEFAULT_READ_TIMEOUT_2026("aws.enableDefaultReadTimeout2026", null);
+    AWS_ENABLE_DEFAULT_SOCKET_TIMEOUT_2026("aws.enableDefaultSocketTimeout2026", null);
 
     private final String systemProperty;
     private final String defaultValue;

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/config/SdkClientOption.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/client/config/SdkClientOption.java
@@ -312,11 +312,11 @@ public final class SdkClientOption<T> extends ClientOption<T> {
     public static final SdkClientOption<Boolean> DEFAULT_NEW_RETRIES_2026 = new SdkClientOption<>(Boolean.class);
 
     /**
-     * Option to specify the default for the {@code AWS_ENABLE_DEFAULT_READ_TIMEOUT_2026} feature gate for the SDK client.
+     * Option to specify the default for the {@code AWS_ENABLE_DEFAULT_SOCKET_TIMEOUT_2026} feature gate for the SDK client.
      * This option is not intended to be set by end users. It gates an interim rollout and is subject to removal in a future
      * release.
      */
-    public static final SdkClientOption<Boolean> DEFAULT_ENABLE_READ_TIMEOUT_2026 = new SdkClientOption<>(Boolean.class);
+    public static final SdkClientOption<Boolean> DEFAULT_ENABLE_SOCKET_TIMEOUT_2026 = new SdkClientOption<>(Boolean.class);
 
     /**
      * Whether retries 2.1 behavior is enabled.

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/http/EnableDefaultSocketTimeout2026Resolver.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/http/EnableDefaultSocketTimeout2026Resolver.java
@@ -20,21 +20,21 @@ import software.amazon.awssdk.annotations.SdkProtectedApi;
 import software.amazon.awssdk.core.SdkSystemSetting;
 
 /**
- * Resolver for the {@link SdkSystemSetting#AWS_ENABLE_DEFAULT_READ_TIMEOUT_2026} that supports setting a fallback value if not
+ * Resolver for the {@link SdkSystemSetting#AWS_ENABLE_DEFAULT_SOCKET_TIMEOUT_2026} that supports setting a fallback value if not
  * defined in the environment or system properties.
  */
 @SdkProtectedApi
-public final class EnableDefaultReadTimeout2026Resolver {
-    private Boolean defaultEnableReadTimeout2026;
+public final class EnableDefaultSocketTimeout2026Resolver {
+    private Boolean defaultEnableSocketTimeout2026;
 
     /**
-     * The default value for {@code AWS_ENABLE_DEFAULT_READ_TIMEOUT_2026} if not configured via
-     * {@link SdkSystemSetting#AWS_ENABLE_DEFAULT_READ_TIMEOUT_2026}.
+     * The default value for {@code AWS_ENABLE_DEFAULT_SOCKET_TIMEOUT_2026} if not configured via
+     * {@link SdkSystemSetting#AWS_ENABLE_DEFAULT_SOCKET_TIMEOUT_2026}.
      *
      * @return This resolver for method chaining.
      */
-    public EnableDefaultReadTimeout2026Resolver defaultEnableReadTimeout2026(Boolean defaultEnableReadTimeout2026) {
-        this.defaultEnableReadTimeout2026 = defaultEnableReadTimeout2026;
+    public EnableDefaultSocketTimeout2026Resolver defaultEnableSocketTimeout2026(Boolean defaultEnableSocketTimeout2026) {
+        this.defaultEnableSocketTimeout2026 = defaultEnableSocketTimeout2026;
         return this;
     }
 
@@ -42,14 +42,14 @@ public final class EnableDefaultReadTimeout2026Resolver {
      * Resolve whether a default read/write timeout is applied.
      */
     public boolean resolve() {
-        Optional<Boolean> envConfig = SdkSystemSetting.AWS_ENABLE_DEFAULT_READ_TIMEOUT_2026.getBooleanValue();
+        Optional<Boolean> envConfig = SdkSystemSetting.AWS_ENABLE_DEFAULT_SOCKET_TIMEOUT_2026.getBooleanValue();
 
         if (envConfig.isPresent()) {
             return envConfig.get();
         }
 
-        if (defaultEnableReadTimeout2026 != null) {
-            return defaultEnableReadTimeout2026;
+        if (defaultEnableSocketTimeout2026 != null) {
+            return defaultEnableSocketTimeout2026;
         }
 
         return false;

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/http/EnableDefaultSocketTimeout2026ResolverTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/http/EnableDefaultSocketTimeout2026ResolverTest.java
@@ -27,35 +27,35 @@ import org.junit.jupiter.params.provider.MethodSource;
 import software.amazon.awssdk.core.SdkSystemSetting;
 import software.amazon.awssdk.testutils.EnvironmentVariableHelper;
 
-public class EnableDefaultReadTimeout2026ResolverTest {
-    private static String enableDefaultReadTimeout2026Save;
+public class EnableDefaultSocketTimeout2026ResolverTest {
+    private static String enableDefaultSocketTimeout2026Save;
 
     @BeforeAll
     static void setup() {
-        enableDefaultReadTimeout2026Save = System.getProperty(SdkSystemSetting.AWS_ENABLE_DEFAULT_READ_TIMEOUT_2026.property());
+        enableDefaultSocketTimeout2026Save = System.getProperty(SdkSystemSetting.AWS_ENABLE_DEFAULT_SOCKET_TIMEOUT_2026.property());
     }
 
     @AfterAll
     static void teardown() {
-        if (enableDefaultReadTimeout2026Save != null) {
-            System.setProperty(SdkSystemSetting.AWS_ENABLE_DEFAULT_READ_TIMEOUT_2026.property(),
-                               enableDefaultReadTimeout2026Save);
+        if (enableDefaultSocketTimeout2026Save != null) {
+            System.setProperty(SdkSystemSetting.AWS_ENABLE_DEFAULT_SOCKET_TIMEOUT_2026.property(),
+                               enableDefaultSocketTimeout2026Save);
         } else {
-            System.clearProperty(SdkSystemSetting.AWS_ENABLE_DEFAULT_READ_TIMEOUT_2026.property());
+            System.clearProperty(SdkSystemSetting.AWS_ENABLE_DEFAULT_SOCKET_TIMEOUT_2026.property());
         }
     }
 
     @BeforeEach
     void methodSetup() {
-        System.clearProperty(SdkSystemSetting.AWS_ENABLE_DEFAULT_READ_TIMEOUT_2026.property());
+        System.clearProperty(SdkSystemSetting.AWS_ENABLE_DEFAULT_SOCKET_TIMEOUT_2026.property());
     }
 
     @Test
     void systemSetting_usesExpectedEnvironmentVariableAndSystemPropertyNames() {
-        assertThat(SdkSystemSetting.AWS_ENABLE_DEFAULT_READ_TIMEOUT_2026.environmentVariable())
-            .isEqualTo("AWS_ENABLE_DEFAULT_READ_TIMEOUT_2026");
-        assertThat(SdkSystemSetting.AWS_ENABLE_DEFAULT_READ_TIMEOUT_2026.property())
-            .isEqualTo("aws.enableDefaultReadTimeout2026");
+        assertThat(SdkSystemSetting.AWS_ENABLE_DEFAULT_SOCKET_TIMEOUT_2026.environmentVariable())
+            .isEqualTo("AWS_ENABLE_DEFAULT_SOCKET_TIMEOUT_2026");
+        assertThat(SdkSystemSetting.AWS_ENABLE_DEFAULT_SOCKET_TIMEOUT_2026.property())
+            .isEqualTo("aws.enableDefaultSocketTimeout2026");
     }
 
     @ParameterizedTest
@@ -63,15 +63,15 @@ public class EnableDefaultReadTimeout2026ResolverTest {
     void resolve_behavesCorrectly(TestParams params) {
         EnvironmentVariableHelper.run((env) -> {
             if (params.systemProperty != null) {
-                System.setProperty(SdkSystemSetting.AWS_ENABLE_DEFAULT_READ_TIMEOUT_2026.property(), params.systemProperty);
+                System.setProperty(SdkSystemSetting.AWS_ENABLE_DEFAULT_SOCKET_TIMEOUT_2026.property(), params.systemProperty);
             }
 
             if (params.envVar != null) {
-                env.set(SdkSystemSetting.AWS_ENABLE_DEFAULT_READ_TIMEOUT_2026.environmentVariable(), params.envVar);
+                env.set(SdkSystemSetting.AWS_ENABLE_DEFAULT_SOCKET_TIMEOUT_2026.environmentVariable(), params.envVar);
             }
 
-            EnableDefaultReadTimeout2026Resolver resolver =
-                new EnableDefaultReadTimeout2026Resolver().defaultEnableReadTimeout2026(params.defaultEnableReadTimeout2026);
+            EnableDefaultSocketTimeout2026Resolver resolver =
+                new EnableDefaultSocketTimeout2026Resolver().defaultEnableSocketTimeout2026(params.defaultEnableSocketTimeout2026);
 
             assertThat(resolver.resolve()).isEqualTo(params.expected);
         });
@@ -83,19 +83,19 @@ public class EnableDefaultReadTimeout2026ResolverTest {
             new TestParams().expected(false),
 
             // precedence testing
-            new TestParams().systemProperty("true").defaultEnableReadTimeout2026(true).expected(true),
-            new TestParams().systemProperty("false").defaultEnableReadTimeout2026(true).expected(false),
-            new TestParams().envVar("true").defaultEnableReadTimeout2026(true).expected(true),
-            new TestParams().envVar("false").defaultEnableReadTimeout2026(true).expected(false),
-            new TestParams().defaultEnableReadTimeout2026(true).expected(true),
-            new TestParams().defaultEnableReadTimeout2026(false).expected(false)
+            new TestParams().systemProperty("true").defaultEnableSocketTimeout2026(true).expected(true),
+            new TestParams().systemProperty("false").defaultEnableSocketTimeout2026(true).expected(false),
+            new TestParams().envVar("true").defaultEnableSocketTimeout2026(true).expected(true),
+            new TestParams().envVar("false").defaultEnableSocketTimeout2026(true).expected(false),
+            new TestParams().defaultEnableSocketTimeout2026(true).expected(true),
+            new TestParams().defaultEnableSocketTimeout2026(false).expected(false)
         );
     }
 
     private static class TestParams {
         private String systemProperty;
         private String envVar;
-        private Boolean defaultEnableReadTimeout2026;
+        private Boolean defaultEnableSocketTimeout2026;
         private boolean expected;
 
         public TestParams systemProperty(String systemProperty) {
@@ -108,8 +108,8 @@ public class EnableDefaultReadTimeout2026ResolverTest {
             return this;
         }
 
-        public TestParams defaultEnableReadTimeout2026(Boolean defaultEnableReadTimeout2026) {
-            this.defaultEnableReadTimeout2026 = defaultEnableReadTimeout2026;
+        public TestParams defaultEnableSocketTimeout2026(Boolean defaultEnableSocketTimeout2026) {
+            this.defaultEnableSocketTimeout2026 = defaultEnableSocketTimeout2026;
             return this;
         }
 


### PR DESCRIPTION
## Motivation and Context

This is series item 5/N of the default read/write timeout work. Earlier items introduced an interim, off-by-default rollout gate under the working name `AWS_ENABLE_DEFAULT_READ_TIMEOUT_2026`. The cross-SDK teams have since settled on `SOCKET` (rather than `READ`) as the name for this gate. It is a mechanical, behavior-preserving rename with no functional change.

Base branch is the feature branch for this series, not `master`.

## Modifications

Renamed the rollout-gate symbols from the interim `READ` name to the settled `SOCKET` name.

- `SdkSystemSetting`: `AWS_ENABLE_DEFAULT_READ_TIMEOUT_2026` -> `AWS_ENABLE_DEFAULT_SOCKET_TIMEOUT_2026`. This also renames the environment variable string `AWS_ENABLE_DEFAULT_SOCKET_TIMEOUT_2026` and the system property `aws.enableDefaultSocketTimeout2026` (formerly `aws.enableDefaultReadTimeout2026`), which are the customer-facing opt-in names for this interim gate.
- Resolver: `EnableDefaultReadTimeout2026Resolver` -> `EnableDefaultSocketTimeout2026Resolver` (class, file, and its builder method/field `defaultEnableSocketTimeout2026`). The test class/file was renamed to match.
- `SdkClientOption`: `DEFAULT_ENABLE_READ_TIMEOUT_2026` -> `DEFAULT_ENABLE_SOCKET_TIMEOUT_2026`.
- codegen `CustomizationConfig`: field + getter/setter `defaultEnableSocketTimeout2026`, the `BaseClientBuilderClass` emission that reads it, and the affected customization/fixture resources.
- `AwsDefaultClientBuilder` (aws-core): updated all references to the renamed resolver and client option, plus the associated Javadoc `{@code}` references.

## Testing

Built and ran the affected module tests. A repo-wide grep confirms no remaining references to any of the old names

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

This is a behavior-preserving rename/refactor; neither category above applies.

## Checklist
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] I have added a changelog entry.
- [ ] My change is to implement 1.11 parity feature and I have updated LaunchChangelog

## License
- [x] I confirm that this pull request can be released under the Apache 2 license
