### PR TITLE
Preserve existing getObject files

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-7c3e9d1.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-7c3e9d1.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "AWS SDK for Java v2",
+    "contributor": "",
+    "description": "Prevent `AsyncResponseTransformer.toFile` from deleting a pre-existing destination when a request fails before the SDK opens the file. Calls using `CREATE_NEW` now preserve the existing file and surface `FileAlreadyExistsException` instead of allowing a retry to overwrite it."
+}

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/FileAsyncResponseTransformer.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/async/FileAsyncResponseTransformer.java
@@ -139,6 +139,7 @@ public final class FileAsyncResponseTransformer<ResponseT> implements AsyncRespo
 
     @Override
     public CompletableFuture<ResponseT> prepare() {
+        fileChannel = null;
         cf = new CompletableFuture<>();
         cf.whenComplete((r, t) -> {
             if (t != null && fileChannel != null) {
@@ -169,14 +170,16 @@ public final class FileAsyncResponseTransformer<ResponseT> implements AsyncRespo
 
     @Override
     public void exceptionOccurred(Throwable throwable) {
+        AsynchronousFileChannel currentFileChannel = fileChannel;
+        fileChannel = null;
         try {
-            if (fileChannel != null) {
+            if (currentFileChannel != null) {
                 runAndLogError(log.logger(),
                                String.format("Failed to close the file %s, resource may be leaked", path),
-                               () -> fileChannel.close());
+                               currentFileChannel::close);
             }
         } finally {
-            if (configuration.failureBehavior() == FailureBehavior.DELETE) {
+            if (currentFileChannel != null && configuration.failureBehavior() == FailureBehavior.DELETE) {
                 runAndLogError(log.logger(),
                                String.format("Failed to delete the file %s", path),
                                () -> Files.deleteIfExists(path));

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/async/FileAsyncResponseTransformerTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/async/FileAsyncResponseTransformerTest.java
@@ -121,7 +121,8 @@ class FileAsyncResponseTransformerTest {
     @Test
     void noConfiguration_fileAlreadyExists_shouldThrowException() throws Exception {
         Path testPath = testFs.getPath("test_file.txt");
-        Files.write(testPath, RandomStringUtils.random(1000).getBytes(StandardCharsets.UTF_8));
+        String existingContent = RandomStringUtils.randomAlphanumeric(1000);
+        Files.write(testPath, existingContent.getBytes(StandardCharsets.UTF_8));
         assertThat(testPath).exists();
 
         String content = RandomStringUtils.randomAlphanumeric(30000);
@@ -131,6 +132,7 @@ class FileAsyncResponseTransformerTest {
         transformer.onResponse("foobar");
         transformer.onStream(testPublisher(content));
         assertThatThrownBy(() -> future.join()).hasRootCauseInstanceOf(FileAlreadyExistsException.class);
+        assertThat(testPath).hasContent(existingContent);
     }
 
     @Test
@@ -187,6 +189,73 @@ class FileAsyncResponseTransformerTest {
     }
 
     @ParameterizedTest
+    @MethodSource("deleteConfigurations")
+    void exceptionOccurred_beforeFileOpened_shouldPreserveExistingFile(FileTransformerConfiguration configuration)
+        throws Exception {
+        Path testPath = testFs.getPath("test_file.txt");
+        String existingContent = RandomStringUtils.randomAlphanumeric(1000);
+        Files.write(testPath, existingContent.getBytes(StandardCharsets.UTF_8));
+
+        FileAsyncResponseTransformer<String> transformer = new FileAsyncResponseTransformer<>(testPath, configuration);
+        CompletableFuture<String> future = transformer.prepare();
+        RuntimeException exception = new RuntimeException("oops");
+        transformer.exceptionOccurred(exception);
+
+        assertThat(future).failsWithin(1, TimeUnit.SECONDS)
+                          .withThrowableOfType(ExecutionException.class)
+                          .withCause(exception);
+        assertThat(testPath).hasContent(existingContent);
+    }
+
+    @Test
+    void exceptionOccurred_beforeFileOpenedOnRetry_shouldPreserveExistingFile() throws Exception {
+        Path testPath = testFs.getPath("test_file.txt");
+        FileAsyncResponseTransformer<String> transformer = new FileAsyncResponseTransformer<>(testPath);
+
+        stubException(transformer);
+        assertThat(testPath).doesNotExist();
+
+        String existingContent = RandomStringUtils.randomAlphanumeric(1000);
+        Files.write(testPath, existingContent.getBytes(StandardCharsets.UTF_8));
+        CompletableFuture<String> future = transformer.prepare();
+        RuntimeException exception = new RuntimeException("oops");
+        transformer.exceptionOccurred(exception);
+
+        assertThat(future).failsWithin(1, TimeUnit.SECONDS)
+                          .withThrowableOfType(ExecutionException.class)
+                          .withCause(exception);
+        assertThat(testPath).hasContent(existingContent);
+    }
+
+    @Test
+    void exceptionOccurred_afterFileOpened_shouldAllowRetry() throws Exception {
+        Path testPath = testFs.getPath("test_file.txt");
+        FileAsyncResponseTransformer<String> transformer = new FileAsyncResponseTransformer<>(testPath);
+
+        stubException(transformer);
+        assertThat(testPath).doesNotExist();
+
+        String content = RandomStringUtils.randomAlphanumeric(1000);
+        stubSuccessfulStreaming(content, transformer);
+        assertThat(testPath).hasContent(content);
+    }
+
+    @Test
+    void exceptionOccurred_calledTwice_shouldNotDeleteReplacement() throws Exception {
+        Path testPath = testFs.getPath("test_file.txt");
+        FileAsyncResponseTransformer<String> transformer = new FileAsyncResponseTransformer<>(testPath);
+
+        stubException(transformer);
+        assertThat(testPath).doesNotExist();
+
+        String replacementContent = RandomStringUtils.randomAlphanumeric(1000);
+        Files.write(testPath, replacementContent.getBytes(StandardCharsets.UTF_8));
+        transformer.exceptionOccurred(new RuntimeException("second callback"));
+
+        assertThat(testPath).hasContent(replacementContent);
+    }
+
+    @ParameterizedTest
     @MethodSource("configurations")
     void exceptionOccurred_deleteFileBehavior(FileTransformerConfiguration configuration) throws Exception {
         Path testPath = testFs.getPath("test_file.txt");
@@ -201,6 +270,17 @@ class FileAsyncResponseTransformerTest {
         } else {
             assertThat(testPath).doesNotExist();
         }
+    }
+
+    private static List<FileTransformerConfiguration> deleteConfigurations() {
+        List<FileTransformerConfiguration> conf = new ArrayList<>();
+        for (FileWriteOption fileWriteOption : FileWriteOption.values()) {
+            conf.add(FileTransformerConfiguration.builder()
+                                                 .fileWriteOption(fileWriteOption)
+                                                 .failureBehavior(DELETE)
+                                                 .build());
+        }
+        return conf;
     }
 
     private static List<FileTransformerConfiguration> configurations() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
`FileAsyncResponseTransformer` deleted the destination whenever `FailureBehavior.DELETE` was configured, even when the current request attempt failed before opening the file. With `CREATE_NEW`, this could delete a pre-existing file and allow a retry to silently replace it.

## Modifications
<!--- Describe your changes in detail -->
This change resets file-channel state for each attempt, clears it during failure cleanup, and deletes the destination only when the current attempt successfully opened it. Existing files are preserved when opening fails or the request fails before writing. Partial output is still deleted after a successful open when `FailureBehavior.DELETE` is configured.

**Behavior change**: an async download with `CREATE_NEW` onto an existing destination now surfaces
`FileAlreadyExistsException` instead of deleting the file and letting the retry overwrite it.

Callers that intentionally require replacement behavior should use `getObject(request, AsyncResponseTransformer.toFile(path, FileTransformerConfiguration.defaultCreateOrReplaceExisting()))`.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added unit tests
## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
