### PR TITLE
Fix flaky DynamoDB enhanced client integration tests

### DIFF
--- a/services-custom/dynamodb-enhanced/src/it/java/software/amazon/awssdk/enhanced/dynamodb/QueryGSICompositeKeysImmutableSchemaIntegrationTest.java
+++ b/services-custom/dynamodb-enhanced/src/it/java/software/amazon/awssdk/enhanced/dynamodb/QueryGSICompositeKeysImmutableSchemaIntegrationTest.java
@@ -68,11 +68,23 @@ class QueryGSICompositeKeysImmutableSchemaIntegrationTest extends DynamoDbEnhanc
     }
 
     private static void waitForGsiConsistency() {
-        try {
-            Thread.sleep(3000);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
+        int expectedCount = COMPOSITE_RECORDS.size();
+        for (int attempt = 0; attempt < 20; attempt++) {
+            int count = dynamoDbClient.scan(r -> r.tableName(mappedTable.tableName())
+                                                  .indexName("gsi1")
+                                                  .limit(expectedCount + 1))
+                                      .items().size();
+            if (count >= expectedCount) {
+                return;
+            }
+            try {
+                Thread.sleep(Math.min(500L << Math.min(attempt, 3), 2_000L));
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(e);
+            }
         }
+        throw new AssertionError("GSI propagation timed out after retries");
     }
 
     private static final java.util.List<ImmutableCompositeKeyRecord> COMPOSITE_RECORDS = Arrays.asList(

--- a/services-custom/dynamodb-enhanced/src/it/java/software/amazon/awssdk/enhanced/dynamodb/QueryGSICompositeKeysImmutableSchemaIntegrationTest.java
+++ b/services-custom/dynamodb-enhanced/src/it/java/software/amazon/awssdk/enhanced/dynamodb/QueryGSICompositeKeysImmutableSchemaIntegrationTest.java
@@ -30,6 +30,7 @@ import static software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional.so
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.Iterator;
+import java.util.List;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -67,11 +68,19 @@ class QueryGSICompositeKeysImmutableSchemaIntegrationTest extends DynamoDbEnhanc
         }
     }
 
+    private static final List<String> GSI_NAMES = Arrays.asList("gsi1", "gsi2", "gsi3");
+
     private static void waitForGsiConsistency() {
         int expectedCount = COMPOSITE_RECORDS.size();
+        for (String gsiName : GSI_NAMES) {
+            waitForGsiPropagation(gsiName, expectedCount);
+        }
+    }
+
+    private static void waitForGsiPropagation(String gsiName, int expectedCount) {
         for (int attempt = 0; attempt < 20; attempt++) {
             int count = dynamoDbClient.scan(r -> r.tableName(mappedTable.tableName())
-                                                  .indexName("gsi1")
+                                                  .indexName(gsiName)
                                                   .limit(expectedCount + 1))
                                       .items().size();
             if (count >= expectedCount) {
@@ -84,7 +93,7 @@ class QueryGSICompositeKeysImmutableSchemaIntegrationTest extends DynamoDbEnhanc
                 throw new RuntimeException(e);
             }
         }
-        throw new AssertionError("GSI propagation timed out after retries");
+        throw new AssertionError("GSI propagation timed out for " + gsiName);
     }
 
     private static final java.util.List<ImmutableCompositeKeyRecord> COMPOSITE_RECORDS = Arrays.asList(

--- a/services-custom/dynamodb-enhanced/src/it/java/software/amazon/awssdk/enhanced/dynamodb/QueryGSICompositeKeysIntegrationTestBase.java
+++ b/services-custom/dynamodb-enhanced/src/it/java/software/amazon/awssdk/enhanced/dynamodb/QueryGSICompositeKeysIntegrationTestBase.java
@@ -85,11 +85,23 @@ abstract class QueryGSICompositeKeysIntegrationTestBase extends DynamoDbEnhanced
     }
 
     protected static void waitForGsiConsistency() {
-        try {
-            Thread.sleep(3000);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
+        int expectedCount = COMPOSITE_RECORDS.size();
+        for (int attempt = 0; attempt < 20; attempt++) {
+            int count = dynamoDbClient.scan(r -> r.tableName(mappedTable.tableName())
+                                                  .indexName("gsi1")
+                                                  .limit(expectedCount + 1))
+                                      .items().size();
+            if (count >= expectedCount) {
+                return;
+            }
+            try {
+                Thread.sleep(Math.min(500L << Math.min(attempt, 3), 2_000L));
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(e);
+            }
         }
+        throw new AssertionError("GSI propagation timed out after retries");
     }
 
     private static CompositeKeyRecord createRecord(String id, String sort, String pk1, Integer pk2, String pk3,

--- a/services-custom/dynamodb-enhanced/src/it/java/software/amazon/awssdk/enhanced/dynamodb/QueryGSICompositeKeysIntegrationTestBase.java
+++ b/services-custom/dynamodb-enhanced/src/it/java/software/amazon/awssdk/enhanced/dynamodb/QueryGSICompositeKeysIntegrationTestBase.java
@@ -30,6 +30,7 @@ import static software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional.so
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.Iterator;
+import java.util.List;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.enhanced.dynamodb.model.CompositeKeyRecord;
@@ -84,11 +85,19 @@ abstract class QueryGSICompositeKeysIntegrationTestBase extends DynamoDbEnhanced
         COMPOSITE_RECORDS.forEach(record -> mappedTable.putItem(r -> r.item(record)));
     }
 
+    private static final List<String> GSI_NAMES = Arrays.asList("gsi1", "gsi2", "gsi3", "gsi4", "gsi5", "gsi6");
+
     protected static void waitForGsiConsistency() {
         int expectedCount = COMPOSITE_RECORDS.size();
+        for (String gsiName : GSI_NAMES) {
+            waitForGsiPropagation(gsiName, expectedCount);
+        }
+    }
+
+    private static void waitForGsiPropagation(String gsiName, int expectedCount) {
         for (int attempt = 0; attempt < 20; attempt++) {
             int count = dynamoDbClient.scan(r -> r.tableName(mappedTable.tableName())
-                                                  .indexName("gsi1")
+                                                  .indexName(gsiName)
                                                   .limit(expectedCount + 1))
                                       .items().size();
             if (count >= expectedCount) {
@@ -101,7 +110,7 @@ abstract class QueryGSICompositeKeysIntegrationTestBase extends DynamoDbEnhanced
                 throw new RuntimeException(e);
             }
         }
-        throw new AssertionError("GSI propagation timed out after retries");
+        throw new AssertionError("GSI propagation timed out for " + gsiName);
     }
 
     private static CompositeKeyRecord createRecord(String id, String sort, String pk1, Integer pk2, String pk3,

--- a/services-custom/dynamodb-enhanced/src/it/java/software/amazon/awssdk/enhanced/dynamodb/SearchVectorsIntegrationTestBase.java
+++ b/services-custom/dynamodb-enhanced/src/it/java/software/amazon/awssdk/enhanced/dynamodb/SearchVectorsIntegrationTestBase.java
@@ -89,7 +89,6 @@ public abstract class SearchVectorsIntegrationTestBase extends DynamoDbEnhancedI
         "JavaTests-SearchVectors-FilterOnly";
 
     private static final int DEFAULT_SEARCH_RETRY_ATTEMPTS = 15;
-    protected static final int POST_MUTATION_SEARCH_RETRY_ATTEMPTS = 8;
     private static final int QUICK_SEARCH_RETRY_ATTEMPTS = 3;
     private static final int TABLE_WARMUP_SEARCH_RETRY_ATTEMPTS = 20;
     private static final int VECTOR_INDEX_ACTIVE_WAIT_ATTEMPTS = 30;
@@ -1053,7 +1052,7 @@ public abstract class SearchVectorsIntegrationTestBase extends DynamoDbEnhancedI
         String expectedSortKey) {
         List<SearchResultItem<VectorRecord>> results =
             executeSearch(indexName, request);
-        for (int attempt = 0; attempt < POST_MUTATION_SEARCH_RETRY_ATTEMPTS; attempt++) {
+        for (int attempt = 0; attempt < DEFAULT_SEARCH_RETRY_ATTEMPTS; attempt++) {
             boolean found = results.stream()
                                    .anyMatch(r -> r.item() != null
                                                   && expectedSortKey.equals(
@@ -1073,7 +1072,7 @@ public abstract class SearchVectorsIntegrationTestBase extends DynamoDbEnhancedI
         String absentSortKey) {
         List<SearchResultItem<VectorRecord>> results =
             executeSearch(indexName, request);
-        for (int attempt = 0; attempt < POST_MUTATION_SEARCH_RETRY_ATTEMPTS; attempt++) {
+        for (int attempt = 0; attempt < DEFAULT_SEARCH_RETRY_ATTEMPTS; attempt++) {
             boolean found = results.stream()
                                    .anyMatch(r -> r.item() != null
                                                   && absentSortKey.equals(
@@ -1894,15 +1893,22 @@ public abstract class SearchVectorsIntegrationTestBase extends DynamoDbEnhancedI
                 record.setDescription("Updated description only");
                 executePut(record);
 
-                List<SearchResultItem<VectorRecord>> results =
-                    searchVectorsUntilContains(
-                        COSINE_INDEX, request, "metadata-update-item");
-                SearchResultItem<VectorRecord> result = results.stream()
-                                                               .filter(r -> "metadata-update-item".equals(
-                                                                   r.item().getSk()))
-                                                               .findFirst()
-                                                               .orElseThrow(() -> new AssertionError(
-                                                                   "Expected metadata-update-item in search results"));
+                // Retry until the updated description is visible in search results,
+                // not just until the item exists (it may return stale data).
+                SearchResultItem<VectorRecord> result = null;
+                for (int attempt = 0; attempt < DEFAULT_SEARCH_RETRY_ATTEMPTS; attempt++) {
+                    List<SearchResultItem<VectorRecord>> results =
+                        executeSearch(COSINE_INDEX, request);
+                    result = results.stream()
+                                    .filter(r -> "metadata-update-item".equals(r.item().getSk()))
+                                    .findFirst()
+                                    .orElse(null);
+                    if (result != null && "Updated description only".equals(result.item().getDescription())) {
+                        break;
+                    }
+                    sleepBetweenRetries(attempt);
+                }
+                assertThat(result).isNotNull();
                 assertThat(result.item().getDescription())
                     .isEqualTo("Updated description only");
             } finally {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Several DynamoDB enhanced client integration tests flake in preview builds due to eventual consistency:

   - `SearchVectorsIntegrationTestBase` (SearchHappyPathTests): Fails with `No result with sort key: dot-unbounded-item` because POST_MUTATION_SEARCH_RETRY_ATTEMPTS (8 retries, ~4.5s) was insufficient for vector index propagation under CI load.

   - `SearchVectorsIntegrationTestBase` (WritePathTests): `writePath_updateNonVectorFieldsOnly` fails at ~0.026s because searchVectorsUntilContains checks item presence but not content, returning immediately with stale data after an update.

   - `QueryGSICompositeKeysIntegrationTest` (Static, Immutable, Bean schemas): Various queryGsi* tests fail because waitForGsiConsistency() used a fixed 3-second Thread.sleep, which is insufficient for GSI propagation under CI load. 43 failure runs in the last 30 days.
   
## Modifications

   - Removed `POST_MUTATION_SEARCH_RETRY_ATTEMPTS` and consolidated into `DEFAULT_SEARCH_RETRY_ATTEMPTS (15)`, since post-mutation searches need the same consistency window.
   - Added content-aware retry in `writePath_updateNonVectorFieldsOnly` to wait for the updated description to propagate, not just item presence.
   - Replaced fixed `Thread.sleep(3000)` in `waitForGsiConsistency()` with a poll-and-retry loop that scans gsi1 until all records are visible, with exponential backoff (500ms-2s, up to 20 attempts).


## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
