### PR TITLE
Sanitize list indices in DynamoDB projection expressions

### DIFF
--- a/.changes/next-release/bugfix-AmazonDynamoDBEnhancedClient-848e73d.json
+++ b/.changes/next-release/bugfix-AmazonDynamoDBEnhancedClient-848e73d.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "Amazon DynamoDB Enhanced Client",
+    "description": "Fix projection expressions for attributes containing list indices.",
+    "contributor": "afarber"
+}

--- a/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/EnhancedClientUtils.java
+++ b/services-custom/dynamodb-enhanced/src/main/java/software/amazon/awssdk/enhanced/dynamodb/internal/EnhancedClientUtils.java
@@ -46,7 +46,7 @@ import software.amazon.awssdk.utils.StringUtils;
 public final class EnhancedClientUtils {
     private static final Set<Character> SPECIAL_CHARACTERS = Stream.of(
         '*', '.', '-', '#', '+', ':', '/', '(', ')', ' ',
-        '&', '<', '>', '?', '=', '!', '@', '%', '$', '|').collect(Collectors.toSet());
+        '&', '<', '>', '?', '=', '!', '@', '%', '$', '|', '[', ']').collect(Collectors.toSet());
     private static final Pattern NESTED_OBJECT_PATTERN = Pattern.compile(NESTED_OBJECT_UPDATE);
 
     private EnhancedClientUtils() {

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/ProjectionExpressionTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/ProjectionExpressionTest.java
@@ -22,7 +22,7 @@ public class ProjectionExpressionTest {
     static {
         EXPECTED_ATTRIBUTE_NAMES.put("#AMZN_MAPPED_attribute", "attribute");
         EXPECTED_ATTRIBUTE_NAMES.put("#AMZN_MAPPED_Attribute", "Attribute");
-        EXPECTED_ATTRIBUTE_NAMES.put("#AMZN_MAPPED_firstiteminlist[0]", "firstiteminlist[0]");
+        EXPECTED_ATTRIBUTE_NAMES.put("#AMZN_MAPPED_firstiteminlist_0_", "firstiteminlist[0]");
         EXPECTED_ATTRIBUTE_NAMES.put("#AMZN_MAPPED_March_2021", "March-2021");
         EXPECTED_ATTRIBUTE_NAMES.put("#AMZN_MAPPED_Why_Make_This_An_Attribute_Name", "Why.Make-This*An:Attribute:Name");
     }

--- a/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/internal/EnhancedClientUtilsTest.java
+++ b/services-custom/dynamodb-enhanced/src/test/java/software/amazon/awssdk/enhanced/dynamodb/internal/EnhancedClientUtilsTest.java
@@ -125,9 +125,9 @@ public class EnhancedClientUtilsTest {
 
     @Test
     public void cleanAttributeName_cleansSpecialCharacters() {
-        String result = EnhancedClientUtils.cleanAttributeName("a*b.c-d:e#f+g:h/i(j)k&l<m>n?o=p!q@r%s$t|u");
+        String result = EnhancedClientUtils.cleanAttributeName("a*b.c-d:e#f+g:h/i(j)k&l<m>n?o=p!q@r%s$t|u[v]");
         
-        assertThat(result).isEqualTo("a_b_c_d_e_f_g_h_i_j_k_l_m_n_o_p_q_r_s_t_u");
+        assertThat(result).isEqualTo("a_b_c_d_e_f_g_h_i_j_k_l_m_n_o_p_q_r_s_t_u_v_");
     }
 
     @Test


### PR DESCRIPTION
## Motivation and Context

Fixes #5603.

The DynamoDB Enhanced Client generated invalid expression attribute-name keys when projecting an attribute path containing a list index, such as `phoneNumbers[1]`.

## Modifications

- Sanitize `[` and `]` through the existing shared attribute-name sanitizer.
- Update regression coverage for list-index projection aliases.
- Add a changelog entry.

## Testing

```sh
./mvnw -pl :dynamodb-enhanced \
  -Dtest=EnhancedClientUtilsTest,ProjectionExpressionTest test
```

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read the CONTRIBUTING (https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [ ] Local run of mvn install succeeds
- [x] My code follows the code style of this project
- [ ] My change requires a change to the Javadoc documentation
- [ ] I have updated the Javadoc documentation accordingly
- [x] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [x] I have added a changelog entry.
- [ ] My change is to implement 1.11 parity feature and I have updated LaunchChangelog
  (https://github.com/aws/aws-sdk-java-v2/blob/master/docs/LaunchChangelog.md)

## License

- [x] I confirm that this pull request can be released under the Apache 2 license
