### PR TITLE
Fix query/ec2 protocol perf regression

### DIFF
--- a/.changes/next-release/bugfix-AWSSDKforJavav2-e181119.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-e181119.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "AWS SDK for Java v2",
+    "contributor": "",
+    "description": "Fix request-side perfromance regression that scaled with payload size for `query` and `ec2` protocol services where the the request endpoint was re-parsed as a URI."
+}

--- a/.changes/next-release/bugfix-AWSSDKforJavav2-e181119.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-e181119.json
@@ -2,5 +2,5 @@
     "type": "perf-improvement",
     "category": "AWS SDK for Java v2",
     "contributor": "",
-    "description": "Fix request-side performance regression that scaled with payload size for `query` and `ec2` protocol services where the request endpoint was re-parsed as a URI. The internal `HTTP_REQUEST_URI_BEFORE_MODIFY` execution attribute is now deprecated, read-only and computed on demand from `HTTP_REQUEST_ENDPOINT_BEFORE_MODIFY`; it carries the scheme, host, port and path but no query string."
+    "description": "Fix request-side performance regression that scaled with payload size for `query` and `ec2` protocol services where the request endpoint was re-parsed as a URI. The internal `HTTP_REQUEST_URI_BEFORE_MODIFY` execution attribute is now deprecated and computed on demand from `HTTP_REQUEST_ENDPOINT_BEFORE_MODIFY`; the value the SDK records carries the scheme, host, port and path but no query string."
 }

--- a/.changes/next-release/bugfix-AWSSDKforJavav2-e181119.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-e181119.json
@@ -1,5 +1,5 @@
 {
-    "type": "bugfix",
+    "type": "perf-improvement",
     "category": "AWS SDK for Java v2",
     "contributor": "",
     "description": "Fix request-side performance regression that scaled with payload size for `query` and `ec2` protocol services where the request endpoint was re-parsed as a URI. The internal `HTTP_REQUEST_URI_BEFORE_MODIFY` execution attribute is now deprecated and computed on read; use `HTTP_REQUEST_BEFORE_MODIFY` instead."

--- a/.changes/next-release/bugfix-AWSSDKforJavav2-e181119.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-e181119.json
@@ -1,5 +1,5 @@
 {
-    "type": "bugfix",
+    "type": "perf-improvement",
     "category": "AWS SDK for Java v2",
     "contributor": "",
     "description": "Fix request-side performance regression that scaled with payload size for `query` and `ec2` protocol services where the request endpoint was re-parsed as a URI. The internal `HTTP_REQUEST_URI_BEFORE_MODIFY` execution attribute is now deprecated, read-only and computed on demand from `HTTP_REQUEST_ENDPOINT_BEFORE_MODIFY`; it carries the scheme, host, port and path but no query string."

--- a/.changes/next-release/bugfix-AWSSDKforJavav2-e181119.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-e181119.json
@@ -2,5 +2,5 @@
     "type": "bugfix",
     "category": "AWS SDK for Java v2",
     "contributor": "",
-    "description": "Fix request-side perfromance regression that scaled with payload size for `query` and `ec2` protocol services where the the request endpoint was re-parsed as a URI."
+    "description": "Fix request-side performance regression that scaled with payload size for `query` and `ec2` protocol services where the request endpoint was re-parsed as a URI. The internal `HTTP_REQUEST_URI_BEFORE_MODIFY` execution attribute is now deprecated and computed on read; use `HTTP_REQUEST_BEFORE_MODIFY` instead."
 }

--- a/.changes/next-release/bugfix-AWSSDKforJavav2-e181119.json
+++ b/.changes/next-release/bugfix-AWSSDKforJavav2-e181119.json
@@ -1,6 +1,6 @@
 {
-    "type": "perf-improvement",
+    "type": "bugfix",
     "category": "AWS SDK for Java v2",
     "contributor": "",
-    "description": "Fix request-side performance regression that scaled with payload size for `query` and `ec2` protocol services where the request endpoint was re-parsed as a URI. The internal `HTTP_REQUEST_URI_BEFORE_MODIFY` execution attribute is now deprecated and computed on read; use `HTTP_REQUEST_BEFORE_MODIFY` instead."
+    "description": "Fix request-side performance regression that scaled with payload size for `query` and `ec2` protocol services where the request endpoint was re-parsed as a URI. The internal `HTTP_REQUEST_URI_BEFORE_MODIFY` execution attribute is now deprecated, read-only and computed on demand from `HTTP_REQUEST_ENDPOINT_BEFORE_MODIFY`; it carries the scheme, host, port and path but no query string."
 }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/SdkInternalExecutionAttribute.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/SdkInternalExecutionAttribute.java
@@ -15,6 +15,7 @@
 
 package software.amazon.awssdk.core.interceptor;
 
+import java.net.URI;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
@@ -37,8 +38,8 @@ import software.amazon.awssdk.core.useragent.AdditionalMetadata;
 import software.amazon.awssdk.core.useragent.BusinessMetricCollection;
 import software.amazon.awssdk.endpoints.Endpoint;
 import software.amazon.awssdk.endpoints.EndpointProvider;
-import software.amazon.awssdk.endpoints.EndpointUrl;
 import software.amazon.awssdk.http.SdkHttpExecutionAttributes;
+import software.amazon.awssdk.http.SdkHttpRequest;
 import software.amazon.awssdk.http.auth.spi.scheme.AuthScheme;
 import software.amazon.awssdk.http.auth.spi.scheme.AuthSchemeProvider;
 import software.amazon.awssdk.http.auth.spi.signer.HttpSigner;
@@ -212,16 +213,35 @@ public final class SdkInternalExecutionAttribute extends SdkExecutionAttribute {
         new ExecutionAttribute<>("EndpointResolver");
 
     /**
-     * The HTTP request endpoint (scheme, host and port) captured before modifyHttpRequest interceptors run.
+     * The marshalled HTTP request captured before modifyHttpRequest interceptors run.
      * Used by EndpointResolutionStage to detect if a customer interceptor modified the endpoint.
      *
-     * <p>This is deliberately an {@link EndpointUrl} of pre-parsed components rather than a {@link java.net.URI}:
-     * {@link software.amazon.awssdk.http.SdkHttpRequest#getUri()} percent-encodes the request's query parameters and
-     * re-parses the resulting string, and for the {@code query} and {@code ec2} protocols those query parameters still
-     * hold the entire request payload at this point in the execution.
+     * <p>The request is stored as-is rather than reduced to a URI, so that reading the endpoint costs nothing but
+     * field access. {@link SdkHttpRequest#getUri()} percent-encodes the request's query parameters and re-parses the
+     * resulting string, and for the {@code query} and {@code ec2} protocols those query parameters still hold the
+     * entire request payload at this point in the execution.
      */
-    public static final ExecutionAttribute<EndpointUrl> HTTP_REQUEST_ENDPOINT_BEFORE_MODIFY =
-        new ExecutionAttribute<>("HttpRequestEndpointBeforeModify");
+    public static final ExecutionAttribute<SdkHttpRequest> HTTP_REQUEST_BEFORE_MODIFY =
+        new ExecutionAttribute<>("HttpRequestBeforeModify");
+
+    /**
+     * The HTTP request URI captured before modifyHttpRequest interceptors run.
+     *
+     * @deprecated Use {@link #HTTP_REQUEST_BEFORE_MODIFY} instead. Reading this attribute builds a {@link URI} from
+     * the snapshotted request on every read, which percent-encodes the request's query parameters and parses the
+     * result. For the {@code query} and {@code ec2} protocols those query parameters still hold the entire request
+     * payload at this point, making each read cost two passes over the whole payload.
+     */
+    @Deprecated
+    public static final ExecutionAttribute<URI> HTTP_REQUEST_URI_BEFORE_MODIFY =
+        ExecutionAttribute.derivedBuilder("HttpRequestUriBeforeModify",
+                                          URI.class,
+                                          () -> HTTP_REQUEST_BEFORE_MODIFY)
+                          .readMapping(request -> request != null ? request.getUri() : null)
+                          .writeMapping((request, uri) -> request != null && uri != null
+                                                          ? request.toBuilder().uri(uri).build()
+                                                          : request)
+                          .build();
 
     /**
      * The selected auth scheme for a request.

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/SdkInternalExecutionAttribute.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/SdkInternalExecutionAttribute.java
@@ -225,7 +225,8 @@ public final class SdkInternalExecutionAttribute extends SdkExecutionAttribute {
         new ExecutionAttribute<>("HttpRequestBeforeModify");
 
     /**
-     * The HTTP request URI captured before modifyHttpRequest interceptors run.
+     * The HTTP request URI captured before modifyHttpRequest interceptors run. Read-only; setting it throws
+     * {@link UnsupportedOperationException}.
      *
      * @deprecated Use {@link #HTTP_REQUEST_BEFORE_MODIFY} instead. Reading this attribute builds a {@link URI} from
      * the snapshotted request on every read, which percent-encodes the request's query parameters and parses the
@@ -238,9 +239,11 @@ public final class SdkInternalExecutionAttribute extends SdkExecutionAttribute {
                                           URI.class,
                                           () -> HTTP_REQUEST_BEFORE_MODIFY)
                           .readMapping(request -> request != null ? request.getUri() : null)
-                          .writeMapping((request, uri) -> request != null && uri != null
-                                                          ? request.toBuilder().uri(uri).build()
-                                                          : request)
+                          .writeMapping((request, uri) -> {
+                              throw new UnsupportedOperationException(
+                                  "HttpRequestUriBeforeModify is a read-only view of HttpRequestBeforeModify and "
+                                  + "cannot be set.");
+                          })
                           .build();
 
     /**

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/SdkInternalExecutionAttribute.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/SdkInternalExecutionAttribute.java
@@ -220,12 +220,12 @@ public final class SdkInternalExecutionAttribute extends SdkExecutionAttribute {
         new ExecutionAttribute<>("HttpRequestEndpointBeforeModify");
 
     /**
-     * The HTTP request URI captured before modifyHttpRequest interceptors run. Read-only; setting it throws
-     * {@link UnsupportedOperationException}.
+     * The HTTP request URI captured before modifyHttpRequest interceptors run. Writing this replaces
+     * {@link #HTTP_REQUEST_ENDPOINT_BEFORE_MODIFY} with the written URI's components.
      *
-     * @deprecated Use {@link #HTTP_REQUEST_ENDPOINT_BEFORE_MODIFY} instead. This is a view over that attribute, so it
-     * carries only the scheme, host, port and path: the query string is always absent, and the port is always present
-     * even when it is the protocol's default. Reading it builds a {@link URI}, which
+     * @deprecated Use {@link #HTTP_REQUEST_ENDPOINT_BEFORE_MODIFY} instead. This is a view over that attribute, so the
+     * value recorded by the SDK carries only the scheme, host, port and path: the query string is absent, and the port
+     * is present even when it is the protocol's default. Reading it builds a {@link URI}, which
      * {@link #HTTP_REQUEST_ENDPOINT_BEFORE_MODIFY} lets you avoid.
      */
     @Deprecated
@@ -234,11 +234,7 @@ public final class SdkInternalExecutionAttribute extends SdkExecutionAttribute {
                                           URI.class,
                                           () -> HTTP_REQUEST_ENDPOINT_BEFORE_MODIFY)
                           .readMapping(endpoint -> endpoint != null ? endpoint.toUri() : null)
-                          .writeMapping((endpoint, uri) -> {
-                              throw new UnsupportedOperationException(
-                                  "HttpRequestUriBeforeModify is a read-only view of HttpRequestEndpointBeforeModify "
-                                  + "and cannot be set.");
-                          })
+                          .writeMapping((endpoint, uri) -> uri != null ? EndpointUrl.fromUri(uri) : null)
                           .build();
 
     /**

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/SdkInternalExecutionAttribute.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/SdkInternalExecutionAttribute.java
@@ -216,12 +216,6 @@ public final class SdkInternalExecutionAttribute extends SdkExecutionAttribute {
     /**
      * The HTTP request endpoint (scheme, host, port and path) captured before modifyHttpRequest interceptors run.
      * Used by EndpointResolutionStage to detect if a customer interceptor modified the endpoint.
-     *
-     * <p>Only the endpoint components are captured, never a {@link URI} and never the request itself.
-     * {@link SdkHttpRequest#getUri()} percent-encodes the request's query parameters and re-parses the resulting
-     * string, and for the {@code query} and {@code ec2} protocols those query parameters still hold the entire request
-     * payload at this point in the execution. Capturing components keeps this cheap to record and stops the snapshot
-     * from holding the payload alive for the rest of the API call.
      */
     public static final ExecutionAttribute<EndpointUrl> HTTP_REQUEST_ENDPOINT_BEFORE_MODIFY =
         new ExecutionAttribute<>("HttpRequestEndpointBeforeModify");

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/SdkInternalExecutionAttribute.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/SdkInternalExecutionAttribute.java
@@ -15,7 +15,6 @@
 
 package software.amazon.awssdk.core.interceptor;
 
-import java.net.URI;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
@@ -38,6 +37,7 @@ import software.amazon.awssdk.core.useragent.AdditionalMetadata;
 import software.amazon.awssdk.core.useragent.BusinessMetricCollection;
 import software.amazon.awssdk.endpoints.Endpoint;
 import software.amazon.awssdk.endpoints.EndpointProvider;
+import software.amazon.awssdk.endpoints.EndpointUrl;
 import software.amazon.awssdk.http.SdkHttpExecutionAttributes;
 import software.amazon.awssdk.http.auth.spi.scheme.AuthScheme;
 import software.amazon.awssdk.http.auth.spi.scheme.AuthSchemeProvider;
@@ -212,11 +212,16 @@ public final class SdkInternalExecutionAttribute extends SdkExecutionAttribute {
         new ExecutionAttribute<>("EndpointResolver");
 
     /**
-     * The HTTP request URI captured before modifyHttpRequest interceptors run.
-     * Used by EndpointResolutionStage to detect if a customer interceptor modified the URL.
+     * The HTTP request endpoint (scheme, host and port) captured before modifyHttpRequest interceptors run.
+     * Used by EndpointResolutionStage to detect if a customer interceptor modified the endpoint.
+     *
+     * <p>This is deliberately an {@link EndpointUrl} of pre-parsed components rather than a {@link java.net.URI}:
+     * {@link software.amazon.awssdk.http.SdkHttpRequest#getUri()} percent-encodes the request's query parameters and
+     * re-parses the resulting string, and for the {@code query} and {@code ec2} protocols those query parameters still
+     * hold the entire request payload at this point in the execution.
      */
-    public static final ExecutionAttribute<URI> HTTP_REQUEST_URI_BEFORE_MODIFY =
-        new ExecutionAttribute<>("HttpRequestUriBeforeModify");
+    public static final ExecutionAttribute<EndpointUrl> HTTP_REQUEST_ENDPOINT_BEFORE_MODIFY =
+        new ExecutionAttribute<>("HttpRequestEndpointBeforeModify");
 
     /**
      * The selected auth scheme for a request.

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/SdkInternalExecutionAttribute.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/SdkInternalExecutionAttribute.java
@@ -40,7 +40,6 @@ import software.amazon.awssdk.endpoints.Endpoint;
 import software.amazon.awssdk.endpoints.EndpointProvider;
 import software.amazon.awssdk.endpoints.EndpointUrl;
 import software.amazon.awssdk.http.SdkHttpExecutionAttributes;
-import software.amazon.awssdk.http.SdkHttpRequest;
 import software.amazon.awssdk.http.auth.spi.scheme.AuthScheme;
 import software.amazon.awssdk.http.auth.spi.scheme.AuthSchemeProvider;
 import software.amazon.awssdk.http.auth.spi.signer.HttpSigner;

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/SdkInternalExecutionAttribute.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/interceptor/SdkInternalExecutionAttribute.java
@@ -38,6 +38,7 @@ import software.amazon.awssdk.core.useragent.AdditionalMetadata;
 import software.amazon.awssdk.core.useragent.BusinessMetricCollection;
 import software.amazon.awssdk.endpoints.Endpoint;
 import software.amazon.awssdk.endpoints.EndpointProvider;
+import software.amazon.awssdk.endpoints.EndpointUrl;
 import software.amazon.awssdk.http.SdkHttpExecutionAttributes;
 import software.amazon.awssdk.http.SdkHttpRequest;
 import software.amazon.awssdk.http.auth.spi.scheme.AuthScheme;
@@ -213,36 +214,37 @@ public final class SdkInternalExecutionAttribute extends SdkExecutionAttribute {
         new ExecutionAttribute<>("EndpointResolver");
 
     /**
-     * The marshalled HTTP request captured before modifyHttpRequest interceptors run.
+     * The HTTP request endpoint (scheme, host, port and path) captured before modifyHttpRequest interceptors run.
      * Used by EndpointResolutionStage to detect if a customer interceptor modified the endpoint.
      *
-     * <p>The request is stored as-is rather than reduced to a URI, so that reading the endpoint costs nothing but
-     * field access. {@link SdkHttpRequest#getUri()} percent-encodes the request's query parameters and re-parses the
-     * resulting string, and for the {@code query} and {@code ec2} protocols those query parameters still hold the
-     * entire request payload at this point in the execution.
+     * <p>Only the endpoint components are captured, never a {@link URI} and never the request itself.
+     * {@link SdkHttpRequest#getUri()} percent-encodes the request's query parameters and re-parses the resulting
+     * string, and for the {@code query} and {@code ec2} protocols those query parameters still hold the entire request
+     * payload at this point in the execution. Capturing components keeps this cheap to record and stops the snapshot
+     * from holding the payload alive for the rest of the API call.
      */
-    public static final ExecutionAttribute<SdkHttpRequest> HTTP_REQUEST_BEFORE_MODIFY =
-        new ExecutionAttribute<>("HttpRequestBeforeModify");
+    public static final ExecutionAttribute<EndpointUrl> HTTP_REQUEST_ENDPOINT_BEFORE_MODIFY =
+        new ExecutionAttribute<>("HttpRequestEndpointBeforeModify");
 
     /**
      * The HTTP request URI captured before modifyHttpRequest interceptors run. Read-only; setting it throws
      * {@link UnsupportedOperationException}.
      *
-     * @deprecated Use {@link #HTTP_REQUEST_BEFORE_MODIFY} instead. Reading this attribute builds a {@link URI} from
-     * the snapshotted request on every read, which percent-encodes the request's query parameters and parses the
-     * result. For the {@code query} and {@code ec2} protocols those query parameters still hold the entire request
-     * payload at this point, making each read cost two passes over the whole payload.
+     * @deprecated Use {@link #HTTP_REQUEST_ENDPOINT_BEFORE_MODIFY} instead. This is a view over that attribute, so it
+     * carries only the scheme, host, port and path: the query string is always absent, and the port is always present
+     * even when it is the protocol's default. Reading it builds a {@link URI}, which
+     * {@link #HTTP_REQUEST_ENDPOINT_BEFORE_MODIFY} lets you avoid.
      */
     @Deprecated
     public static final ExecutionAttribute<URI> HTTP_REQUEST_URI_BEFORE_MODIFY =
         ExecutionAttribute.derivedBuilder("HttpRequestUriBeforeModify",
                                           URI.class,
-                                          () -> HTTP_REQUEST_BEFORE_MODIFY)
-                          .readMapping(request -> request != null ? request.getUri() : null)
-                          .writeMapping((request, uri) -> {
+                                          () -> HTTP_REQUEST_ENDPOINT_BEFORE_MODIFY)
+                          .readMapping(endpoint -> endpoint != null ? endpoint.toUri() : null)
+                          .writeMapping((endpoint, uri) -> {
                               throw new UnsupportedOperationException(
-                                  "HttpRequestUriBeforeModify is a read-only view of HttpRequestBeforeModify and "
-                                  + "cannot be set.");
+                                  "HttpRequestUriBeforeModify is a read-only view of HttpRequestEndpointBeforeModify "
+                                  + "and cannot be set.");
                           })
                           .build();
 

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/handler/BaseClientHandler.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/handler/BaseClientHandler.java
@@ -41,7 +41,6 @@ import software.amazon.awssdk.core.internal.util.MetricUtils;
 import software.amazon.awssdk.core.metrics.CoreMetric;
 import software.amazon.awssdk.core.signer.Signer;
 import software.amazon.awssdk.core.sync.RequestBody;
-import software.amazon.awssdk.endpoints.EndpointUrl;
 import software.amazon.awssdk.http.ContentStreamProvider;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
 import software.amazon.awssdk.http.SdkHttpFullResponse;
@@ -82,21 +81,17 @@ public abstract class BaseClientHandler {
         addHttpRequest(executionContext, request);
         runAfterMarshallingInterceptors(executionContext);
 
-        // Snapshot the HTTP request endpoint before modifyHttpRequest interceptors run.
+        // Snapshot the marshalled HTTP request before modifyHttpRequest interceptors run.
         // EndpointResolutionStage uses this to detect if a customer interceptor modified the endpoint.
         //
-        // Only the endpoint components are captured, never a URI. Building a URI here would call
+        // The request is stored as-is, never reduced to a URI. Building a URI here would call
         // SdkHttpRequest#getUri(), which percent-encodes the request's query parameters and then re-parses the
         // resulting string. For the query and ec2 protocols those query parameters still hold the entire request
         // payload at this point -- QueryParametersToBodyStage only moves them into the body later, inside the
         // request pipeline -- so that would cost two extra passes over the whole payload on every API call.
-        SdkHttpRequest marshalledRequest = executionContext.interceptorContext().httpRequest();
         executionContext.executionAttributes().putAttribute(
-            SdkInternalExecutionAttribute.HTTP_REQUEST_ENDPOINT_BEFORE_MODIFY,
-            EndpointUrl.fromComponents(marshalledRequest.protocol(),
-                                       marshalledRequest.host(),
-                                       marshalledRequest.port(),
-                                       marshalledRequest.encodedPath()));
+            SdkInternalExecutionAttribute.HTTP_REQUEST_BEFORE_MODIFY,
+            executionContext.interceptorContext().httpRequest());
 
         return runModifyHttpRequestAndHttpContentInterceptors(executionContext);
     }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/handler/BaseClientHandler.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/handler/BaseClientHandler.java
@@ -41,6 +41,7 @@ import software.amazon.awssdk.core.internal.util.MetricUtils;
 import software.amazon.awssdk.core.metrics.CoreMetric;
 import software.amazon.awssdk.core.signer.Signer;
 import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.endpoints.EndpointUrl;
 import software.amazon.awssdk.http.ContentStreamProvider;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
 import software.amazon.awssdk.http.SdkHttpFullResponse;
@@ -81,11 +82,21 @@ public abstract class BaseClientHandler {
         addHttpRequest(executionContext, request);
         runAfterMarshallingInterceptors(executionContext);
 
-        // Snapshot the HTTP request URI before modifyHttpRequest interceptors run.
-        // EndpointResolutionStage uses this to detect if a customer interceptor modified the URL.
+        // Snapshot the HTTP request endpoint before modifyHttpRequest interceptors run.
+        // EndpointResolutionStage uses this to detect if a customer interceptor modified the endpoint.
+        //
+        // Only the endpoint components are captured, never a URI. Building a URI here would call
+        // SdkHttpRequest#getUri(), which percent-encodes the request's query parameters and then re-parses the
+        // resulting string. For the query and ec2 protocols those query parameters still hold the entire request
+        // payload at this point -- QueryParametersToBodyStage only moves them into the body later, inside the
+        // request pipeline -- so that would cost two extra passes over the whole payload on every API call.
+        SdkHttpRequest marshalledRequest = executionContext.interceptorContext().httpRequest();
         executionContext.executionAttributes().putAttribute(
-            SdkInternalExecutionAttribute.HTTP_REQUEST_URI_BEFORE_MODIFY,
-            executionContext.interceptorContext().httpRequest().getUri());
+            SdkInternalExecutionAttribute.HTTP_REQUEST_ENDPOINT_BEFORE_MODIFY,
+            EndpointUrl.fromComponents(marshalledRequest.protocol(),
+                                       marshalledRequest.host(),
+                                       marshalledRequest.port(),
+                                       marshalledRequest.encodedPath()));
 
         return runModifyHttpRequestAndHttpContentInterceptors(executionContext);
     }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/handler/BaseClientHandler.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/handler/BaseClientHandler.java
@@ -41,6 +41,7 @@ import software.amazon.awssdk.core.internal.util.MetricUtils;
 import software.amazon.awssdk.core.metrics.CoreMetric;
 import software.amazon.awssdk.core.signer.Signer;
 import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.endpoints.EndpointUrl;
 import software.amazon.awssdk.http.ContentStreamProvider;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
 import software.amazon.awssdk.http.SdkHttpFullResponse;
@@ -81,17 +82,22 @@ public abstract class BaseClientHandler {
         addHttpRequest(executionContext, request);
         runAfterMarshallingInterceptors(executionContext);
 
-        // Snapshot the marshalled HTTP request before modifyHttpRequest interceptors run.
+        // Snapshot the HTTP request endpoint before modifyHttpRequest interceptors run.
         // EndpointResolutionStage uses this to detect if a customer interceptor modified the endpoint.
         //
-        // The request is stored as-is, never reduced to a URI. Building a URI here would call
-        // SdkHttpRequest#getUri(), which percent-encodes the request's query parameters and then re-parses the
-        // resulting string. For the query and ec2 protocols those query parameters still hold the entire request
-        // payload at this point -- QueryParametersToBodyStage only moves them into the body later, inside the
-        // request pipeline -- so that would cost two extra passes over the whole payload on every API call.
+        // Only the endpoint components are captured, never a URI and never the request itself. Building a URI here
+        // would call SdkHttpRequest#getUri(), which percent-encodes the request's query parameters and then re-parses
+        // the resulting string; retaining the request would instead keep those query parameters alive until the end of
+        // the API call. For the query and ec2 protocols they hold the entire request payload at this point --
+        // QueryParametersToBodyStage only moves them into the body later, inside the request pipeline -- so either
+        // approach would cost the payload twice over, in time or in memory.
+        SdkHttpRequest marshalledRequest = executionContext.interceptorContext().httpRequest();
         executionContext.executionAttributes().putAttribute(
-            SdkInternalExecutionAttribute.HTTP_REQUEST_BEFORE_MODIFY,
-            executionContext.interceptorContext().httpRequest());
+            SdkInternalExecutionAttribute.HTTP_REQUEST_ENDPOINT_BEFORE_MODIFY,
+            EndpointUrl.fromComponents(marshalledRequest.protocol(),
+                                       marshalledRequest.host(),
+                                       marshalledRequest.port(),
+                                       marshalledRequest.encodedPath()));
 
         return runModifyHttpRequestAndHttpContentInterceptors(executionContext);
     }

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/handler/BaseClientHandler.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/handler/BaseClientHandler.java
@@ -85,12 +85,9 @@ public abstract class BaseClientHandler {
         // Snapshot the HTTP request endpoint before modifyHttpRequest interceptors run.
         // EndpointResolutionStage uses this to detect if a customer interceptor modified the endpoint.
         //
-        // Only the endpoint components are captured, never a URI and never the request itself. Building a URI here
-        // would call SdkHttpRequest#getUri(), which percent-encodes the request's query parameters and then re-parses
-        // the resulting string; retaining the request would instead keep those query parameters alive until the end of
-        // the API call. For the query and ec2 protocols they hold the entire request payload at this point --
-        // QueryParametersToBodyStage only moves them into the body later, inside the request pipeline -- so either
-        // approach would cost the payload twice over, in time or in memory.
+        // Use the optimized EndpointUrl instead of an expensive URI to avoid the cost of parsing/re-parsing it.
+        // Query/EC2 protocols have the entire request payload in query params at this point which increases the time
+        // to build the URI in proportion to the size of the request.
         SdkHttpRequest marshalledRequest = executionContext.interceptorContext().httpRequest();
         executionContext.executionAttributes().putAttribute(
             SdkInternalExecutionAttribute.HTTP_REQUEST_ENDPOINT_BEFORE_MODIFY,

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/EndpointResolutionStage.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/EndpointResolutionStage.java
@@ -110,20 +110,26 @@ public final class EndpointResolutionStage implements MutableRequestToRequestPip
     }
 
     /**
-     * Detects if an interceptor modified the HTTP request URL in modifyHttpRequest().
-     * Compares the current request's host and scheme against the snapshot taken before interceptors ran.
+     * Detects if an interceptor modified the HTTP request endpoint in modifyHttpRequest().
+     * Compares the current request's host, scheme and port against the snapshot taken before interceptors ran.
      */
     private static boolean interceptorModifiedEndpoint(SdkHttpFullRequest.Builder request, ExecutionAttributes attrs) {
-        URI preModifyUri = attrs.getAttribute(SdkInternalExecutionAttribute.HTTP_REQUEST_URI_BEFORE_MODIFY);
-        if (preModifyUri == null) {
+        EndpointUrl preModifyEndpoint =
+            attrs.getAttribute(SdkInternalExecutionAttribute.HTTP_REQUEST_ENDPOINT_BEFORE_MODIFY);
+        if (preModifyEndpoint == null) {
             return false;
         }
         String requestHost = request.host();
+        if (requestHost == null) {
+            return false;
+        }
+        // The snapshot's port is always resolved, since SdkHttpRequest#port() substitutes the protocol's standard
+        // port when the endpoint did not specify one. The builder's port is the raw value and is null in that case,
+        // which is not a modification.
         Integer requestPort = request.port();
-        return requestHost != null
-            && (!requestHost.equals(preModifyUri.getHost())
-                || !String.valueOf(request.protocol()).equals(preModifyUri.getScheme())
-                || (requestPort != null && requestPort != preModifyUri.getPort()));
+        return !requestHost.equals(preModifyEndpoint.host())
+               || !String.valueOf(request.protocol()).equals(preModifyEndpoint.scheme())
+               || (requestPort != null && requestPort != preModifyEndpoint.port());
     }
 
     /**

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/EndpointResolutionStage.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/EndpointResolutionStage.java
@@ -35,6 +35,7 @@ import software.amazon.awssdk.core.metrics.CoreMetric;
 import software.amazon.awssdk.endpoints.Endpoint;
 import software.amazon.awssdk.endpoints.EndpointUrl;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.http.SdkHttpRequest;
 import software.amazon.awssdk.metrics.MetricCollector;
 import software.amazon.awssdk.utils.StringUtils;
 import software.amazon.awssdk.utils.http.SdkHttpUtils;
@@ -114,9 +115,8 @@ public final class EndpointResolutionStage implements MutableRequestToRequestPip
      * Compares the current request's host, scheme and port against the snapshot taken before interceptors ran.
      */
     private static boolean interceptorModifiedEndpoint(SdkHttpFullRequest.Builder request, ExecutionAttributes attrs) {
-        EndpointUrl preModifyEndpoint =
-            attrs.getAttribute(SdkInternalExecutionAttribute.HTTP_REQUEST_ENDPOINT_BEFORE_MODIFY);
-        if (preModifyEndpoint == null) {
+        SdkHttpRequest preModifyRequest = attrs.getAttribute(SdkInternalExecutionAttribute.HTTP_REQUEST_BEFORE_MODIFY);
+        if (preModifyRequest == null) {
             return false;
         }
         String requestHost = request.host();
@@ -127,9 +127,9 @@ public final class EndpointResolutionStage implements MutableRequestToRequestPip
         // port when the endpoint did not specify one. The builder's port is the raw value and is null in that case,
         // which is not a modification.
         Integer requestPort = request.port();
-        return !requestHost.equals(preModifyEndpoint.host())
-               || !String.valueOf(request.protocol()).equals(preModifyEndpoint.scheme())
-               || (requestPort != null && requestPort != preModifyEndpoint.port());
+        return !requestHost.equals(preModifyRequest.host())
+               || !String.valueOf(request.protocol()).equals(preModifyRequest.protocol())
+               || (requestPort != null && requestPort != preModifyRequest.port());
     }
 
     /**

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/EndpointResolutionStage.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/EndpointResolutionStage.java
@@ -35,7 +35,6 @@ import software.amazon.awssdk.core.metrics.CoreMetric;
 import software.amazon.awssdk.endpoints.Endpoint;
 import software.amazon.awssdk.endpoints.EndpointUrl;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
-import software.amazon.awssdk.http.SdkHttpRequest;
 import software.amazon.awssdk.metrics.MetricCollector;
 import software.amazon.awssdk.utils.StringUtils;
 import software.amazon.awssdk.utils.http.SdkHttpUtils;
@@ -115,8 +114,9 @@ public final class EndpointResolutionStage implements MutableRequestToRequestPip
      * Compares the current request's host, scheme and port against the snapshot taken before interceptors ran.
      */
     private static boolean interceptorModifiedEndpoint(SdkHttpFullRequest.Builder request, ExecutionAttributes attrs) {
-        SdkHttpRequest preModifyRequest = attrs.getAttribute(SdkInternalExecutionAttribute.HTTP_REQUEST_BEFORE_MODIFY);
-        if (preModifyRequest == null) {
+        EndpointUrl preModifyEndpoint =
+            attrs.getAttribute(SdkInternalExecutionAttribute.HTTP_REQUEST_ENDPOINT_BEFORE_MODIFY);
+        if (preModifyEndpoint == null) {
             return false;
         }
         String requestHost = request.host();
@@ -127,9 +127,9 @@ public final class EndpointResolutionStage implements MutableRequestToRequestPip
         // port when the endpoint did not specify one. The builder's port is the raw value and is null in that case,
         // which is not a modification.
         Integer requestPort = request.port();
-        return !requestHost.equals(preModifyRequest.host())
-               || !String.valueOf(request.protocol()).equals(preModifyRequest.protocol())
-               || (requestPort != null && requestPort != preModifyRequest.port());
+        return !requestHost.equals(preModifyEndpoint.host())
+               || !String.valueOf(request.protocol()).equals(preModifyEndpoint.scheme())
+               || (requestPort != null && requestPort != preModifyEndpoint.port());
     }
 
     /**

--- a/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/EndpointResolutionStage.java
+++ b/core/sdk-core/src/main/java/software/amazon/awssdk/core/internal/http/pipeline/stages/EndpointResolutionStage.java
@@ -123,9 +123,6 @@ public final class EndpointResolutionStage implements MutableRequestToRequestPip
         if (requestHost == null) {
             return false;
         }
-        // The snapshot's port is always resolved, since SdkHttpRequest#port() substitutes the protocol's standard
-        // port when the endpoint did not specify one. The builder's port is the raw value and is null in that case,
-        // which is not a modification.
         Integer requestPort = request.port();
         return !requestHost.equals(preModifyEndpoint.host())
                || !String.valueOf(request.protocol()).equals(preModifyEndpoint.scheme())

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/client/handler/SyncClientHandlerTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/client/handler/SyncClientHandlerTest.java
@@ -15,6 +15,7 @@
 
 package software.amazon.awssdk.core.client.handler;
 
+import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -22,6 +23,8 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import java.io.ByteArrayInputStream;
+import java.net.URI;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -41,14 +44,20 @@ import software.amazon.awssdk.core.exception.NonRetryableException;
 import software.amazon.awssdk.core.exception.RetryableException;
 import software.amazon.awssdk.core.exception.SdkServiceException;
 import software.amazon.awssdk.core.http.HttpResponseHandler;
+import software.amazon.awssdk.core.interceptor.Context;
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
+import software.amazon.awssdk.core.interceptor.SdkInternalExecutionAttribute;
 import software.amazon.awssdk.core.protocol.VoidSdkResponse;
 import software.amazon.awssdk.core.runtime.transform.Marshaller;
 import software.amazon.awssdk.core.sync.ResponseTransformer;
+import software.amazon.awssdk.endpoints.EndpointUrl;
 import software.amazon.awssdk.http.AbortableInputStream;
 import software.amazon.awssdk.http.HttpExecuteResponse;
 import software.amazon.awssdk.http.ExecutableHttpRequest;
 import software.amazon.awssdk.http.SdkHttpClient;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.http.SdkHttpRequest;
 import software.amazon.awssdk.http.SdkHttpResponse;
 import software.amazon.awssdk.retries.DefaultRetryStrategy;
 import utils.HttpTestUtils;
@@ -187,6 +196,69 @@ public class SyncClientHandlerTest {
                                                                   .response(SdkHttpResponse.builder().statusCode(200).build())
                                                                   .build());
         when(responseHandler.handle(any(), any())).thenReturn(VoidSdkResponse.builder().build());
+    }
+
+    /**
+     * The pre-modify snapshot must never encode the marshalled request's query parameters. For the query and ec2
+     * protocols those parameters still hold the entire request payload when the snapshot is taken, so encoding them
+     * costs a full pass over the payload on every API call, and retaining them keeps the payload alive for the rest of
+     * the call. Guards the regression fixed in this change.
+     */
+    @Test
+    public void snapshottedEndpoint_doesNotEncodeOrRetainQueryParameters() throws Exception {
+        SdkHttpFullRequest.Builder marshalled =
+            ValidSdkObjects.sdkHttpFullRequest(8080)
+                           .encodedPath("/2015-03-31/functions/my-function/invocations")
+                           .putRawQueryParameter("Qualifier", "prod");
+        // A handful of payload-shaped parameters is enough: the assertion is that the query string is absent
+        // entirely, so any of these appearing in the snapshot is a failure.
+        for (int i = 0; i < 20; i++) {
+            marshalled.putRawQueryParameter("MetricData.member." + i + ".Value", "12345.6789");
+        }
+
+        List<EndpointUrl> capturedEndpoint = new ArrayList<>();
+        List<URI> capturedUri = new ArrayList<>();
+        ExecutionInterceptor interceptor = new ExecutionInterceptor() {
+            @Override
+            public SdkHttpRequest modifyHttpRequest(Context.ModifyHttpRequest context, ExecutionAttributes attrs) {
+                capturedEndpoint.add(
+                    attrs.getAttribute(SdkInternalExecutionAttribute.HTTP_REQUEST_ENDPOINT_BEFORE_MODIFY));
+                capturedUri.add(attrs.getAttribute(SdkInternalExecutionAttribute.HTTP_REQUEST_URI_BEFORE_MODIFY));
+                return context.httpRequest();
+            }
+        };
+
+        SdkSyncClientHandler handler = new SdkSyncClientHandler(
+            clientConfiguration().toBuilder()
+                                 .option(SdkClientOption.EXECUTION_INTERCEPTORS, singletonList(interceptor))
+                                 .build());
+
+        when(marshaller.marshall(request)).thenReturn(marshalled.build());
+        when(httpClient.prepareRequest(any())).thenReturn(httpClientCall);
+        when(httpClientCall.call()).thenReturn(HttpExecuteResponse.builder()
+                                                                 .response(SdkHttpResponse.builder()
+                                                                                          .statusCode(200)
+                                                                                          .build())
+                                                                 .build());
+        when(responseHandler.handle(any(), any())).thenReturn(VoidSdkResponse.builder().build());
+
+        handler.execute(clientExecutionParams());
+
+        // The endpoint snapshot holds components only; nothing references the query parameters.
+        assertThat(capturedEndpoint).hasSize(1);
+        assertThat(capturedEndpoint.get(0).host()).isEqualTo("localhost");
+        assertThat(capturedEndpoint.get(0).encodedPath()).isEqualTo("/2015-03-31/functions/my-function/invocations");
+
+        // The deprecated URI view carries no query string, so the payload was never encoded.
+        URI uri = capturedUri.get(0);
+        assertThat(uri.getQuery()).isNull();
+        assertThat(uri.toString()).isEqualTo("http://localhost:8080/2015-03-31/functions/my-function/invocations");
+
+        // The known consumer pattern: extract the path suffix following "/invocations".
+        String path = uri.toString();
+        int idx = path.indexOf("/invocations");
+        assertThat(idx).isGreaterThanOrEqualTo(0);
+        assertThat(path.substring(idx + "/invocations".length())).isEmpty();
     }
 
     private void expectRetrievalFromMocks() {

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/interceptor/SdkInternalExecutionAttributeTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/interceptor/SdkInternalExecutionAttributeTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.core.interceptor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.net.URI;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.http.SdkHttpMethod;
+import software.amazon.awssdk.http.SdkHttpRequest;
+
+/**
+ * Tests for the deprecated {@link SdkInternalExecutionAttribute#HTTP_REQUEST_URI_BEFORE_MODIFY}, which is a derived
+ * view over {@link SdkInternalExecutionAttribute#HTTP_REQUEST_BEFORE_MODIFY}.
+ */
+class SdkInternalExecutionAttributeTest {
+
+    private ExecutionAttributes attributes;
+
+    @BeforeEach
+    void setup() {
+        attributes = new ExecutionAttributes();
+    }
+
+    @Test
+    void httpRequestUriBeforeModify_noSnapshot_isNull() {
+        assertThat(attributes.getAttribute(SdkInternalExecutionAttribute.HTTP_REQUEST_URI_BEFORE_MODIFY)).isNull();
+    }
+
+    @Test
+    void httpRequestUriBeforeModify_readsUriOfSnapshottedRequest() {
+        attributes.putAttribute(SdkInternalExecutionAttribute.HTTP_REQUEST_BEFORE_MODIFY,
+                                requestWithQueryParams());
+
+        assertThat(attributes.getAttribute(SdkInternalExecutionAttribute.HTTP_REQUEST_URI_BEFORE_MODIFY))
+            .isEqualTo(URI.create("https://monitoring.us-east-1.amazonaws.com/"
+                                  + "?Action=PutMetricData&Namespace=My%2FNamespace"));
+    }
+
+    @Test
+    void httpRequestUriBeforeModify_isNotComputedUntilRead() {
+        URI uri = URI.create("https://monitoring.us-east-1.amazonaws.com/");
+        SdkHttpRequest snapshot = mock(SdkHttpRequest.class);
+        when(snapshot.host()).thenReturn("monitoring.us-east-1.amazonaws.com");
+        when(snapshot.getUri()).thenReturn(uri);
+
+        attributes.putAttribute(SdkInternalExecutionAttribute.HTTP_REQUEST_BEFORE_MODIFY, snapshot);
+        verify(snapshot, never()).getUri();
+
+        // Reading the endpoint components must not build the URI either.
+        SdkHttpRequest read = attributes.getAttribute(SdkInternalExecutionAttribute.HTTP_REQUEST_BEFORE_MODIFY);
+        assertThat(read.host()).isEqualTo("monitoring.us-east-1.amazonaws.com");
+        verify(snapshot, never()).getUri();
+
+        assertThat(attributes.getAttribute(SdkInternalExecutionAttribute.HTTP_REQUEST_URI_BEFORE_MODIFY))
+            .isSameAs(uri);
+        verify(snapshot).getUri();
+    }
+
+    @Test
+    void httpRequestUriBeforeModify_writeIsVisibleOnSnapshottedRequest() {
+        attributes.putAttribute(SdkInternalExecutionAttribute.HTTP_REQUEST_BEFORE_MODIFY, requestWithQueryParams());
+
+        attributes.putAttribute(SdkInternalExecutionAttribute.HTTP_REQUEST_URI_BEFORE_MODIFY,
+                                URI.create("https://custom.example.com:8443/"));
+
+        SdkHttpRequest snapshot = attributes.getAttribute(SdkInternalExecutionAttribute.HTTP_REQUEST_BEFORE_MODIFY);
+        assertThat(snapshot.host()).isEqualTo("custom.example.com");
+        assertThat(snapshot.port()).isEqualTo(8443);
+    }
+
+    /**
+     * Shaped like a marshalled query-protocol request: the payload lives in the raw query parameters until
+     * {@code QueryParametersToBodyStage} moves it into the body.
+     */
+    private static SdkHttpRequest requestWithQueryParams() {
+        return SdkHttpFullRequest.builder()
+                                 .method(SdkHttpMethod.POST)
+                                 .protocol("https")
+                                 .host("monitoring.us-east-1.amazonaws.com")
+                                 .encodedPath("/")
+                                 .putRawQueryParameter("Action", "PutMetricData")
+                                 .putRawQueryParameter("Namespace", "My/Namespace")
+                                 .build();
+    }
+}

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/interceptor/SdkInternalExecutionAttributeTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/interceptor/SdkInternalExecutionAttributeTest.java
@@ -16,6 +16,7 @@
 package software.amazon.awssdk.core.interceptor;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -77,15 +78,31 @@ class SdkInternalExecutionAttributeTest {
     }
 
     @Test
-    void httpRequestUriBeforeModify_writeIsVisibleOnSnapshottedRequest() {
-        attributes.putAttribute(SdkInternalExecutionAttribute.HTTP_REQUEST_BEFORE_MODIFY, requestWithQueryParams());
+    void httpRequestUriBeforeModify_writeIsUnsupported() {
+        SdkHttpRequest snapshot = requestWithQueryParams();
+        attributes.putAttribute(SdkInternalExecutionAttribute.HTTP_REQUEST_BEFORE_MODIFY, snapshot);
+        URI uri = URI.create("https://custom.example.com:8443/");
 
-        attributes.putAttribute(SdkInternalExecutionAttribute.HTTP_REQUEST_URI_BEFORE_MODIFY,
-                                URI.create("https://custom.example.com:8443/"));
+        assertThatThrownBy(() -> attributes.putAttribute(
+            SdkInternalExecutionAttribute.HTTP_REQUEST_URI_BEFORE_MODIFY, uri))
+            .isInstanceOf(UnsupportedOperationException.class);
 
-        SdkHttpRequest snapshot = attributes.getAttribute(SdkInternalExecutionAttribute.HTTP_REQUEST_BEFORE_MODIFY);
-        assertThat(snapshot.host()).isEqualTo("custom.example.com");
-        assertThat(snapshot.port()).isEqualTo(8443);
+        assertThat(attributes.getAttribute(SdkInternalExecutionAttribute.HTTP_REQUEST_BEFORE_MODIFY))
+            .isSameAs(snapshot);
+    }
+
+    @Test
+    void httpRequestBeforeModify_survivesCopy() {
+        SdkHttpRequest snapshot = requestWithQueryParams();
+        attributes.putAttribute(SdkInternalExecutionAttribute.HTTP_REQUEST_BEFORE_MODIFY, snapshot);
+
+        // Copies duplicate the backing map rather than re-setting each attribute, so the read-only derived view
+        // must still resolve against the copy.
+        ExecutionAttributes copy = attributes.copy();
+
+        assertThat(copy.getAttribute(SdkInternalExecutionAttribute.HTTP_REQUEST_BEFORE_MODIFY)).isSameAs(snapshot);
+        assertThat(copy.getAttribute(SdkInternalExecutionAttribute.HTTP_REQUEST_URI_BEFORE_MODIFY))
+            .isEqualTo(snapshot.getUri());
     }
 
     /**

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/interceptor/SdkInternalExecutionAttributeTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/interceptor/SdkInternalExecutionAttributeTest.java
@@ -16,7 +16,6 @@
 package software.amazon.awssdk.core.interceptor;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.net.URI;
 import org.junit.jupiter.api.BeforeEach;
@@ -24,8 +23,8 @@ import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.endpoints.EndpointUrl;
 
 /**
- * Tests for the deprecated {@link SdkInternalExecutionAttribute#HTTP_REQUEST_URI_BEFORE_MODIFY}, which is a read-only
- * derived view over {@link SdkInternalExecutionAttribute#HTTP_REQUEST_ENDPOINT_BEFORE_MODIFY}.
+ * Tests for the deprecated {@link SdkInternalExecutionAttribute#HTTP_REQUEST_URI_BEFORE_MODIFY}, which is a derived
+ * view over {@link SdkInternalExecutionAttribute#HTTP_REQUEST_ENDPOINT_BEFORE_MODIFY}.
  */
 class SdkInternalExecutionAttributeTest {
 
@@ -75,16 +74,40 @@ class SdkInternalExecutionAttributeTest {
     }
 
     @Test
-    void httpRequestUriBeforeModify_writeIsUnsupported() {
+    void httpRequestUriBeforeModify_writeReplacesTheEndpoint() {
         attributes.putAttribute(SdkInternalExecutionAttribute.HTTP_REQUEST_ENDPOINT_BEFORE_MODIFY, ENDPOINT);
-        URI uri = URI.create("https://custom.example.com:8443/");
 
-        assertThatThrownBy(() -> attributes.putAttribute(
-            SdkInternalExecutionAttribute.HTTP_REQUEST_URI_BEFORE_MODIFY, uri))
-            .isInstanceOf(UnsupportedOperationException.class);
+        attributes.putAttribute(SdkInternalExecutionAttribute.HTTP_REQUEST_URI_BEFORE_MODIFY,
+                                URI.create("http://custom.example.com:8443/my-path"));
 
-        assertThat(attributes.getAttribute(SdkInternalExecutionAttribute.HTTP_REQUEST_ENDPOINT_BEFORE_MODIFY))
-            .isSameAs(ENDPOINT);
+        EndpointUrl endpoint =
+            attributes.getAttribute(SdkInternalExecutionAttribute.HTTP_REQUEST_ENDPOINT_BEFORE_MODIFY);
+        assertThat(endpoint.scheme()).isEqualTo("http");
+        assertThat(endpoint.host()).isEqualTo("custom.example.com");
+        assertThat(endpoint.port()).isEqualTo(8443);
+        assertThat(endpoint.encodedPath()).isEqualTo("/my-path");
+    }
+
+    @Test
+    void httpRequestUriBeforeModify_writeRoundTripsExactly() {
+        // A written URI reads back unchanged, query string included, so a caller that sets this attribute sees
+        // precisely what it set.
+        URI written = URI.create("https://custom.example.com/my-path?Qualifier=prod");
+
+        attributes.putAttribute(SdkInternalExecutionAttribute.HTTP_REQUEST_URI_BEFORE_MODIFY, written);
+
+        assertThat(attributes.getAttribute(SdkInternalExecutionAttribute.HTTP_REQUEST_URI_BEFORE_MODIFY))
+            .isEqualTo(written);
+    }
+
+    @Test
+    void httpRequestUriBeforeModify_writeNull_clearsTheEndpoint() {
+        attributes.putAttribute(SdkInternalExecutionAttribute.HTTP_REQUEST_ENDPOINT_BEFORE_MODIFY, ENDPOINT);
+
+        attributes.putAttribute(SdkInternalExecutionAttribute.HTTP_REQUEST_URI_BEFORE_MODIFY, null);
+
+        assertThat(attributes.getAttribute(SdkInternalExecutionAttribute.HTTP_REQUEST_ENDPOINT_BEFORE_MODIFY)).isNull();
+        assertThat(attributes.getAttribute(SdkInternalExecutionAttribute.HTTP_REQUEST_URI_BEFORE_MODIFY)).isNull();
     }
 
     @Test

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/interceptor/SdkInternalExecutionAttributeTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/interceptor/SdkInternalExecutionAttributeTest.java
@@ -17,23 +17,21 @@ package software.amazon.awssdk.core.interceptor;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 import java.net.URI;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import software.amazon.awssdk.http.SdkHttpFullRequest;
-import software.amazon.awssdk.http.SdkHttpMethod;
-import software.amazon.awssdk.http.SdkHttpRequest;
+import software.amazon.awssdk.endpoints.EndpointUrl;
 
 /**
- * Tests for the deprecated {@link SdkInternalExecutionAttribute#HTTP_REQUEST_URI_BEFORE_MODIFY}, which is a derived
- * view over {@link SdkInternalExecutionAttribute#HTTP_REQUEST_BEFORE_MODIFY}.
+ * Tests for the deprecated {@link SdkInternalExecutionAttribute#HTTP_REQUEST_URI_BEFORE_MODIFY}, which is a read-only
+ * derived view over {@link SdkInternalExecutionAttribute#HTTP_REQUEST_ENDPOINT_BEFORE_MODIFY}.
  */
 class SdkInternalExecutionAttributeTest {
+
+    private static final EndpointUrl ENDPOINT =
+        EndpointUrl.fromComponents("https", "lambda.us-east-1.amazonaws.com", 443,
+                                   "/2015-03-31/functions/my-function/invocations");
 
     private ExecutionAttributes attributes;
 
@@ -48,75 +46,58 @@ class SdkInternalExecutionAttributeTest {
     }
 
     @Test
-    void httpRequestUriBeforeModify_readsUriOfSnapshottedRequest() {
-        attributes.putAttribute(SdkInternalExecutionAttribute.HTTP_REQUEST_BEFORE_MODIFY,
-                                requestWithQueryParams());
+    void httpRequestUriBeforeModify_rendersSnapshottedEndpoint() {
+        attributes.putAttribute(SdkInternalExecutionAttribute.HTTP_REQUEST_ENDPOINT_BEFORE_MODIFY, ENDPOINT);
 
         assertThat(attributes.getAttribute(SdkInternalExecutionAttribute.HTTP_REQUEST_URI_BEFORE_MODIFY))
-            .isEqualTo(URI.create("https://monitoring.us-east-1.amazonaws.com/"
-                                  + "?Action=PutMetricData&Namespace=My%2FNamespace"));
+            .isEqualTo(URI.create("https://lambda.us-east-1.amazonaws.com:443"
+                                  + "/2015-03-31/functions/my-function/invocations"));
     }
 
     @Test
-    void httpRequestUriBeforeModify_isNotComputedUntilRead() {
-        URI uri = URI.create("https://monitoring.us-east-1.amazonaws.com/");
-        SdkHttpRequest snapshot = mock(SdkHttpRequest.class);
-        when(snapshot.host()).thenReturn("monitoring.us-east-1.amazonaws.com");
-        when(snapshot.getUri()).thenReturn(uri);
+    void httpRequestUriBeforeModify_neverCarriesQueryString() {
+        // The snapshot holds components only, so the query string is always absent. This is what keeps the query and
+        // ec2 protocols cheap: for those the raw query parameters are the entire request payload at this point.
+        attributes.putAttribute(SdkInternalExecutionAttribute.HTTP_REQUEST_ENDPOINT_BEFORE_MODIFY, ENDPOINT);
 
-        attributes.putAttribute(SdkInternalExecutionAttribute.HTTP_REQUEST_BEFORE_MODIFY, snapshot);
-        verify(snapshot, never()).getUri();
+        URI uri = attributes.getAttribute(SdkInternalExecutionAttribute.HTTP_REQUEST_URI_BEFORE_MODIFY);
 
-        // Reading the endpoint components must not build the URI either.
-        SdkHttpRequest read = attributes.getAttribute(SdkInternalExecutionAttribute.HTTP_REQUEST_BEFORE_MODIFY);
-        assertThat(read.host()).isEqualTo("monitoring.us-east-1.amazonaws.com");
-        verify(snapshot, never()).getUri();
+        assertThat(uri.getQuery()).isNull();
+        assertThat(uri.getRawPath()).isEqualTo("/2015-03-31/functions/my-function/invocations");
+    }
+
+    @Test
+    void httpRequestUriBeforeModify_repeatedReadsShareTheSameUri() {
+        attributes.putAttribute(SdkInternalExecutionAttribute.HTTP_REQUEST_ENDPOINT_BEFORE_MODIFY, ENDPOINT);
 
         assertThat(attributes.getAttribute(SdkInternalExecutionAttribute.HTTP_REQUEST_URI_BEFORE_MODIFY))
-            .isSameAs(uri);
-        verify(snapshot).getUri();
+            .isSameAs(attributes.getAttribute(SdkInternalExecutionAttribute.HTTP_REQUEST_URI_BEFORE_MODIFY));
     }
 
     @Test
     void httpRequestUriBeforeModify_writeIsUnsupported() {
-        SdkHttpRequest snapshot = requestWithQueryParams();
-        attributes.putAttribute(SdkInternalExecutionAttribute.HTTP_REQUEST_BEFORE_MODIFY, snapshot);
+        attributes.putAttribute(SdkInternalExecutionAttribute.HTTP_REQUEST_ENDPOINT_BEFORE_MODIFY, ENDPOINT);
         URI uri = URI.create("https://custom.example.com:8443/");
 
         assertThatThrownBy(() -> attributes.putAttribute(
             SdkInternalExecutionAttribute.HTTP_REQUEST_URI_BEFORE_MODIFY, uri))
             .isInstanceOf(UnsupportedOperationException.class);
 
-        assertThat(attributes.getAttribute(SdkInternalExecutionAttribute.HTTP_REQUEST_BEFORE_MODIFY))
-            .isSameAs(snapshot);
+        assertThat(attributes.getAttribute(SdkInternalExecutionAttribute.HTTP_REQUEST_ENDPOINT_BEFORE_MODIFY))
+            .isSameAs(ENDPOINT);
     }
 
     @Test
-    void httpRequestBeforeModify_survivesCopy() {
-        SdkHttpRequest snapshot = requestWithQueryParams();
-        attributes.putAttribute(SdkInternalExecutionAttribute.HTTP_REQUEST_BEFORE_MODIFY, snapshot);
+    void httpRequestEndpointBeforeModify_survivesCopy() {
+        attributes.putAttribute(SdkInternalExecutionAttribute.HTTP_REQUEST_ENDPOINT_BEFORE_MODIFY, ENDPOINT);
 
-        // Copies duplicate the backing map rather than re-setting each attribute, so the read-only derived view
-        // must still resolve against the copy.
+        // Copies duplicate the backing map rather than re-setting each attribute, so the read-only derived view must
+        // still resolve against the copy.
         ExecutionAttributes copy = attributes.copy();
 
-        assertThat(copy.getAttribute(SdkInternalExecutionAttribute.HTTP_REQUEST_BEFORE_MODIFY)).isSameAs(snapshot);
+        assertThat(copy.getAttribute(SdkInternalExecutionAttribute.HTTP_REQUEST_ENDPOINT_BEFORE_MODIFY))
+            .isSameAs(ENDPOINT);
         assertThat(copy.getAttribute(SdkInternalExecutionAttribute.HTTP_REQUEST_URI_BEFORE_MODIFY))
-            .isEqualTo(snapshot.getUri());
-    }
-
-    /**
-     * Shaped like a marshalled query-protocol request: the payload lives in the raw query parameters until
-     * {@code QueryParametersToBodyStage} moves it into the body.
-     */
-    private static SdkHttpRequest requestWithQueryParams() {
-        return SdkHttpFullRequest.builder()
-                                 .method(SdkHttpMethod.POST)
-                                 .protocol("https")
-                                 .host("monitoring.us-east-1.amazonaws.com")
-                                 .encodedPath("/")
-                                 .putRawQueryParameter("Action", "PutMetricData")
-                                 .putRawQueryParameter("Namespace", "My/Namespace")
-                                 .build();
+            .isEqualTo(ENDPOINT.toUri());
     }
 }

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/http/pipeline/stages/EndpointResolutionStageTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/http/pipeline/stages/EndpointResolutionStageTest.java
@@ -17,9 +17,7 @@ package software.amazon.awssdk.core.internal.http.pipeline.stages;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 import java.net.URI;
 import java.time.Duration;
@@ -36,9 +34,9 @@ import software.amazon.awssdk.core.interceptor.SdkInternalExecutionAttribute;
 import software.amazon.awssdk.core.internal.http.RequestExecutionContext;
 import software.amazon.awssdk.core.metrics.CoreMetric;
 import software.amazon.awssdk.endpoints.Endpoint;
+import software.amazon.awssdk.endpoints.EndpointUrl;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
 import software.amazon.awssdk.http.SdkHttpMethod;
-import software.amazon.awssdk.http.SdkHttpRequest;
 import software.amazon.awssdk.metrics.MetricCollector;
 
 class EndpointResolutionStageTest {
@@ -199,8 +197,8 @@ class EndpointResolutionStageTest {
                                                                 .host("custom.example.com")
                                                                 .port(8080)
                                                                 .encodedPath("/my-operation");
-        executionAttributes.putAttribute(SdkInternalExecutionAttribute.HTTP_REQUEST_BEFORE_MODIFY,
-                                         preModifyRequest("https", "myservice.amazonaws.com", null, "/my-operation"));
+        executionAttributes.putAttribute(SdkInternalExecutionAttribute.HTTP_REQUEST_ENDPOINT_BEFORE_MODIFY,
+                                         preModifyEndpoint("https", "myservice.amazonaws.com", "/my-operation"));
         executionAttributes.putAttribute(SdkInternalExecutionAttribute.ENDPOINT_RESOLVER, (req, attrs) -> endpoint);
         executionAttributes.putAttribute(SdkInternalExecutionAttribute.CLIENT_ENDPOINT_PROVIDER,
                                          ClientEndpointProvider.forEndpointOverride(CLIENT_ENDPOINT));
@@ -225,8 +223,8 @@ class EndpointResolutionStageTest {
                                                                 .host("example.com")
                                                                 .encodedPath("/my-key");
 
-        executionAttributes.putAttribute(SdkInternalExecutionAttribute.HTTP_REQUEST_BEFORE_MODIFY,
-                                         preModifyRequest("https", "s3.us-west-2.amazonaws.com", null, "/my-key"));
+        executionAttributes.putAttribute(SdkInternalExecutionAttribute.HTTP_REQUEST_ENDPOINT_BEFORE_MODIFY,
+                                         preModifyEndpoint("https", "s3.us-west-2.amazonaws.com", "/my-key"));
         executionAttributes.putAttribute(SdkInternalExecutionAttribute.ENDPOINT_RESOLVER, (req, attrs) -> endpoint);
         executionAttributes.putAttribute(SdkInternalExecutionAttribute.CLIENT_ENDPOINT_PROVIDER,
                                          ClientEndpointProvider.forEndpointOverride(clientEndpoint));
@@ -249,8 +247,8 @@ class EndpointResolutionStageTest {
                                                               .port(443)
                                                               .encodedPath("/");
         Endpoint endpoint = Endpoint.builder().url(RESOLVED_ENDPOINT).build();
-        executionAttributes.putAttribute(SdkInternalExecutionAttribute.HTTP_REQUEST_BEFORE_MODIFY,
-                                         preModifyRequest("https", CLIENT_ENDPOINT.getHost(), null, "/"));
+        executionAttributes.putAttribute(SdkInternalExecutionAttribute.HTTP_REQUEST_ENDPOINT_BEFORE_MODIFY,
+                                         preModifyEndpoint("https", CLIENT_ENDPOINT.getHost(), "/"));
         executionAttributes.putAttribute(SdkInternalExecutionAttribute.ENDPOINT_RESOLVER, (req, attrs) -> endpoint);
         executionAttributes.putAttribute(SdkInternalExecutionAttribute.CLIENT_ENDPOINT_PROVIDER,
                                          ClientEndpointProvider.forEndpointOverride(CLIENT_ENDPOINT));
@@ -270,8 +268,8 @@ class EndpointResolutionStageTest {
                                                               .port(8443)
                                                               .encodedPath("/");
         Endpoint endpoint = Endpoint.builder().url(RESOLVED_ENDPOINT).build();
-        executionAttributes.putAttribute(SdkInternalExecutionAttribute.HTTP_REQUEST_BEFORE_MODIFY,
-                                         preModifyRequest("https", CLIENT_ENDPOINT.getHost(), null, "/"));
+        executionAttributes.putAttribute(SdkInternalExecutionAttribute.HTTP_REQUEST_ENDPOINT_BEFORE_MODIFY,
+                                         preModifyEndpoint("https", CLIENT_ENDPOINT.getHost(), "/"));
         executionAttributes.putAttribute(SdkInternalExecutionAttribute.ENDPOINT_RESOLVER, (req, attrs) -> endpoint);
         executionAttributes.putAttribute(SdkInternalExecutionAttribute.CLIENT_ENDPOINT_PROVIDER,
                                          ClientEndpointProvider.forEndpointOverride(CLIENT_ENDPOINT));
@@ -283,35 +281,12 @@ class EndpointResolutionStageTest {
         assertThat(result.port()).isEqualTo(8443);
     }
 
-    @Test
-    void execute_neverBuildsUriFromSnapshottedRequest() throws Exception {
-        // Guards the query/ec2 protocol performance regression: for those protocols the snapshotted request still
-        // holds the entire payload in its raw query parameters, so getUri() would encode and re-parse the whole
-        // payload on every API call. The stage must only read the endpoint components.
-        SdkHttpRequest snapshot = mock(SdkHttpRequest.class);
-        when(snapshot.protocol()).thenReturn("https");
-        when(snapshot.host()).thenReturn(CLIENT_ENDPOINT.getHost());
-        when(snapshot.port()).thenReturn(443);
-        Endpoint endpoint = Endpoint.builder().url(RESOLVED_ENDPOINT).build();
-        executionAttributes.putAttribute(SdkInternalExecutionAttribute.HTTP_REQUEST_BEFORE_MODIFY, snapshot);
-        executionAttributes.putAttribute(SdkInternalExecutionAttribute.ENDPOINT_RESOLVER, (req, attrs) -> endpoint);
-        executionAttributes.putAttribute(SdkInternalExecutionAttribute.CLIENT_ENDPOINT_PROVIDER,
-                                         ClientEndpointProvider.forEndpointOverride(CLIENT_ENDPOINT));
-        RequestExecutionContext context = createContext();
-
-        stage.execute(defaultRequest(), context);
-
-        verify(snapshot, never()).getUri();
-    }
-
-    private static SdkHttpRequest preModifyRequest(String protocol, String host, Integer port, String encodedPath) {
-        return SdkHttpFullRequest.builder()
-                                 .method(SdkHttpMethod.GET)
-                                 .protocol(protocol)
-                                 .host(host)
-                                 .port(port)
-                                 .encodedPath(encodedPath)
-                                 .build();
+    /**
+     * Mirrors the snapshot {@code BaseClientHandler} records: endpoint components only, with the port resolved the
+     * way {@link software.amazon.awssdk.http.SdkHttpRequest#port()} resolves it.
+     */
+    private static EndpointUrl preModifyEndpoint(String scheme, String host, String encodedPath) {
+        return EndpointUrl.fromComponents(scheme, host, "https".equals(scheme) ? 443 : 80, encodedPath);
     }
 
     private SdkHttpFullRequest.Builder defaultRequest() {

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/http/pipeline/stages/EndpointResolutionStageTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/http/pipeline/stages/EndpointResolutionStageTest.java
@@ -34,6 +34,7 @@ import software.amazon.awssdk.core.interceptor.SdkInternalExecutionAttribute;
 import software.amazon.awssdk.core.internal.http.RequestExecutionContext;
 import software.amazon.awssdk.core.metrics.CoreMetric;
 import software.amazon.awssdk.endpoints.Endpoint;
+import software.amazon.awssdk.endpoints.EndpointUrl;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
 import software.amazon.awssdk.http.SdkHttpMethod;
 import software.amazon.awssdk.metrics.MetricCollector;
@@ -196,8 +197,9 @@ class EndpointResolutionStageTest {
                                                                 .host("custom.example.com")
                                                                 .port(8080)
                                                                 .encodedPath("/my-operation");
-        executionAttributes.putAttribute(SdkInternalExecutionAttribute.HTTP_REQUEST_URI_BEFORE_MODIFY,
-                                         URI.create("https://myservice.amazonaws.com/my-operation"));
+        executionAttributes.putAttribute(SdkInternalExecutionAttribute.HTTP_REQUEST_ENDPOINT_BEFORE_MODIFY,
+                                         EndpointUrl.fromComponents("https", "myservice.amazonaws.com", 443,
+                                                                    "/my-operation"));
         executionAttributes.putAttribute(SdkInternalExecutionAttribute.ENDPOINT_RESOLVER, (req, attrs) -> endpoint);
         executionAttributes.putAttribute(SdkInternalExecutionAttribute.CLIENT_ENDPOINT_PROVIDER,
                                          ClientEndpointProvider.forEndpointOverride(CLIENT_ENDPOINT));
@@ -222,8 +224,9 @@ class EndpointResolutionStageTest {
                                                                 .host("example.com")
                                                                 .encodedPath("/my-key");
 
-        executionAttributes.putAttribute(SdkInternalExecutionAttribute.HTTP_REQUEST_URI_BEFORE_MODIFY,
-                                         URI.create("https://s3.us-west-2.amazonaws.com/my-key"));
+        executionAttributes.putAttribute(SdkInternalExecutionAttribute.HTTP_REQUEST_ENDPOINT_BEFORE_MODIFY,
+                                         EndpointUrl.fromComponents("https", "s3.us-west-2.amazonaws.com", 443,
+                                                                    "/my-key"));
         executionAttributes.putAttribute(SdkInternalExecutionAttribute.ENDPOINT_RESOLVER, (req, attrs) -> endpoint);
         executionAttributes.putAttribute(SdkInternalExecutionAttribute.CLIENT_ENDPOINT_PROVIDER,
                                          ClientEndpointProvider.forEndpointOverride(clientEndpoint));
@@ -233,6 +236,51 @@ class EndpointResolutionStageTest {
 
         assertThat(result.host()).isEqualTo("example.com");
         assertThat(result.encodedPath()).isEqualTo("/my-bucket/my-key");
+    }
+
+    @Test
+    void execute_explicitStandardPortUnmodified_appliesResolvedUrl() throws Exception {
+        // The snapshot always carries a resolved port, so an endpoint that explicitly specifies the protocol's
+        // standard port must not be mistaken for one an interceptor modified.
+        SdkHttpFullRequest.Builder request = SdkHttpFullRequest.builder()
+                                                              .method(SdkHttpMethod.GET)
+                                                              .protocol("https")
+                                                              .host(CLIENT_ENDPOINT.getHost())
+                                                              .port(443)
+                                                              .encodedPath("/");
+        Endpoint endpoint = Endpoint.builder().url(RESOLVED_ENDPOINT).build();
+        executionAttributes.putAttribute(SdkInternalExecutionAttribute.HTTP_REQUEST_ENDPOINT_BEFORE_MODIFY,
+                                         EndpointUrl.fromComponents("https", CLIENT_ENDPOINT.getHost(), 443, "/"));
+        executionAttributes.putAttribute(SdkInternalExecutionAttribute.ENDPOINT_RESOLVER, (req, attrs) -> endpoint);
+        executionAttributes.putAttribute(SdkInternalExecutionAttribute.CLIENT_ENDPOINT_PROVIDER,
+                                         ClientEndpointProvider.forEndpointOverride(CLIENT_ENDPOINT));
+        RequestExecutionContext context = createContext();
+
+        SdkHttpFullRequest.Builder result = stage.execute(request, context);
+
+        assertThat(result.host()).isEqualTo("resolved.us-west-2.amazonaws.com");
+    }
+
+    @Test
+    void execute_interceptorModifiedPortOnly_preservesCustomPort() throws Exception {
+        SdkHttpFullRequest.Builder request = SdkHttpFullRequest.builder()
+                                                              .method(SdkHttpMethod.GET)
+                                                              .protocol("https")
+                                                              .host(CLIENT_ENDPOINT.getHost())
+                                                              .port(8443)
+                                                              .encodedPath("/");
+        Endpoint endpoint = Endpoint.builder().url(RESOLVED_ENDPOINT).build();
+        executionAttributes.putAttribute(SdkInternalExecutionAttribute.HTTP_REQUEST_ENDPOINT_BEFORE_MODIFY,
+                                         EndpointUrl.fromComponents("https", CLIENT_ENDPOINT.getHost(), 443, "/"));
+        executionAttributes.putAttribute(SdkInternalExecutionAttribute.ENDPOINT_RESOLVER, (req, attrs) -> endpoint);
+        executionAttributes.putAttribute(SdkInternalExecutionAttribute.CLIENT_ENDPOINT_PROVIDER,
+                                         ClientEndpointProvider.forEndpointOverride(CLIENT_ENDPOINT));
+        RequestExecutionContext context = createContext();
+
+        SdkHttpFullRequest.Builder result = stage.execute(request, context);
+
+        assertThat(result.host()).isEqualTo(CLIENT_ENDPOINT.getHost());
+        assertThat(result.port()).isEqualTo(8443);
     }
 
     private SdkHttpFullRequest.Builder defaultRequest() {

--- a/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/http/pipeline/stages/EndpointResolutionStageTest.java
+++ b/core/sdk-core/src/test/java/software/amazon/awssdk/core/internal/http/pipeline/stages/EndpointResolutionStageTest.java
@@ -17,7 +17,9 @@ package software.amazon.awssdk.core.internal.http.pipeline.stages;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.net.URI;
 import java.time.Duration;
@@ -34,9 +36,9 @@ import software.amazon.awssdk.core.interceptor.SdkInternalExecutionAttribute;
 import software.amazon.awssdk.core.internal.http.RequestExecutionContext;
 import software.amazon.awssdk.core.metrics.CoreMetric;
 import software.amazon.awssdk.endpoints.Endpoint;
-import software.amazon.awssdk.endpoints.EndpointUrl;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
 import software.amazon.awssdk.http.SdkHttpMethod;
+import software.amazon.awssdk.http.SdkHttpRequest;
 import software.amazon.awssdk.metrics.MetricCollector;
 
 class EndpointResolutionStageTest {
@@ -197,9 +199,8 @@ class EndpointResolutionStageTest {
                                                                 .host("custom.example.com")
                                                                 .port(8080)
                                                                 .encodedPath("/my-operation");
-        executionAttributes.putAttribute(SdkInternalExecutionAttribute.HTTP_REQUEST_ENDPOINT_BEFORE_MODIFY,
-                                         EndpointUrl.fromComponents("https", "myservice.amazonaws.com", 443,
-                                                                    "/my-operation"));
+        executionAttributes.putAttribute(SdkInternalExecutionAttribute.HTTP_REQUEST_BEFORE_MODIFY,
+                                         preModifyRequest("https", "myservice.amazonaws.com", null, "/my-operation"));
         executionAttributes.putAttribute(SdkInternalExecutionAttribute.ENDPOINT_RESOLVER, (req, attrs) -> endpoint);
         executionAttributes.putAttribute(SdkInternalExecutionAttribute.CLIENT_ENDPOINT_PROVIDER,
                                          ClientEndpointProvider.forEndpointOverride(CLIENT_ENDPOINT));
@@ -224,9 +225,8 @@ class EndpointResolutionStageTest {
                                                                 .host("example.com")
                                                                 .encodedPath("/my-key");
 
-        executionAttributes.putAttribute(SdkInternalExecutionAttribute.HTTP_REQUEST_ENDPOINT_BEFORE_MODIFY,
-                                         EndpointUrl.fromComponents("https", "s3.us-west-2.amazonaws.com", 443,
-                                                                    "/my-key"));
+        executionAttributes.putAttribute(SdkInternalExecutionAttribute.HTTP_REQUEST_BEFORE_MODIFY,
+                                         preModifyRequest("https", "s3.us-west-2.amazonaws.com", null, "/my-key"));
         executionAttributes.putAttribute(SdkInternalExecutionAttribute.ENDPOINT_RESOLVER, (req, attrs) -> endpoint);
         executionAttributes.putAttribute(SdkInternalExecutionAttribute.CLIENT_ENDPOINT_PROVIDER,
                                          ClientEndpointProvider.forEndpointOverride(clientEndpoint));
@@ -249,8 +249,8 @@ class EndpointResolutionStageTest {
                                                               .port(443)
                                                               .encodedPath("/");
         Endpoint endpoint = Endpoint.builder().url(RESOLVED_ENDPOINT).build();
-        executionAttributes.putAttribute(SdkInternalExecutionAttribute.HTTP_REQUEST_ENDPOINT_BEFORE_MODIFY,
-                                         EndpointUrl.fromComponents("https", CLIENT_ENDPOINT.getHost(), 443, "/"));
+        executionAttributes.putAttribute(SdkInternalExecutionAttribute.HTTP_REQUEST_BEFORE_MODIFY,
+                                         preModifyRequest("https", CLIENT_ENDPOINT.getHost(), null, "/"));
         executionAttributes.putAttribute(SdkInternalExecutionAttribute.ENDPOINT_RESOLVER, (req, attrs) -> endpoint);
         executionAttributes.putAttribute(SdkInternalExecutionAttribute.CLIENT_ENDPOINT_PROVIDER,
                                          ClientEndpointProvider.forEndpointOverride(CLIENT_ENDPOINT));
@@ -270,8 +270,8 @@ class EndpointResolutionStageTest {
                                                               .port(8443)
                                                               .encodedPath("/");
         Endpoint endpoint = Endpoint.builder().url(RESOLVED_ENDPOINT).build();
-        executionAttributes.putAttribute(SdkInternalExecutionAttribute.HTTP_REQUEST_ENDPOINT_BEFORE_MODIFY,
-                                         EndpointUrl.fromComponents("https", CLIENT_ENDPOINT.getHost(), 443, "/"));
+        executionAttributes.putAttribute(SdkInternalExecutionAttribute.HTTP_REQUEST_BEFORE_MODIFY,
+                                         preModifyRequest("https", CLIENT_ENDPOINT.getHost(), null, "/"));
         executionAttributes.putAttribute(SdkInternalExecutionAttribute.ENDPOINT_RESOLVER, (req, attrs) -> endpoint);
         executionAttributes.putAttribute(SdkInternalExecutionAttribute.CLIENT_ENDPOINT_PROVIDER,
                                          ClientEndpointProvider.forEndpointOverride(CLIENT_ENDPOINT));
@@ -281,6 +281,37 @@ class EndpointResolutionStageTest {
 
         assertThat(result.host()).isEqualTo(CLIENT_ENDPOINT.getHost());
         assertThat(result.port()).isEqualTo(8443);
+    }
+
+    @Test
+    void execute_neverBuildsUriFromSnapshottedRequest() throws Exception {
+        // Guards the query/ec2 protocol performance regression: for those protocols the snapshotted request still
+        // holds the entire payload in its raw query parameters, so getUri() would encode and re-parse the whole
+        // payload on every API call. The stage must only read the endpoint components.
+        SdkHttpRequest snapshot = mock(SdkHttpRequest.class);
+        when(snapshot.protocol()).thenReturn("https");
+        when(snapshot.host()).thenReturn(CLIENT_ENDPOINT.getHost());
+        when(snapshot.port()).thenReturn(443);
+        Endpoint endpoint = Endpoint.builder().url(RESOLVED_ENDPOINT).build();
+        executionAttributes.putAttribute(SdkInternalExecutionAttribute.HTTP_REQUEST_BEFORE_MODIFY, snapshot);
+        executionAttributes.putAttribute(SdkInternalExecutionAttribute.ENDPOINT_RESOLVER, (req, attrs) -> endpoint);
+        executionAttributes.putAttribute(SdkInternalExecutionAttribute.CLIENT_ENDPOINT_PROVIDER,
+                                         ClientEndpointProvider.forEndpointOverride(CLIENT_ENDPOINT));
+        RequestExecutionContext context = createContext();
+
+        stage.execute(defaultRequest(), context);
+
+        verify(snapshot, never()).getUri();
+    }
+
+    private static SdkHttpRequest preModifyRequest(String protocol, String host, Integer port, String encodedPath) {
+        return SdkHttpFullRequest.builder()
+                                 .method(SdkHttpMethod.GET)
+                                 .protocol(protocol)
+                                 .host(host)
+                                 .port(port)
+                                 .encodedPath(encodedPath)
+                                 .build();
     }
 
     private SdkHttpFullRequest.Builder defaultRequest() {

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/EndpointOverrideEndpointResolutionTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/EndpointOverrideEndpointResolutionTest.java
@@ -222,6 +222,25 @@ public class EndpointOverrideEndpointResolutionTest {
                                 .setExpectedSigningServiceName("s3")
                                 .setExpectedSigningRegion(Region.US_WEST_2));
 
+        // An override that spells out the protocol's own default port must still have the rules-engine-resolved host
+        // applied. The port ends up in the resolved authority, but getUri() omits it again because it is the standard
+        // port for the scheme.
+        cases.add(new TestCase().setCaseName("normal bucket with the default https port spelled out")
+                                .setGetObjectBucketName("bucketname")
+                                .setEndpointUrl("https://beta.example.com:443")
+                                .setClientRegion(Region.US_WEST_2)
+                                .setExpectedEndpoint("https://bucketname.beta.example.com/object")
+                                .setExpectedSigningServiceName("s3")
+                                .setExpectedSigningRegion(Region.US_WEST_2));
+
+        cases.add(new TestCase().setCaseName("normal bucket with the default http port spelled out")
+                                .setGetObjectBucketName("bucketname")
+                                .setEndpointUrl("http://beta.example.com:80")
+                                .setClientRegion(Region.US_WEST_2)
+                                .setExpectedEndpoint("http://bucketname.beta.example.com/object")
+                                .setExpectedSigningServiceName("s3")
+                                .setExpectedSigningRegion(Region.US_WEST_2));
+
         cases.add(new TestCase().setCaseName("access point")
                                 .setGetObjectBucketName("arn:aws:s3:us-west-2:123456789012:accesspoint:myendpoint")
                                 .setEndpointUrl("https://beta.example.com")

--- a/services/s3/src/test/java/software/amazon/awssdk/services/s3/EndpointOverrideInterceptorResolutionTest.java
+++ b/services/s3/src/test/java/software/amazon/awssdk/services/s3/EndpointOverrideInterceptorResolutionTest.java
@@ -1,0 +1,242 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.services.s3;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.UncheckedIOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.util.function.UnaryOperator;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.http.HttpExecuteResponse;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.interceptor.Context;
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
+import software.amazon.awssdk.core.interceptor.SdkInternalExecutionAttribute;
+import software.amazon.awssdk.http.SdkHttpRequest;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.testutils.service.http.MockAsyncHttpClient;
+import software.amazon.awssdk.testutils.service.http.MockSyncHttpClient;
+
+/**
+ * End-to-end coverage of how {@code endpointOverride} interacts with a customer {@link ExecutionInterceptor} that
+ * modifies the HTTP request in {@code modifyHttpRequest}.
+ *
+ * <p>S3 is used because its endpoint rules <em>rewrite</em> the host taken
+ * from an {@code endpointOverride}: virtual-host addressing resolves {@code {Bucket}.{url#authority}}. That makes the
+ * assertions here able to distinguish "the rules-engine host was applied" from "the interceptor's host was preserved",
+ * which a service whose rules pass the override through verbatim could not. Additionally, S3 endpoint rules
+ * modify the path which we also need to test with.
+ *
+ * <p>The contract being pinned down, as implemented by {@code EndpointResolutionStage}:
+ * <ul>
+ *   <li>If no interceptor changed the endpoint, the resolved scheme, host and port are applied.</li>
+ *   <li>If an interceptor changed the host, scheme or port, that change wins and the resolved scheme/host/port are
+ *       <em>not</em> applied — but the resolved path still is.</li>
+ *   <li>An override that spells out the protocol's default port is not a change.</li>
+ * </ul>
+ */
+class EndpointOverrideInterceptorResolutionTest {
+
+    private static final String BUCKET = "bucketname";
+
+    // The rules engine rewrites the override's authority to "<bucket>.<authority>" for virtual-host addressing.
+    private static final URI OVERRIDE = URI.create("https://beta.example.com");
+    private static final String RESOLVED_HOST = BUCKET + ".beta.example.com";
+
+    @Test
+    void noInterceptor_appliesResolvedHost() {
+        SdkHttpRequest wireRequest = sync(OVERRIDE, null);
+
+        assertThat(wireRequest.host()).isEqualTo(RESOLVED_HOST);
+        assertThat(wireRequest.protocol()).isEqualTo("https");
+        assertThat(wireRequest.getUri()).isEqualTo(URI.create("https://" + RESOLVED_HOST));
+    }
+
+    @Test
+    void noInterceptor_overrideSpellsOutDefaultPort_stillAppliesResolvedHost() {
+        SdkHttpRequest wireRequest = sync(URI.create("https://beta.example.com:443"), null);
+
+        assertThat(wireRequest.host()).isEqualTo(RESOLVED_HOST);
+        assertThat(wireRequest.port()).isEqualTo(443);
+    }
+
+    @Test
+    void noInterceptor_overrideSpellsOutDefaultHttpPort_stillAppliesResolvedHost() {
+        SdkHttpRequest wireRequest = sync(URI.create("http://beta.example.com:80"), null);
+
+        assertThat(wireRequest.host()).isEqualTo(RESOLVED_HOST);
+        assertThat(wireRequest.port()).isEqualTo(80);
+    }
+
+    @Test
+    void noInterceptor_overrideWithNonDefaultPort_appliesResolvedHostAndKeepsPort() {
+        SdkHttpRequest wireRequest = sync(URI.create("https://beta.example.com:8443"), null);
+
+        assertThat(wireRequest.host()).isEqualTo(RESOLVED_HOST);
+        assertThat(wireRequest.port()).isEqualTo(8443);
+    }
+
+    @Test
+    void interceptorReturnsRequestUnchanged_appliesResolvedHost() {
+        SdkHttpRequest wireRequest = sync(OVERRIDE, r -> r);
+
+        assertThat(wireRequest.host()).isEqualTo(RESOLVED_HOST);
+    }
+
+    @Test
+    void interceptorAddsHeaderOnly_appliesResolvedHost() {
+        SdkHttpRequest wireRequest = sync(OVERRIDE, r -> r.toBuilder().putHeader("x-custom", "value").build());
+
+        assertThat(wireRequest.host()).isEqualTo(RESOLVED_HOST);
+        assertThat(wireRequest.firstMatchingHeader("x-custom")).hasValue("value");
+    }
+
+    @Test
+    void interceptorRestatesTheSameEndpoint_appliesResolvedHost() {
+        SdkHttpRequest wireRequest = sync(OVERRIDE, r -> r.toBuilder()
+                                                          .protocol(r.protocol())
+                                                          .host(r.host())
+                                                          .port(r.port())
+                                                          .build());
+
+        assertThat(wireRequest.host()).isEqualTo(RESOLVED_HOST);
+    }
+
+    @Test
+    void interceptorChangesHost_hostWinsOverResolvedEndpoint() {
+        SdkHttpRequest wireRequest = sync(OVERRIDE, r -> r.toBuilder().host("interceptor.example.com").build());
+
+        assertThat(wireRequest.host()).isEqualTo("interceptor.example.com");
+        assertThat(wireRequest.protocol()).isEqualTo("https");
+    }
+
+    @Test
+    void interceptorChangesScheme_schemeWinsOverResolvedEndpoint() {
+        SdkHttpRequest wireRequest = sync(OVERRIDE, r -> r.toBuilder().protocol("http").port(80).build());
+
+        assertThat(wireRequest.protocol()).isEqualTo("http");
+        assertThat(wireRequest.host()).isEqualTo("beta.example.com");
+    }
+
+    @Test
+    void interceptorChangesPort_portWinsOverResolvedEndpoint() {
+        SdkHttpRequest wireRequest = sync(OVERRIDE, r -> r.toBuilder().port(9999).build());
+
+        assertThat(wireRequest.port()).isEqualTo(9999);
+        assertThat(wireRequest.host()).isEqualTo("beta.example.com");
+    }
+
+    @Test
+    void interceptorChangesHost_resolvedPathIsStillApplied() {
+        // The override carries a path, so the rules engine prefixes it. That path must survive even though the
+        // interceptor's host suppresses the resolved host.
+        SdkHttpRequest wireRequest = sync(URI.create("https://beta.example.com/path"),
+                                          r -> r.toBuilder().host("interceptor.example.com").build());
+
+        assertThat(wireRequest.host()).isEqualTo("interceptor.example.com");
+        assertThat(wireRequest.encodedPath()).startsWith("/path");
+    }
+
+    @Test
+    void async_overrideSpellsOutDefaultPort_stillAppliesResolvedHost() {
+        SdkHttpRequest wireRequest = async(URI.create("https://beta.example.com:443"), null);
+
+        assertThat(wireRequest.host()).isEqualTo(RESOLVED_HOST);
+    }
+
+    @Test
+    void async_interceptorChangesHost_hostWinsOverResolvedEndpoint() {
+        SdkHttpRequest wireRequest = async(OVERRIDE, r -> r.toBuilder().host("interceptor.example.com").build());
+
+        assertThat(wireRequest.host()).isEqualTo("interceptor.example.com");
+    }
+
+    // ---------------------------------------------------------------------------------------------------------
+
+    /** Runs a listObjects against a mocked HTTP client and returns the request that reached the wire. */
+    private SdkHttpRequest sync(URI endpointOverride, UnaryOperator<SdkHttpRequest> modifyHttpRequest) {
+        try (MockSyncHttpClient httpClient = new MockSyncHttpClient()) {
+            httpClient.stubNextResponse(listObjectsResponse());
+            S3Client client = S3Client.builder()
+                                      .region(Region.US_WEST_2)
+                                      .credentialsProvider(credentials())
+                                      .endpointOverride(endpointOverride)
+                                      .httpClient(httpClient)
+                                      .overrideConfiguration(c -> c.addExecutionInterceptor(
+                                          new EndpointModifyingInterceptor(modifyHttpRequest)))
+                                      .build();
+
+            client.listObjects(r -> r.bucket(BUCKET));
+            return httpClient.getLastRequest();
+        }
+    }
+
+    private SdkHttpRequest async(URI endpointOverride, UnaryOperator<SdkHttpRequest> modifyHttpRequest) {
+        try (MockAsyncHttpClient httpClient = new MockAsyncHttpClient()) {
+            httpClient.stubNextResponse(listObjectsResponse());
+            S3AsyncClient client = S3AsyncClient.builder()
+                                                .region(Region.US_WEST_2)
+                                                .credentialsProvider(credentials())
+                                                .endpointOverride(endpointOverride)
+                                                .httpClient(httpClient)
+                                                .overrideConfiguration(c -> c.addExecutionInterceptor(
+                                                    new EndpointModifyingInterceptor(modifyHttpRequest)))
+                                                .build();
+
+            client.listObjects(r -> r.bucket(BUCKET)).join();
+            return httpClient.getLastRequest();
+        }
+    }
+
+    private static HttpExecuteResponse listObjectsResponse() {
+        try {
+            return S3MockUtils.mockListObjectsResponse();
+        } catch (UnsupportedEncodingException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private static StaticCredentialsProvider credentials() {
+        return StaticCredentialsProvider.create(AwsBasicCredentials.create("akid", "skid"));
+    }
+
+    /**
+     * A customer-style interceptor. Also asserts that the pre-modify endpoint snapshot is visible here and describes
+     * the request as it was marshalled, before endpoint resolution ran.
+     */
+    private static final class EndpointModifyingInterceptor implements ExecutionInterceptor {
+        private final UnaryOperator<SdkHttpRequest> modifyHttpRequest;
+
+        private EndpointModifyingInterceptor(UnaryOperator<SdkHttpRequest> modifyHttpRequest) {
+            this.modifyHttpRequest = modifyHttpRequest;
+        }
+
+        @Override
+        public SdkHttpRequest modifyHttpRequest(Context.ModifyHttpRequest context, ExecutionAttributes attrs) {
+            assertThat(attrs.getAttribute(SdkInternalExecutionAttribute.HTTP_REQUEST_ENDPOINT_BEFORE_MODIFY))
+                .as("the pre-modify endpoint snapshot must be readable from modifyHttpRequest")
+                .isNotNull()
+                .satisfies(endpoint -> assertThat(endpoint.host()).isEqualTo(context.httpRequest().host()));
+
+            return modifyHttpRequest == null ? context.httpRequest()
+                                             : modifyHttpRequest.apply(context.httpRequest());
+        }
+    }
+}


### PR DESCRIPTION
Fix query/ec2 protocol perf regression

## Motivation and Context
#7017 was a large scale refactoring that moved endpoint and auth resolution from interceptors into pipeline stages.  A minor part of that change (unrealted to the core refactoring) introduced a regression in query/ec2 protocol performance by re-parsing the entire URI (which for query/ec2 at this point in the request lifecycle includes the entire payload). 

The regression scales with payload size:
```
benchmark	request bytes	2.46.21	2.47.0	added ns/byte  
GetMetricDataRequest_M	5,006	37.4 µs	60.1 µs	4.55  
GetMetricDataRequest_L	9,183	67.9 µs	117.0 µs	5.35  
PutMetricDataRequest_M	3,281	30.3 µs	48.2 µs	5.46  
PutMetricDataRequest_L	33,602	251.1 µs	430.1 µs	5.33 
```

## Modifications
Change the internal execution attribute `HTTP_REQUEST_URI_BEFORE_MODIFY` from being a URI to using the new, more efficient `EndpointUrl` class.  This attribute is only used by `EndpointResolutionStage.interceptorModifiedEndpoint`, which compares nothing but getHost(), getScheme(), and getPort().

## Testing
New and existing tests

## Performance
```
payload bytes   before (getUri) after (components)          saved
3607                 19466.1 ns          50.7 ns     19415.3 ns  (5.38 ns/byte)
5421                 29484.2 ns           0.7 ns     29483.5 ns  (5.44 ns/byte)
9525                 54312.1 ns           0.0 ns     54312.1 ns  (5.70 ns/byte)
33693               217126.8 ns           0.0 ns    217126.8 ns  (6.44 ns/byte)
```

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/aws/aws-sdk-java-v2/blob/master/CONTRIBUTING.md) document
- [x] Local run of `mvn install` succeeds
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have added a changelog entry. Adding a new entry must be accomplished by running the `scripts/new-change` script and following the instructions. Commit the new file created by the script in `.changes/next-release` with your changes.

## License
<!--- The SDK is released under the Apache 2.0 license (http://aws.amazon.com/apache2.0/), so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a Contributor License Agreement (http://en.wikipedia.org/wiki/Contributor_License_Agreement) -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license
