### PR TITLE
Fix flaky test ResponsePublisherTimeoutIntegrationTest

### DIFF
--- a/services/s3/src/it/java/software/amazon/awssdk/services/s3/ResponsePublisherTimeoutIntegrationTest.java
+++ b/services/s3/src/it/java/software/amazon/awssdk/services/s3/ResponsePublisherTimeoutIntegrationTest.java
@@ -43,7 +43,9 @@ public class ResponsePublisherTimeoutIntegrationTest extends S3IntegrationTestBa
 
     private static final String BUCKET = temporaryBucketName(GetObjectIntegrationTest.class);
     private static final String KEY = "TestKey";
-    private static final String CONTENT = "Hello";
+    // Large enough to trigger StreamedHttpResponse instead of FullHttpResponse in Netty.
+    // FullHttpResponse releases the connection immediately, defeating pool-exhaustion tests.
+    private static final int CONTENT_LENGTH = 2 * 1024 * 1024;
     private static final GetObjectRequest getObjectRequest = GetObjectRequest.builder()
                                                                              .bucket(BUCKET)
                                                                              .key(KEY)
@@ -61,7 +63,7 @@ public class ResponsePublisherTimeoutIntegrationTest extends S3IntegrationTestBa
         s3.putObject(PutObjectRequest.builder()
                                      .bucket(BUCKET)
                                      .key(KEY)
-                                     .build(), RequestBody.fromString(CONTENT));
+                                     .build(), RequestBody.fromBytes(new byte[CONTENT_LENGTH]));
     }
 
     @AfterClass
@@ -87,7 +89,7 @@ public class ResponsePublisherTimeoutIntegrationTest extends S3IntegrationTestBa
         CompletableFuture<ResponsePublisher<GetObjectResponse>> get2 = getObjectWithDefaultTimeoutPublisher();
 
         GetObjectResponse getObjectResponse = get2.join().response();
-        assertThat(getObjectResponse.contentLength()).isEqualTo(CONTENT.length());
+        assertThat(getObjectResponse.contentLength()).isEqualTo(CONTENT_LENGTH);
     }
 
     @Test
@@ -97,7 +99,7 @@ public class ResponsePublisherTimeoutIntegrationTest extends S3IntegrationTestBa
         CompletableFuture<ResponsePublisher<GetObjectResponse>> get2 = getObjectWithDefaultTimeoutPublisher();
 
         GetObjectResponse getObjectResponse = get2.join().response();
-        assertThat(getObjectResponse.contentLength()).isEqualTo(CONTENT.length());
+        assertThat(getObjectResponse.contentLength()).isEqualTo(CONTENT_LENGTH);
     }
 
     @Test
@@ -107,7 +109,7 @@ public class ResponsePublisherTimeoutIntegrationTest extends S3IntegrationTestBa
         CompletableFuture<ResponsePublisher<GetObjectResponse>> get2 = getObjectWithDefaultTimeoutPublisher();
 
         GetObjectResponse getObjectResponse = get2.join().response();
-        assertThat(getObjectResponse.contentLength()).isEqualTo(CONTENT.length());
+        assertThat(getObjectResponse.contentLength()).isEqualTo(CONTENT_LENGTH);
     }
 
     private CompletableFuture<ResponsePublisher<GetObjectResponse>> getObjectWithDefaultTimeoutPublisher() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
`defaultTimeout_firstPublisherNotConsumed_secondRequestTimesOut` flakes with `Expecting code to raise a throwable` because the 5-byte content ("Hello") is received as a FullHttpResponse by Netty. In ResponseHandler, the FullHttpResponse path calls finalizeResponse() which releases the connection back to the pool immediately, so the second request acquires it and succeeds instead of timing out.

## Modifications
Increased content size to 2MB to force Netty to treat the response as a StreamedHttpResponse, which keeps the connection held until the publisher body is consumed or the timeout fires.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
