### PR TITLE
Fix NPE when EmittingSubscription is cancelled while emitting

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-02cbbff.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-02cbbff.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "AWS SDK for Java v2",
+    "description": "Fixed a NullPointerException in EmittingSubscription when a subscription is cancelled while the emitting thread is signalling the downstream subscriber. This surfaced as an intermittent failure of parallel multipart downloads of single-part objects, for example S3TransferManager.downloadFile against an S3AsyncClient built with multipartEnabled(true).",
+    "contributor": "cthiebault"
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/EmittingSubscription.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/EmittingSubscription.java
@@ -35,7 +35,7 @@ import software.amazon.awssdk.utils.Logger;
 public final class EmittingSubscription<T> implements Subscription {
     private static final Logger log = Logger.loggerFor(EmittingSubscription.class);
 
-    private Subscriber<? super T> downstreamSubscriber;
+    private volatile Subscriber<? super T> downstreamSubscriber;
     private final AtomicBoolean emitting;
     private final AtomicLong outstandingDemand;
     private final Runnable onCancel;
@@ -58,7 +58,10 @@ public final class EmittingSubscription<T> implements Subscription {
     @Override
     public void request(long n) {
         if (n <= 0) {
-            downstreamSubscriber.onError(new IllegalArgumentException("Amount requested must be positive"));
+            Subscriber<? super T> subscriber = downstreamSubscriber;
+            if (subscriber != null) {
+                subscriber.onError(new IllegalArgumentException("Amount requested must be positive"));
+            }
             return;
         }
         long newDemand = outstandingDemand.updateAndGet(current -> {
@@ -97,7 +100,10 @@ public final class EmittingSubscription<T> implements Subscription {
         long demand = outstandingDemand.get();
 
         while (demand > 0) {
-            if (isCancelled.get()) {
+            // Read the subscriber once per iteration: cancel() nulls the field from another thread. Signalling a
+            // subscriber that cancelled mid-emit is permitted by the spec (rule 2.8); throwing an NPE is not.
+            Subscriber<? super T> subscriber = downstreamSubscriber;
+            if (isCancelled.get() || subscriber == null) {
                 return true;
             }
             if (outstandingDemand.get() > 0) {
@@ -106,10 +112,10 @@ public final class EmittingSubscription<T> implements Subscription {
                 try {
                     value = supplier.get();
                 } catch (Exception e) {
-                    downstreamSubscriber.onError(e);
+                    subscriber.onError(e);
                     return true;
                 }
-                downstreamSubscriber.onNext(value);
+                subscriber.onNext(value);
             }
         }
         return false;

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/async/EmittingSubscriptionTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/async/EmittingSubscriptionTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.internal.async;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+class EmittingSubscriptionTest {
+
+    @Test
+    void request_cancelledWhileEmitting_doesNotThrow() throws Exception {
+        CountDownLatch supplierEntered = new CountDownLatch(1);
+        CountDownLatch cancelCompleted = new CountDownLatch(1);
+        AtomicBoolean firstSupplierCall = new AtomicBoolean(true);
+        AtomicInteger onNextCount = new AtomicInteger();
+
+        EmittingSubscription<Object> subscription =
+            EmittingSubscription.builder()
+                                .downstreamSubscriber(subscriber(onNextCount, new AtomicReference<>()))
+                                .onCancel(() -> {
+                                })
+                                .supplier(() -> {
+                                    // Hold the emitting thread inside the supplier so cancel() lands between the
+                                    // isCancelled check and the downstream signal.
+                                    if (firstSupplierCall.compareAndSet(true, false)) {
+                                        supplierEntered.countDown();
+                                        await(cancelCompleted);
+                                    }
+                                    return new Object();
+                                })
+                                .build();
+
+        Thread canceller = new Thread(() -> {
+            await(supplierEntered);
+            subscription.cancel();
+            cancelCompleted.countDown();
+        });
+        canceller.start();
+
+        assertThatCode(() -> subscription.request(2)).doesNotThrowAnyException();
+
+        canceller.join(TimeUnit.SECONDS.toMillis(10));
+        // Signalling a subscriber that cancelled mid-emit is allowed (spec rule 2.8), but the loop must stop after it.
+        assertThat(onNextCount.get()).isLessThanOrEqualTo(1);
+    }
+
+    @Test
+    void request_negativeDemandAfterCancel_doesNotThrow() {
+        AtomicReference<Throwable> onErrorValue = new AtomicReference<>();
+
+        EmittingSubscription<Object> subscription =
+            EmittingSubscription.builder()
+                                .downstreamSubscriber(subscriber(new AtomicInteger(), onErrorValue))
+                                .onCancel(() -> {
+                                })
+                                .supplier(Object::new)
+                                .build();
+
+        subscription.cancel();
+
+        assertThatCode(() -> subscription.request(0)).doesNotThrowAnyException();
+        assertThat(onErrorValue.get()).isNull();
+    }
+
+    private static Subscriber<Object> subscriber(AtomicInteger onNextCount, AtomicReference<Throwable> onErrorValue) {
+        return new Subscriber<Object>() {
+            @Override
+            public void onSubscribe(Subscription s) {
+            }
+
+            @Override
+            public void onNext(Object o) {
+                onNextCount.incrementAndGet();
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                onErrorValue.set(t);
+            }
+
+            @Override
+            public void onComplete() {
+            }
+        };
+    }
+
+    private static void await(CountDownLatch latch) {
+        try {
+            if (!latch.await(10, TimeUnit.SECONDS)) {
+                throw new IllegalStateException("Timed out waiting for latch");
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException(e);
+        }
+    }
+}


### PR DESCRIPTION
## Motivation and Context

Fixes #7351.

`EmittingSubscription` is annotated `@ThreadSafe`, but `cancel()` and `doEmit()` race on the plain, non-`volatile`
`downstreamSubscriber` field. `cancel()` nulls the field; `doEmit()` checks `isCancelled` at the top of its loop and
dereferences `downstreamSubscriber` several statements later, after `supplier.get()`. A `cancel()` landing in that
window makes the emitting thread throw a bare `NullPointerException` out of `Subscription.request(long)`:

```
java.lang.NullPointerException: Cannot invoke "org.reactivestreams.Subscriber.onNext(Object)" because "this.downstreamSubscriber" is null
    at software.amazon.awssdk.core.internal.async.EmittingSubscription.doEmit(EmittingSubscription.java:112)
    at software.amazon.awssdk.core.internal.async.EmittingSubscription.emit(EmittingSubscription.java:87)
    at software.amazon.awssdk.core.internal.async.EmittingSubscription.request(EmittingSubscription.java:71)
```

The S3 parallel multipart download path drives exactly that interleaving, on every single-part object:
`ParallelMultipartDownloaderSubscriber.onSubscribe` calls `subscription.request(maxInFlightParts)` synchronously on the
calling thread, and `isMultipartObject()` calls `subscription.cancel()` from an SDK response thread as soon as part 1
comes back with `partsCount == null`. Whether the download survives is decided purely by whether the emitting thread
finished its iterations first. We hit it as an intermittent `S3TransferManager.downloadFile` failure that no caller can
classify, since the NPE arrives unwrapped.

`request(long n)` has the same hazard on its `n <= 0` branch.

## Modifications

- `downstreamSubscriber` is now `volatile`.
- `doEmit()` reads it into a local once per iteration and returns when it is null or the subscription is cancelled, then
  signals through that local, so a concurrent `cancel()` cannot null it between the check and the signal.
- The `n <= 0` branch of `request(long)` gets the same read-into-local guard.

This can still deliver one `onNext` to a subscriber that cancelled during `supplier.get()`, which Reactive Streams rule
2.8 explicitly permits ("a Subscriber MUST be prepared to receive one or more onNext signals after having called
Subscription.cancel()"). The field is still nulled in `cancel()`, so the reference is released for GC as before.

Not changed here, but worth a look separately: `FileAsyncResponseTransformerPublisher.subscriber` is also a
non-volatile field nulled in `onCancel()`, and two of its dereferences are unguarded — the "Content length header is
missing" branch of `IndividualFileTransformer.onResponse`, and `handleError`. Same defect class, same feature. Happy to
add it to this PR if you would rather have it in one change.

## Testing

New `EmittingSubscriptionTest` with two cases, both deterministic (latch-driven, no sleeps):

- `request_cancelledWhileEmitting_doesNotThrow` — holds the emitting thread inside `supplier.get()` while another thread
  cancels, i.e. the exact interleaving above. Asserts `request(2)` does not throw and that at most one `onNext` is
  delivered.
- `request_negativeDemandAfterCancel_doesNotThrow` — covers the `n <= 0` branch after a cancel.

Both fail on unmodified `master` with the NPE above and pass with this change.

Local runs on JDK 17 (Temurin 17.0.18):

```
mvn install -pl core/sdk-core   # 1538 unit tests + 624 TCK tests green, checkstyle clean
mvn checkstyle:check -pl core/sdk-core   # 0 violations
```

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License

- [x] I confirm that this pull request can be released under the Apache 2 license
