### PR TITLE
Support leading-dot suffixes in NO_PROXY

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-134c9c4.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-134c9c4.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "AWS SDK for Java v2",
+    "contributor": "afarber",
+    "description": "Support leading-dot domain suffixes in the NO_PROXY environment variable."
+}

--- a/core/crt-core/src/main/java/software/amazon/awssdk/crtcore/CrtProxyConfiguration.java
+++ b/core/crt-core/src/main/java/software/amazon/awssdk/crtcore/CrtProxyConfiguration.java
@@ -276,7 +276,8 @@ public abstract class CrtProxyConfiguration {
          * originate from environment variableValues, and no partial settings will be obtained from SystemPropertyValues.
          * <p>Comma-separated host names in the NO_PROXY environment variable indicate multiple hosts to exclude from
          * proxy settings. Surrounding empty spaces around each host name are trimmed, so both {@code "a.com,b.com"} and
-         * {@code "a.com, b.com"} are accepted.
+         * {@code "a.com, b.com"} are accepted. A leading-dot suffix such as {@code .example.com} is equivalent to
+         * {@code *.example.com}.
          *
          * @param useEnvironmentVariableValues The option whether to use environment variable values
          * @return This object for method chaining.

--- a/http-clients/apache-client/src/main/java/software/amazon/awssdk/http/apache/ProxyConfiguration.java
+++ b/http-clients/apache-client/src/main/java/software/amazon/awssdk/http/apache/ProxyConfiguration.java
@@ -313,6 +313,7 @@ public final class ProxyConfiguration implements ToCopyableBuilder<ProxyConfigur
          * proxy settings. Surrounding empty spaces around each host name are trimmed, so both {@code "a.com,b.com"} and
          * {@code "a.com, b.com"} are accepted. Each entry may be an exact host name (e.g. {@code example.com}), a
          * leading-wildcard suffix (e.g. {@code *.example.com}, which matches {@code example.com} and its subdomains),
+         * or a leading-dot suffix (e.g. {@code .example.com}, equivalent to {@code *.example.com}),
          * a single {@code *} (which matches all hosts), or a CIDR range for IP addresses (e.g. {@code 10.0.0.0/8}).
          *
          * @param useEnvironmentVariableValues The option whether to use environment variable values.

--- a/http-clients/apache-client/src/test/java/software/amazon/awssdk/http/apache/internal/SdkProxyRoutePlannerTest.java
+++ b/http-clients/apache-client/src/test/java/software/amazon/awssdk/http/apache/internal/SdkProxyRoutePlannerTest.java
@@ -16,6 +16,7 @@
 package software.amazon.awssdk.http.apache.internal;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.Collections;
 import org.apache.http.HttpException;
@@ -29,6 +30,7 @@ import org.junit.jupiter.api.Test;
  */
 public class SdkProxyRoutePlannerTest {
     private static final HttpHost S3_HOST = new HttpHost("s3.us-west-2.amazonaws.com", 443, "https");
+    private static final HttpHost INTERNAL_HOST = new HttpHost("s3.storage.company.internal", 443, "https");
     private static final HttpGet S3_REQUEST = new HttpGet("/my-bucket/my-object");
     private static final HttpClientContext CONTEXT = new HttpClientContext();
 
@@ -48,5 +50,13 @@ public class SdkProxyRoutePlannerTest {
         HttpHost proxyHost = planner.determineRoute(S3_HOST, S3_REQUEST, CONTEXT).getProxyHost();
         assertEquals("localhost", proxyHost.getHostName());
         assertEquals("http", proxyHost.getSchemeName());
+    }
+
+    @Test
+    public void leadingDotSuffixPatternBypassesProxy() throws HttpException {
+        SdkProxyRoutePlanner planner = new SdkProxyRoutePlanner("localhost", 1234, "https",
+                                                                 Collections.singleton(".*?.company.internal"));
+
+        assertNull(planner.determineRoute(INTERNAL_HOST, S3_REQUEST, CONTEXT).getProxyHost());
     }
 }

--- a/http-clients/apache5-client/src/main/java/software/amazon/awssdk/http/apache5/ProxyConfiguration.java
+++ b/http-clients/apache5-client/src/main/java/software/amazon/awssdk/http/apache5/ProxyConfiguration.java
@@ -308,6 +308,7 @@ public final class ProxyConfiguration implements ToCopyableBuilder<ProxyConfigur
          * proxy settings. Surrounding empty spaces around each host name are trimmed, so both {@code "a.com,b.com"} and
          * {@code "a.com, b.com"} are accepted. Each entry may be an exact host name (e.g. {@code example.com}), a
          * leading-wildcard suffix (e.g. {@code *.example.com}, which matches {@code example.com} and its subdomains),
+         * or a leading-dot suffix (e.g. {@code .example.com}, equivalent to {@code *.example.com}),
          * a single {@code *} (which matches all hosts), or a CIDR range for IP addresses (e.g. {@code 10.0.0.0/8}).
          *
          * @param useEnvironmentVariableValues The option whether to use environment variable values.

--- a/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/ProxyConfiguration.java
+++ b/http-clients/aws-crt-client/src/main/java/software/amazon/awssdk/http/crt/ProxyConfiguration.java
@@ -126,7 +126,7 @@ public final class ProxyConfiguration extends CrtProxyConfiguration
          * proxy settings will exclusively originate from Environment Variable Values, and no partial settings will be obtained
          * from System Property Values.
          * <p>Comma-separated host names in the NO_PROXY environment variable indicate multiple hosts to exclude from
-         * proxy settings.
+         * proxy settings. A leading-dot suffix such as {@code .example.com} is equivalent to {@code *.example.com}.
          *
          * @param useEnvironmentVariableValues The option whether to use environment variable values
          * @return This object for method chaining.

--- a/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/ProxyConfiguration.java
+++ b/http-clients/netty-nio-client/src/main/java/software/amazon/awssdk/http/nio/netty/ProxyConfiguration.java
@@ -353,6 +353,7 @@ public final class ProxyConfiguration implements ToCopyableBuilder<ProxyConfigur
          * proxy settings. Surrounding empty spaces around each host name are trimmed, so both {@code "a.com,b.com"} and
          * {@code "a.com, b.com"} are accepted. Each entry may be an exact host name (e.g. {@code example.com}), a
          * leading-wildcard suffix (e.g. {@code *.example.com}, which matches {@code example.com} and its subdomains),
+         * or a leading-dot suffix (e.g. {@code .example.com}, equivalent to {@code *.example.com}),
          * a single {@code *} (which matches all hosts), or a CIDR range for IP addresses (e.g. {@code 10.0.0.0/8}).
          *
          * @param useEnvironmentVariablesValues The option whether to use environment variable values

--- a/http-clients/url-connection-client/src/main/java/software/amazon/awssdk/http/urlconnection/ProxyConfiguration.java
+++ b/http-clients/url-connection-client/src/main/java/software/amazon/awssdk/http/urlconnection/ProxyConfiguration.java
@@ -261,6 +261,7 @@ public final class ProxyConfiguration implements ToCopyableBuilder<ProxyConfigur
          * proxy settings. Surrounding empty spaces around each host name are trimmed, so both {@code "a.com,b.com"} and
          * {@code "a.com, b.com"} are accepted. Each entry may be an exact host name (e.g. {@code example.com}), a
          * leading-wildcard suffix (e.g. {@code *.example.com}, which matches {@code example.com} and its subdomains),
+         * or a leading-dot suffix (e.g. {@code .example.com}, equivalent to {@code *.example.com}),
          * a single {@code *} (which matches all hosts), or a CIDR range for IP addresses (e.g. {@code 10.0.0.0/8}).
          *
          * @param useEnvironmentVariablesValues The option whether to use environment variable values

--- a/utils/src/main/java/software/amazon/awssdk/utils/http/SdkHttpUtils.java
+++ b/utils/src/main/java/software/amazon/awssdk/utils/http/SdkHttpUtils.java
@@ -436,10 +436,15 @@ public final class SdkHttpUtils {
     }
 
     private static Set<String> extractNonProxyHosts(String nonProxyHosts) {
+        return extractNonProxyHosts(nonProxyHosts, UnaryOperator.identity());
+    }
+
+    private static Set<String> extractNonProxyHosts(String nonProxyHosts, UnaryOperator<String> tokenMapper) {
         if (nonProxyHosts != null && !isEmpty(nonProxyHosts)) {
             return Arrays.stream(nonProxyHosts.split("\\|"))
                          .map(String::trim)
                          .map(String::toLowerCase)
+                         .map(tokenMapper)
                          .map(s -> StringUtils.replace(s, "*", ".*?"))
                          .collect(Collectors.toSet());
         }
@@ -450,6 +455,10 @@ public final class SdkHttpUtils {
         String hosts = ProxyEnvironmentSetting.NO_PROXY.getStringValue()
                                                        .map(noProxyHost -> noProxyHost.replace(",", "|"))
                                                        .orElse(null);
-        return extractNonProxyHosts(hosts);
+        return extractNonProxyHosts(hosts, SdkHttpUtils::convertLeadingDotToWildcard);
+    }
+
+    private static String convertLeadingDotToWildcard(String host) {
+        return host.startsWith(".") ? "*" + host : host;
     }
 }

--- a/utils/src/test/java/software/amazon/awssdk/utils/SdkHttpUtilsTest.java
+++ b/utils/src/test/java/software/amazon/awssdk/utils/SdkHttpUtilsTest.java
@@ -319,12 +319,37 @@ public class SdkHttpUtilsTest {
     }
 
     @Test
+    void parseListOfNonProxyHostWithLeadingDotSuffix() {
+        ENVIRONMENT_VARIABLE_HELPER.set("no_proxy", "example.com, .company.internal,*.greedy.org");
+
+        Set<String> strings = SdkHttpUtils.parseNonProxyHostsEnvironmentVariable();
+
+        assertThat(strings).isEqualTo(Stream.of("example.com", ".*?.company.internal", ".*?.greedy.org")
+                                            .collect(Collectors.toSet()));
+    }
+
+    @Test
     void parseNonProxyHostsProperty_regexPathStillRewritesWildcard() {
         String previous = System.getProperty("http.nonProxyHosts");
         System.setProperty("http.nonProxyHosts", "example.com|*greedy.org");
         try {
             assertThat(SdkHttpUtils.parseNonProxyHostsProperty())
                 .isEqualTo(Stream.of("example.com", ".*?greedy.org").collect(Collectors.toSet()));
+        } finally {
+            if (previous == null) {
+                System.clearProperty("http.nonProxyHosts");
+            } else {
+                System.setProperty("http.nonProxyHosts", previous);
+            }
+        }
+    }
+
+    @Test
+    void parseNonProxyHostsProperty_leadingDotIsNotNormalized() {
+        String previous = System.getProperty("http.nonProxyHosts");
+        System.setProperty("http.nonProxyHosts", ".company.internal");
+        try {
+            assertThat(SdkHttpUtils.parseNonProxyHostsProperty()).containsExactly(".company.internal");
         } finally {
             if (previous == null) {
                 System.clearProperty("http.nonProxyHosts");


### PR DESCRIPTION
## Motivation and Context

Fixes #5573.

`NO_PROXY` commonly uses a leading-dot domain suffix such as `.company.internal`. The SDK accepted `*.company.internal`, but not the equivalent leading-dot form.

## Modifications

- Normalize leading-dot suffixes in the `NO_PROXY` environment variable to the existing wildcard form.
- Add parsing and Apache proxy-route tests.
- Document leading-dot suffix support in the HTTP client proxy configuration Javadocs.
- Add a changelog entry.

## Testing

Ran the affected utility tests:

```sh
./mvnw -pl :utils -Dtest=SdkHttpUtilsTest,ProxyConfigurationTest test
```

Ran the Apache proxy tests:

```sh
./mvnw -pl :apache-client -am -Dcheckstyle.skip=true -Dspotbugs.skip=true -Dtest=ApacheHttpProxyTest,SdkProxyRoutePlannerTest -Dsurefire.failIfNoSpecifiedTests=false test
```

Both commands succeeded.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read the CONTRIBUTING (https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of mvn install succeeds
- [x] My code follows the code style of this project
- [x] My change requires a change to the Javadoc documentation
- [x] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have added a changelog entry.
- [ ] My change is to implement 1.11 parity feature and I have updated LaunchChangelog
  (https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License

- [x] I confirm that this pull request can be released under the Apache 2 license

