### PR TITLE
Fix flaky ParallelScanIntegrationTest by adding pagination to scan requests

### DIFF
--- a/services/dynamodb/src/it/java/software/amazon/awssdk/services/dynamodb/ParallelScanIntegrationTest.java
+++ b/services/dynamodb/src/it/java/software/amazon/awssdk/services/dynamodb/ParallelScanIntegrationTest.java
@@ -88,43 +88,40 @@ public class ParallelScanIntegrationTest extends DynamoDBTestBase {
     public void testParallelScan() {
         putTestData();
 
-        /**
-         * Only one segment.
-         */
-        ScanRequest scanRequest = ScanRequest.builder()
-                .tableName(tableName)
-                .scanFilter(Collections.singletonMap(
-                        ATTRIBUTE_RANDOM,
-                        Condition.builder()
-                                .attributeValueList(
-                                        AttributeValue.builder().n("" + itemNumber / 2).build())
-                                .comparisonOperator(
-                                        ComparisonOperator.LT.toString()).build()))
-                .totalSegments(1).segment(0).build();
-        ScanResponse scanResult = dynamo.scan(scanRequest);
-        assertEquals((Object) itemNumber, (Object) scanResult.scannedCount());
-        int filteredItems = scanResult.count();
+        Condition filterCondition = Condition.builder()
+                .attributeValueList(AttributeValue.builder().n("" + itemNumber / 2).build())
+                .comparisonOperator(ComparisonOperator.LT.toString())
+                .build();
+        Map<String, Condition> scanFilter = Collections.singletonMap(ATTRIBUTE_RANDOM, filterCondition);
 
         /**
-         * Multiple segments.
+         * Only one segment — use scanPaginator to handle pagination automatically.
+         */
+        int totalScannedCount = 0;
+        int filteredItems = 0;
+        for (ScanResponse page : dynamo.scanPaginator(ScanRequest.builder()
+                .tableName(tableName)
+                .scanFilter(scanFilter)
+                .totalSegments(1).segment(0)
+                .build())) {
+            totalScannedCount += page.scannedCount();
+            filteredItems += page.count();
+        }
+        assertEquals((Object) itemNumber, (Object) totalScannedCount);
+
+        /**
+         * Multiple segments — use scanPaginator for each segment.
          */
         int totalSegments = 10;
         int filteredItemsInsegments = 0;
         for (int segment = 0; segment < totalSegments; segment++) {
-            scanRequest = ScanRequest.builder()
+            for (ScanResponse page : dynamo.scanPaginator(ScanRequest.builder()
                     .tableName(tableName)
-                    .scanFilter(
-                            Collections.singletonMap(
-                                    ATTRIBUTE_RANDOM,
-                                    Condition.builder().attributeValueList(
-                                            AttributeValue.builder().n(""
-                                                                       + itemNumber / 2).build())
-                                                   .comparisonOperator(
-                                                           ComparisonOperator.LT
-                                                                   .toString()).build()))
-                    .totalSegments(totalSegments).segment(segment).build();
-            scanResult = dynamo.scan(scanRequest);
-            filteredItemsInsegments += scanResult.count();
+                    .scanFilter(scanFilter)
+                    .totalSegments(totalSegments).segment(segment)
+                    .build())) {
+                filteredItemsInsegments += page.count();
+            }
         }
         assertEquals(filteredItems, filteredItemsInsegments);
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
ParallelScanIntegrationTest.testParallelScan flakes in preview builds with small count mismatches (off by 1–5 items) at the assertion comparing single-segment scan results against 10-segment parallel scan results. 16 failures in the last 14 days. The root cause is that neither scan paginates - DynamoDB scan returns at most 1MB per call, and on the shared CI table with accumulated data, responses get truncated at different boundaries for the single-segment and multi-segment scans, producing different filtered counts.

## Modifications
Replaced single-call dynamo.scan() with dynamo.scanPaginator() for both the single-segment scan and each of the 10 parallel segment scans, so all pages are read automatically before comparing counts. Also extracted the shared scan filter to reduce duplication.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of `mvn install` succeeds
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.
- [ ] My change is to implement 1.11 parity feature and I have updated [LaunchChangelog](https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license
