### PR TITLE
Honor duration_seconds in assume-role profiles

### DIFF
--- a/.changes/next-release/bugfix-AWSSecurityTokenService-76d0320.json
+++ b/.changes/next-release/bugfix-AWSSecurityTokenService-76d0320.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "AWS Security Token Service",
+    "contributor": "afarber",
+    "description": "Honor `duration_seconds` in assume-role profiles."
+}

--- a/services/sts/src/main/java/software/amazon/awssdk/services/sts/internal/StsProfileCredentialsProviderFactory.java
+++ b/services/sts/src/main/java/software/amazon/awssdk/services/sts/internal/StsProfileCredentialsProviderFactory.java
@@ -51,6 +51,29 @@ public final class StsProfileCredentialsProviderFactory implements ChildProfileC
                                                  request.sourceChain());
     }
 
+    static AssumeRoleRequest createAssumeRoleRequest(Profile profile) {
+        String roleArn = requireProperty(profile, ProfileProperty.ROLE_ARN);
+        String roleSessionName = profile.property(ProfileProperty.ROLE_SESSION_NAME)
+                                        .orElseGet(() -> "aws-sdk-java-" + System.currentTimeMillis());
+        String externalId = profile.property(ProfileProperty.EXTERNAL_ID).orElse(null);
+        Integer durationSeconds = profile.property(ProfileProperty.DURATION_SECONDS)
+                                         .map(Integer::valueOf)
+                                         .orElse(null);
+
+        return AssumeRoleRequest.builder()
+                                .roleArn(roleArn)
+                                .roleSessionName(roleSessionName)
+                                .externalId(externalId)
+                                .durationSeconds(durationSeconds)
+                                .build();
+    }
+
+    private static String requireProperty(Profile profile, String requiredProperty) {
+        return profile.property(requiredProperty)
+                      .orElseThrow(() -> new IllegalArgumentException(String.format(MISSING_PROPERTY_ERROR_FORMAT,
+                                                                                    requiredProperty, profile.name())));
+    }
+
     /**
      * A wrapper for a {@link StsAssumeRoleCredentialsProvider} that is returned by this factory when
      * {@link #create(ChildProfileCredentialsRequest)} is invoked. This wrapper is important because it ensures the
@@ -63,16 +86,7 @@ public final class StsProfileCredentialsProviderFactory implements ChildProfileC
 
         private StsProfileCredentialsProvider(AwsCredentialsProvider parentCredentialsProvider, Profile profile,
                                               String sourceChain) {
-            String roleArn = requireProperty(profile, ProfileProperty.ROLE_ARN);
-            String roleSessionName = profile.property(ProfileProperty.ROLE_SESSION_NAME)
-                                            .orElseGet(() -> "aws-sdk-java-" + System.currentTimeMillis());
-            String externalId = profile.property(ProfileProperty.EXTERNAL_ID).orElse(null);
-
-            AssumeRoleRequest assumeRoleRequest = AssumeRoleRequest.builder()
-                                                                   .roleArn(roleArn)
-                                                                   .roleSessionName(roleSessionName)
-                                                                   .externalId(externalId)
-                                                                   .build();
+            AssumeRoleRequest assumeRoleRequest = createAssumeRoleRequest(profile);
 
             this.stsClient = StsClient.builder()
                                       .applyMutation(client -> configureEndpoint(client, profile))
@@ -104,12 +118,6 @@ public final class StsProfileCredentialsProviderFactory implements ChildProfileC
                 stsClientBuilder.region(Region.US_EAST_1);
                 stsClientBuilder.endpointOverride(URI.create("https://sts.amazonaws.com"));
             }
-        }
-
-        private String requireProperty(Profile profile, String requiredProperty) {
-            return profile.property(requiredProperty)
-                          .orElseThrow(() -> new IllegalArgumentException(String.format(MISSING_PROPERTY_ERROR_FORMAT,
-                                                                                        requiredProperty, profile.name())));
         }
 
         @Override

--- a/services/sts/src/test/java/software/amazon/awssdk/services/sts/internal/AssumeRoleProfileTest.java
+++ b/services/sts/src/test/java/software/amazon/awssdk/services/sts/internal/AssumeRoleProfileTest.java
@@ -19,10 +19,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
 import software.amazon.awssdk.auth.credentials.internal.ProfileCredentialsUtils;
-import software.amazon.awssdk.utils.StringInputStream;
 import software.amazon.awssdk.profiles.ProfileFile;
 import software.amazon.awssdk.services.sts.AssumeRoleIntegrationTest;
+import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
 import software.amazon.awssdk.utils.SdkAutoCloseable;
+import software.amazon.awssdk.utils.StringInputStream;
 
 /**
  * Verify some basic functionality of {@link StsProfileCredentialsProviderFactory} via the way customers will encounter it:
@@ -69,5 +70,36 @@ public class AssumeRoleProfileTest {
                                           .type(ProfileFile.Type.CONFIGURATION)
                                           .build();
         assertThat(profiles.profile("child")).isPresent();
+    }
+
+    @Test
+    public void assumeRoleRequestUsesDurationSecondsFromProfile() {
+        ProfileFile profiles = profileFileWithRoleProfile("duration_seconds=1800");
+
+        assertThat(profiles.profile("test")).hasValueSatisfying(profile -> {
+            AssumeRoleRequest request = StsProfileCredentialsProviderFactory.createAssumeRoleRequest(profile);
+            assertThat(request.durationSeconds()).isEqualTo(1800);
+        });
+    }
+
+    @Test
+    public void assumeRoleRequestDoesNotSetDurationSecondsWhenProfileOmitsIt() {
+        ProfileFile profiles = profileFileWithRoleProfile("");
+
+        assertThat(profiles.profile("test")).hasValueSatisfying(profile -> {
+            AssumeRoleRequest request = StsProfileCredentialsProviderFactory.createAssumeRoleRequest(profile);
+            assertThat(request.durationSeconds()).isNull();
+        });
+    }
+
+    private ProfileFile profileFileWithRoleProfile(String additionalRoleProperties) {
+        String profileContent =
+                "[profile test]\n"
+                + "role_arn=arn:aws:iam::123456789012:role/testRole\n"
+                + additionalRoleProperties;
+        return ProfileFile.builder()
+                          .content(new StringInputStream(profileContent))
+                          .type(ProfileFile.Type.CONFIGURATION)
+                          .build();
     }
 }


### PR DESCRIPTION
## Motivation and Context

Fixes #5695.

Assume-role profiles could specify `duration_seconds`, but the STS request did not use the configured value. STS therefore issued sessions using its default duration.

## Modifications

- Map `duration_seconds` from assume-role profiles to `AssumeRoleRequest.durationSeconds`.
- Extract package-visible request construction for direct unit testing.
- Add regression tests for configured and absent duration values.
- Add a changelog entry.

## Testing

```sh
./mvnw -pl :sts -am \
  -Dtest=AssumeRoleProfileTest \
  -Dsurefire.failIfNoSpecifiedTests=false test
```

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read the CONTRIBUTING (https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of mvn install succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [x] I have added a changelog entry.
- [ ] My change is to implement 1.11 parity feature and I have updated LaunchChangelog
  (https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License

- [x] I confirm that this pull request can be released under the Apache 2 license

