### PR TITLE
Fix flaky test DynamoDbJavaClientRetryOnTimeoutIntegrationTest

### DIFF
--- a/services/dynamodb/src/it/java/software/amazon/awssdk/services/dynamodb/DynamoDbJavaClientRetryOnTimeoutIntegrationTest.java
+++ b/services/dynamodb/src/it/java/software/amazon/awssdk/services/dynamodb/DynamoDbJavaClientRetryOnTimeoutIntegrationTest.java
@@ -65,9 +65,8 @@ public class DynamoDbJavaClientRetryOnTimeoutIntegrationTest extends AwsTestBase
     public void testRetryAttemptsOnTimeOut() throws Exception {
         AtomicInteger atomicInteger = new AtomicInteger(0);
         Boolean apiTimeOutExceptionOccurred = Boolean.FALSE;
-        setupWithRetryPolicy(createRetryPolicyWithCounter(atomicInteger, RETRY_ATTEMPTS), 2);
+        setupWithRetryPolicy(createRetryPolicyWithCounter(atomicInteger, RETRY_ATTEMPTS), 5);
         try {
-
             ddb.listTables();
         } catch (ApiCallAttemptTimeoutException e) {
             apiTimeOutExceptionOccurred = true;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
The test uses a 2ms `apiCallAttemptTimeout` which is so short that the connection gets cancelled before the SDK can wrap the timeout as `ApiCallAttemptTimeoutException`, resulting in `CancellationException` or `ConnectionShutdownException` instead.

## Modifications
Increased `apiCallAttemptTimeout` from 2ms to 5ms. Still reliably too short for a DynamoDB listTables round trip (~50-200ms), but long enough for the SDK's timeout wrapper to fire properly.

## Testing
Ran the test locally with timeout values of 2, 5, 10, 15, and 20ms(10 runs each). 
Results:
   - 2ms: 8/10 correct, 2/10 CancellationException
   - 5ms: 10/10 correct
   - 10ms: 10/10 correct
   - 15ms: 10/10 correct
   - 20ms: 10/10 correct

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
