### PR TITLE
Support mutually recursive DynamoDB bean schemas

### DIFF
--- a/.changes/next-release/bugfix-AmazonDynamoDB-c60c54b.json
+++ b/.changes/next-release/bugfix-AmazonDynamoDB-c60c54b.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "Amazon DynamoDB",
+    "description": "Fix `TableSchema.fromBean` for mutually recursive `@DynamoDbBean` classes. ([#6110](https://github.com/aws/aws-sdk-java-v2/issues/6110))",
+    "contributor": "afarber"
+}

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/mapper/BeanTableSchema.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/mapper/BeanTableSchema.java
@@ -192,8 +192,8 @@ public final class BeanTableSchema<T> extends WrappedTableSchema<T, StaticTableS
         return newTableSchema;
     }
 
-    // Called when creating an immutable TableSchema recursively. Utilizes the MetaTableSchema cache to stop infinite
-    // recursion
+    // Called when creating a bean TableSchema recursively. Utilizes the MetaTableSchema cache to stop infinite
+    // recursion for self-referencing and mutually recursive schemas.
     static <T> TableSchema<T> recursiveCreate(Class<T> beanClass, MethodHandles.Lookup lookup,
                                               MetaTableSchemaCache metaTableSchemaCache) {
         Optional<MetaTableSchema<T>> metaTableSchema = metaTableSchemaCache.get(beanClass);
@@ -211,7 +211,8 @@ public final class BeanTableSchema<T> extends WrappedTableSchema<T, StaticTableS
         }
 
         // Otherwise: cache doesn't know about this class; create a new one from scratch
-        return create(BeanTableSchemaParams.builder(beanClass).lookup(lookup).build());
+        return create(BeanTableSchemaParams.builder(beanClass).lookup(lookup).build(), metaTableSchemaCache,
+                      ExecutionContext.ROOT);
 
     }
 
@@ -603,4 +604,3 @@ public final class BeanTableSchema<T> extends WrappedTableSchema<T, StaticTableS
         BEAN_TABLE_SCHEMA_CACHE.clear();
     }
 }
-

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/functionaltests/BeanTableSchemaRecursiveTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/functionaltests/BeanTableSchemaRecursiveTest.java
@@ -23,9 +23,28 @@ import org.junit.Test;
 import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
 import software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.RecursiveRecordBean;
 import software.amazon.awssdk.enhanced.dynamodb.functionaltests.models.RecursiveRecordImmutable;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 public class BeanTableSchemaRecursiveTest {
+    @Test
+    public void transitiveRecursiveBean_document() {
+        TableSchema<TransitiveRecursiveParent> tableSchema = TableSchema.fromBean(TransitiveRecursiveParent.class);
+
+        TransitiveRecursiveChild child = new TransitiveRecursiveChild();
+        child.setName("child");
+
+        TransitiveRecursiveParent parent = new TransitiveRecursiveParent();
+        parent.setName("parent");
+        parent.setChild(child);
+
+        TransitiveRecursiveParent roundTrip = tableSchema.mapToItem(tableSchema.itemToMap(parent, true));
+
+        assertThat(roundTrip.getName()).isEqualTo("parent");
+        assertThat(roundTrip.getChild().getName()).isEqualTo("child");
+        assertThat(roundTrip.getChild().getParent()).isNull();
+    }
+
     @Test
     public void recursiveRecord_document() {
         TableSchema<RecursiveRecordBean> tableSchema = TableSchema.fromClass(RecursiveRecordBean.class);
@@ -88,5 +107,49 @@ public class BeanTableSchemaRecursiveTest {
                 assertThat(listAv.m()).containsEntry("attribute", AttributeValue.builder().n("2").build());
             });
         });
+    }
+
+    @DynamoDbBean
+    public static class TransitiveRecursiveParent {
+        private String name;
+        private TransitiveRecursiveChild child;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public TransitiveRecursiveChild getChild() {
+            return child;
+        }
+
+        public void setChild(TransitiveRecursiveChild child) {
+            this.child = child;
+        }
+    }
+
+    @DynamoDbBean
+    public static class TransitiveRecursiveChild {
+        private String name;
+        private TransitiveRecursiveParent parent;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public TransitiveRecursiveParent getParent() {
+            return parent;
+        }
+
+        public void setParent(TransitiveRecursiveParent parent) {
+            this.parent = parent;
+        }
     }
 }


### PR DESCRIPTION
## Motivation and Context

Fixes #6110.

`BeanTableSchema` supported direct self-references, but lost its in-progress schema cache when constructing a different nested bean type. A mutually recursive bean relationship such as `Parent -> Child -> Parent` therefore recursed until stack overflow.

## Modifications

- Preserve the shared `MetaTableSchemaCache` when recursively creating nested bean schemas.
- Add a regression test covering mutually recursive `@DynamoDbBean` classes and a finite map round-trip.
- Correct the related internal comment.
- Add a changelog entry.

## Testing

```sh
./mvnw -pl :dynamodb-enhanced -am \
  -Dtest=BeanTableSchemaRecursiveTest \
  -Dsurefire.failIfNoSpecifiedTests=false \
  -Dspotbugs.skip \
  -Dcheckstyle.skip test
```

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read the CONTRIBUTING (https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of mvn install succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [x] I have added a changelog entry.
- [ ] My change is to implement 1.11 parity feature and I have updated LaunchChangelog
  (https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License

- [x] I confirm that this pull request can be released under the Apache 2 license
