### PR TITLE
Fix flaky test pause_fileChanged_resumeShouldStartFromBeginning

### DIFF
--- a/services-custom/s3-transfer-manager/src/it/java/software/amazon/awssdk/transfer/s3/S3TransferManagerUploadPauseResumeIntegrationTest.java
+++ b/services-custom/s3-transfer-manager/src/it/java/software/amazon/awssdk/transfer/s3/S3TransferManagerUploadPauseResumeIntegrationTest.java
@@ -31,10 +31,13 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import software.amazon.awssdk.core.ResponseInputStream;
 import software.amazon.awssdk.core.retry.backoff.FixedDelayBackoffStrategy;
+import software.amazon.awssdk.core.sync.ResponseTransformer;
 import software.amazon.awssdk.core.waiters.AsyncWaiter;
 import software.amazon.awssdk.core.waiters.Waiter;
 import software.amazon.awssdk.core.waiters.WaiterAcceptor;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 import software.amazon.awssdk.services.s3.model.ListMultipartUploadsResponse;
 import software.amazon.awssdk.services.s3.model.ListPartsResponse;
 import software.amazon.awssdk.services.s3.model.NoSuchUploadException;
@@ -43,6 +46,7 @@ import software.amazon.awssdk.transfer.s3.model.FileUpload;
 import software.amazon.awssdk.transfer.s3.model.ResumableFileUpload;
 import software.amazon.awssdk.transfer.s3.model.UploadFileRequest;
 import software.amazon.awssdk.transfer.s3.progress.LoggingTransferListener;
+import software.amazon.awssdk.transfer.s3.util.ChecksumUtils;
 import software.amazon.awssdk.utils.Logger;
 
 public class S3TransferManagerUploadPauseResumeIntegrationTest extends S3IntegrationTestBase {
@@ -167,7 +171,12 @@ public class S3TransferManagerUploadPauseResumeIntegrationTest extends S3Integra
             FileUpload resumedUpload = resumeTm.resumeUploadFile(resumableFileUpload);
             resumedUpload.completionFuture().join();
             verifyMultipartUploadIdNotExist(resumableFileUpload);
-            assertThat(resumedUpload.progress().snapshot().totalBytes()).hasValue(bytes.length);
+
+            // Verify via S3 checksum instead of progress snapshot, which may be empty for cross-TM resume
+            ResponseInputStream<GetObjectResponse> obj =
+                s3.getObject(r -> r.bucket(BUCKET).key(KEY), ResponseTransformer.toInputStream());
+            assertThat(ChecksumUtils.computeCheckSum(bytes))
+                .isEqualTo(ChecksumUtils.computeCheckSum(obj));
         } finally {
             Files.write(largeFile.toPath(), originalBytes);
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
`pause_fileChanged_resumeShouldStartFromBeginning` is flaking in preview builds (parameterized cases [3] and [4] - cross-TM resume). After file change, the transfer manager starts a fresh single-part upload, but the progress tracker does not populate `totalBytes`, causing `Expecting Optional to contain a value but it was empty`.

## Modifications
Replaced the assertion on `progress().snapshot().totalBytes()` with a SHA-256 checksum comparison of the local bytes against the S3 object content, following the existing pattern in `S3TransferManagerUploadIntegrationTest`.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
