### PR TITLE
feat(codegen): add defaultEnableSocketTimeout2026 customization config field

### DIFF
--- a/codegen/src/main/java/software/amazon/awssdk/codegen/model/config/customization/CustomizationConfig.java
+++ b/codegen/src/main/java/software/amazon/awssdk/codegen/model/config/customization/CustomizationConfig.java
@@ -231,6 +231,11 @@ public class CustomizationConfig {
     private Boolean defaultNewRetries2026;
 
     /**
+     * Whether the client will apply a default read/write timeout by default.
+     */
+    private Boolean defaultEnableSocketTimeout2026;
+
+    /**
      * Whether to generate an abstract decorator class that delegates to the async service client
      */
     private boolean delegateAsyncClientClass;
@@ -730,6 +735,14 @@ public class CustomizationConfig {
 
     public void setDefaultNewRetries2026(Boolean defaultNewRetries2026) {
         this.defaultNewRetries2026 = defaultNewRetries2026;
+    }
+
+    public Boolean getDefaultEnableSocketTimeout2026() {
+        return defaultEnableSocketTimeout2026;
+    }
+
+    public void setDefaultEnableSocketTimeout2026(Boolean defaultEnableSocketTimeout2026) {
+        this.defaultEnableSocketTimeout2026 = defaultEnableSocketTimeout2026;
     }
 
     public ServiceConfig getServiceConfig() {


### PR DESCRIPTION
## Motivation and Context

This adds a new customization-config field, `defaultEnableSocketTimeout2026`, to the codegen customization model. It is additive and inert: the field is recognized when a service's `customization.config` is parsed, but nothing in codegen consumes it, so no generated code or runtime behavior changes.

## Modifications

- Added a `Boolean defaultEnableSocketTimeout2026` field (with Javadoc) and its getter/setter to `CustomizationConfig`, mirroring the existing `defaultNewRetries2026` field.
- No consumer: the field is read nowhere in codegen, so with no service setting it the generated output is unchanged. Default value is `null` (off).

## Testing

- `mvn install -pl :codegen -P quick` (compile) succeeds.
- No dedicated test added: the change is a no-op field with no behavior to exercise, matching the `defaultNewRetries2026` precedent (no dedicated test for that field either).

## Screenshots (if appropriate)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
- [x] I confirm that this pull request can be released under the Apache 2 license
